### PR TITLE
Check pull request ref

### DIFF
--- a/.github/workflows/pr-e2e-tests.yml
+++ b/.github/workflows/pr-e2e-tests.yml
@@ -19,7 +19,9 @@ jobs:
             exit 1
           fi
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
 
       - name: Setup uv
         uses: astral-sh/setup-uv@v6


### PR DESCRIPTION
Since for workflow based on `pull_request_target` event, by default the main (target) is fetched by the checkout!
I tested on my fork --- this should work on the upstream as well...