### PR TITLE
chore: fix script interpreter

### DIFF
--- a/.github/actions/kind/action.yaml
+++ b/.github/actions/kind/action.yaml
@@ -25,7 +25,7 @@ runs:
       shell: bash
 
     - name: Create Kind Cluster
-      run: ./scripts/ci/kind-with-registry.sh
+      run: bash ./scripts/ci/kind-with-registry.sh
       shell: bash
 
     - name: Helm Depend


### PR DESCRIPTION
This fix won't be visible in the run of this PR, due of the nature of `pull_request_target`, that uses the version on the target code. The fix will be visible on any further PR.
This is the drawback of `pull_request_target`, but `pull_request_target` protects our secrets.

see https://unix.stackexchange.com/questions/667499/sh-syntax-error-unexpected-expecting-fi