### PR TITLE
chore: small fix on unit tests

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -74,7 +74,7 @@ jobs:
           version: "0.8.9"
 
       - name: Install the project
-        run: uv sync --extra test
+        run: uv sync
   
       - name: Run tests
         run: uv run pytest tests


### PR DESCRIPTION
test does not exist as dependency group on the pyproject... I don't know why it worked...