### PR TITLE
feat: Enable agent/session persistence in llama-stack

### DIFF
--- a/asset-manager/config/agents/laptop-refresh-agent.yaml
+++ b/asset-manager/config/agents/laptop-refresh-agent.yaml
@@ -15,5 +15,6 @@ tool_choice: "required"
 input_shields: []
 output_shields: []
 max_infer_iters: 25
+enable_session_persistence: true
 mcp_servers: ["employee-info", "snow"]
 knowledge_bases: ["laptop-refresh"]

--- a/asset-manager/config/agents/routing-agent.yaml
+++ b/asset-manager/config/agents/routing-agent.yaml
@@ -17,5 +17,6 @@ tool_choice: "none"
 input_shields: []
 output_shields: []
 max_infer_iters: 10
+enable_session_persistence: false
 mcp_servers: []
 knowledge_bases: []

--- a/asset-manager/local_testing/config/agents/agent-1.yaml
+++ b/asset-manager/local_testing/config/agents/agent-1.yaml
@@ -6,3 +6,4 @@ tool_choice: "auto"
 input_shields: []
 output_shields: []
 max_infer_iters: 10
+enable_session_persistence: false

--- a/asset-manager/src/asset_manager/agent_manager.py
+++ b/asset-manager/src/asset_manager/agent_manager.py
@@ -58,6 +58,7 @@ class AgentManager(Manager):
             max_infer_iters=agent["max_infer_iters"],
             input_shields=agent["input_shields"],
             output_shields=agent["output_shields"],
+            enable_session_persistence=agent["enable_session_persistence"],
         )
         agent_config["name"] = agent["name"]
 

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -80,6 +80,37 @@ llama_stack_url: http://llamastack:8321
 sessionSecret: {}
  # value: "my-session-secret"
 
+# PostgreSQL configuration for llama-stack agent persistence
+pgvector:
+  extraDatabases:
+    - name: llama_agents
+      vectordb: false
+    - name: llama_responses
+      vectordb: false
+
+# Llama Stack agents configuration with PostgreSQL persistence
+llama-stack:
+  providers:
+    agents:
+      - provider_id: meta-ref-postgres
+        provider_type: inline::meta-reference
+        config:
+          persistence_store:
+            type: postgres
+            namespace: null
+            host: ${env.POSTGRES_HOST:=pgvector}
+            port: ${env.POSTGRES_PORT:=5432}
+            db: llama_agents
+            user: ${env.POSTGRES_USER:=pgvector}
+            password: ${env.POSTGRES_PASSWORD:=pgvector}
+          responses_store:
+            type: postgres
+            host: ${env.POSTGRES_HOST:=pgvector}
+            port: ${env.POSTGRES_PORT:=5432}
+            db: llama_responses
+            user: ${env.POSTGRES_USER:=pgvector}
+            password: ${env.POSTGRES_PASSWORD:=pgvector}
+
 mcp-servers:
   mcp-servers:
     self-service-agent-employee-info:


### PR DESCRIPTION
Depends on https://github.com/rh-ai-quickstart/ai-architecture-charts/pull/58

example of a persisted session -
```json
[
    {
      "session_key": "session:7056a999-013c-4cc6-82b3-30cb64e6454b:acd0363e-30a3-45df-bd20-940f5642822a",
      "agent_id": null,
      "created_at": null,
      "owner": null,
      "model": null,
      "full_metadata": {
        "type": "session",
        "owner": null,
        "turns": [],
        "identifier": "b404b8e0-9a2b-4f05-8a20-593c884adeed",
        "session_id": "acd0363e-30a3-45df-bd20-940f5642822a",
        "started_at": "2025-08-26T20:17:53.590015Z",
        "session_name": "b404b8e0-9a2b-4f05-8a20-593c884adeed",
        "vector_db_id": null
      }
    }
]
```