### PR TITLE
feat: APPENG-3831 - Cron-job + continue-on-error

### DIFF
--- a/.github/workflows/pr-e2e-tests.yml
+++ b/.github/workflows/pr-e2e-tests.yml
@@ -3,6 +3,9 @@ name: Pull Request - Integration + End to End Tests
 on:
   pull_request_target:
     types: [opened, synchronize, reopened]
+  workflow_dispatch:
+  schedule:
+    - cron: '0 2 * * *'  # Run daily at 2 AM UTC
   
 jobs:
   e2e-tests:
@@ -55,6 +58,7 @@ jobs:
           make sync-evaluations
 
       - name: Run evaluations
+        continue-on-error: true
         shell: bash
         run: |
           make test-short-integration
@@ -63,6 +67,7 @@ jobs:
           LLM_API_TOKEN: ${{ secrets.LLM_API_TOKEN_EVAL }}
 
       - name: Run evaluations (Request Manager)
+        continue-on-error: true
         shell: bash
         run: |
           make test-short-integration-request-mgr
@@ -71,6 +76,7 @@ jobs:
           LLM_API_TOKEN: ${{ secrets.LLM_API_TOKEN_EVAL }}
 
       - name: Run responses evaluations
+        continue-on-error: true
         shell: bash
         run: |
           make test-short-resp-integration


### PR DESCRIPTION
feat: APPENG-3831

Refs: https://issues.redhat.com/browse/APPENG-3831

As usual, the changes to the workflow won't be visible in the CI run for this pull request.
For security reasons, `pull_request_target` (unlike `pull_request`) always uses the workflow from the main branch (not from the pull request branch).
The changes will be visible on PRs merged after this PR is merged.