### PR TITLE
APPENG-3490 - Support manual release

### DIFF
--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -6,6 +6,9 @@ on:
       - 'main'
   workflow_dispatch:
 
+env:
+ BRANCH_NAME: ${{ github.head_ref || github.ref_name }}    
+
 jobs:
   build-and-push:
     if: github.repository_owner == 'RHEcosystemAppEng'
@@ -36,7 +39,7 @@ jobs:
       - name: Extract version from the GitHub context
         id: version
         run: |
-          version=${{ github.head_ref }}.${{ github.sha }}
+          version=${{ env.BRANCH_NAME }}.${{ github.sha }}
           echo "tag=$version" >> $GITHUB_OUTPUT
 
       - name: Build and push ${{ matrix.name }}


### PR DESCRIPTION
feat: APPENG-3490 - small improvement

Refs: https://issues.redhat.com/browse/APPENG-3490

`github.head_ref` is present if we're in the context of a PR, while `github.ref_name` in the case the workflow is manually started ---> we would like to support both the cases... let's see if it works