### PR TITLE
chore: fix e2e mcp-servers chart install errors

### DIFF
--- a/.github/actions/kind/action.yaml
+++ b/.github/actions/kind/action.yaml
@@ -28,6 +28,13 @@ runs:
       run: bash ./scripts/ci/kind-with-registry.sh
       shell: bash
 
+    - name: Helm install Toolhive CRDs
+      run: |
+        helm repo add toolhive https://stacklok.github.io/toolhive
+        helm repo update
+        helm install toolhive-crds toolhive/toolhive-operator-crds --version 0.0.24
+      shell: bash
+
     - name: Helm Depend
       run: make helm-depend
       shell: bash


### PR DESCRIPTION
mcp-servers chart recently added a dependency on toolhive CRs