### PR TITLE
chore: set test as default namespace

### DIFF
--- a/.github/workflows/pr-e2e-tests.yml
+++ b/.github/workflows/pr-e2e-tests.yml
@@ -42,11 +42,18 @@ jobs:
         env:
           LLM_API_TOKEN: ${{ secrets.LLM_API_TOKEN_INFERENCE }}
 
+      - name: Set `test` as default namespace on Kind
+        shell: bash
+        run: |
+          kubectl config set-context --current --namespace=test
+
       - name: Install evaluations dependencies
+        shell: bash
         run: |
           make sync-evaluations
 
       - name: Run evaluations
+        shell: bash
         run: |
           make test-short-integration
         env:


### PR DESCRIPTION
The fix won't be visible in the run associated with this PR, since the e2e workflow uses the workflows defined in the target.
The fix should be visible in any further PR run after the merge.