### PR TITLE
chore: fetch the PR branch for e2e

### DIFF
--- a/.github/workflows/pr-e2e-tests.yml
+++ b/.github/workflows/pr-e2e-tests.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v5
         with:
-          ref: ${{ github.event.pull_request.head.ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Setup uv
         uses: astral-sh/setup-uv@v6


### PR DESCRIPTION
Let's try `head.sha` in place of `head.ref`...