### PR TITLE
chore: introduce Podman function

### DIFF
--- a/scripts/ci/kind-with-registry.sh
+++ b/scripts/ci/kind-with-registry.sh
@@ -1,6 +1,13 @@
 #!/bin/sh
 set -o errexit
 
+if ! command -v docker &> /dev/null; then
+    echo "docker not installed, trying podman"
+    function docker() {
+        podman "$@"
+    }
+fi
+
 # 1. Create registry container unless it already exists
 reg_name='kind-registry'
 reg_port='5001'


### PR DESCRIPTION
So that the script can be run also with Podman, without the need of installing `podman-docker` for instance.