### PR TITLE
fix: eval framework - reset each conversation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -762,7 +762,7 @@ test-short-integration-request-mgr:
 .PHONY: test-short-resp-integration-request-mgr
 test-short-resp-integration-request-mgr:
 	@echo "Running short responses integration test with Request Manager..."
-	uv --directory evaluations run evaluate.py -n 1 --no-employee-id --test-script chat-responses-request-mgr.py
+	uv --directory evaluations run evaluate.py -n 1 --no-employee-id --test-script chat-responses-request-mgr.py --reset-conversation
 	@echo "short responses integrations tests with Request Manager completed successfully!"
 
 # Create namespace and deploy

--- a/evaluations/evaluate.py
+++ b/evaluations/evaluate.py
@@ -528,6 +528,11 @@ def _parse_arguments() -> argparse.Namespace:
         action="store_true",
         help="Exclude employee ID-related checks in evaluation metrics",
     )
+    parser.add_argument(
+        "--reset-conversation",
+        action="store_true",
+        help="Send 'reset' message at the start of each conversation",
+    )
     return parser.parse_args()
 
 
@@ -802,6 +807,7 @@ def run_evaluation_pipeline(
     max_turns: int = 20,
     test_script: str = "chat.py",
     no_employee_id: bool = False,
+    reset_conversation: bool = False,
 ) -> int:
     """
     Run the complete evaluation pipeline.
@@ -817,6 +823,8 @@ def run_evaluation_pipeline(
         timeout: Timeout in seconds for each script execution
         max_turns: Maximum number of turns per conversation in generator.py
         test_script: Name of the test script to execute
+        no_employee_id: Exclude employee ID-related checks in evaluation metrics
+        reset_conversation: Send 'reset' message at the start of each conversation
 
     Returns:
         Exit code (0 for success, 1 for any failures)
@@ -836,6 +844,8 @@ def run_evaluation_pipeline(
     run_conversations_args = ["--test-script", test_script]
     if no_employee_id:
         run_conversations_args.append("--no-employee-id")
+    if reset_conversation:
+        run_conversations_args.append("--reset-conversation")
     if not run_script(
         "run_conversations.py", args=run_conversations_args, timeout=timeout
     ):
@@ -857,6 +867,8 @@ def run_evaluation_pipeline(
         "--test-script",
         test_script,
     ]
+    if reset_conversation:
+        generator_args.append("--reset-conversation")
     if not run_script("generator.py", args=generator_args, timeout=timeout):
         failed_steps.append("generator.py")
         logger.error("❌ Step 2 failed - continuing with remaining steps")
@@ -940,6 +952,7 @@ def main() -> int:
                 max_turns=args.max_turns,
                 test_script=args.test_script,
                 no_employee_id=args.no_employee_id,
+                reset_conversation=args.reset_conversation,
             )
     except KeyboardInterrupt:
         logger.warning("⚠️  Pipeline interrupted by user")

--- a/evaluations/generator.py
+++ b/evaluations/generator.py
@@ -95,6 +95,11 @@ def _parse_arguments() -> argparse.Namespace:
         default="chat.py",
         help="Name of the test script to execute (default: chat.py)",
     )
+    parser.add_argument(
+        "--reset-conversation",
+        action="store_true",
+        help="Send 'reset' message at the start of each conversation",
+    )
     return parser.parse_args()
 
 
@@ -258,7 +263,9 @@ if __name__ == "__main__":
 
                 # Create a new OpenShift client for this conversation with unique user ID
                 client = OpenShiftChatClient(
-                    conversation_user_id, test_script=args.test_script
+                    conversation_user_id,
+                    test_script=args.test_script,
+                    reset_conversation=args.reset_conversation,
                 )
 
                 # Create a single conversation golden for this iteration

--- a/evaluations/helpers/openshift_chat_client.py
+++ b/evaluations/helpers/openshift_chat_client.py
@@ -120,12 +120,18 @@ class OpenShiftChatClient:
         if self.reset_conversation:
             logger.info("Sending reset message to start fresh conversation")
             reset_response = self.send_message("reset")
-            logger.info(f"Reset response: {reset_response[:100] if reset_response else 'empty'}...")
+            logger.info(
+                f"Reset response: {reset_response[:100] if reset_response else 'empty'}..."
+            )
 
             # After reset, ask for introduction
             logger.info("Requesting agent introduction after reset")
-            intro_response = self.send_message("please introduce yourself and tell me how you can help")
-            logger.info(f"Introduction response: {intro_response[:100] if intro_response else 'empty'}...")
+            intro_response = self.send_message(
+                "please introduce yourself and tell me how you can help"
+            )
+            logger.info(
+                f"Introduction response: {intro_response[:100] if intro_response else 'empty'}..."
+            )
 
             # Return the introduction response instead of the original initialization
             return intro_response
@@ -218,14 +224,18 @@ class OpenShiftChatClient:
                         continue
                     agent_started = True
                     s = s[start_idx + len("agent:") :].strip()
-                    logger.debug(f"Agent message started, read {lines_read} lines to get here")
+                    logger.debug(
+                        f"Agent message started, read {lines_read} lines to get here"
+                    )
 
                 end_idx = s.find(AGENT_MESSAGE_TERMINATOR)
                 if end_idx != -1:
                     part = s[:end_idx].strip()
                     if part:
                         response_parts.append(part)
-                    logger.debug(f"Agent message completed after {lines_read} total lines")
+                    logger.debug(
+                        f"Agent message completed after {lines_read} total lines"
+                    )
                     break
                 else:
                     if s:
@@ -237,7 +247,9 @@ class OpenShiftChatClient:
                 continue
 
         if time.time() - start_time >= timeout:
-            logger.warning(f"Timeout reading agent message after {timeout}s, read {lines_read} lines, agent_started={agent_started}")
+            logger.warning(
+                f"Timeout reading agent message after {timeout}s, read {lines_read} lines, agent_started={agent_started}"
+            )
 
         return "\n".join(response_parts).strip()
 

--- a/evaluations/helpers/openshift_chat_client.py
+++ b/evaluations/helpers/openshift_chat_client.py
@@ -19,6 +19,7 @@ class OpenShiftChatClient:
         authoritative_user_id: str,
         deployment_name: str = "deploy/self-service-agent",
         test_script: str = "chat.py",
+        reset_conversation: bool = False,
     ):
         """
         Initialize the OpenShift chat client.
@@ -27,10 +28,12 @@ class OpenShiftChatClient:
             authoritative_user_id: Required user ID to set as AUTHORITATIVE_USER_ID environment variable
             deployment_name: Name of the OpenShift deployment to connect to
             test_script: Name of the test script to execute (default: "chat.py")
+            reset_conversation: If True, send "reset" message after initialization
         """
         self.deployment_name = deployment_name
         self.test_script = test_script
         self.authoritative_user_id = authoritative_user_id
+        self.reset_conversation = reset_conversation
         self.process = None
         self.session_active = False
         self.session_output = []  # Capture all output for token parsing
@@ -99,6 +102,7 @@ class OpenShiftChatClient:
 
         Reads the initial message sent by the agent when the session starts.
         This is typically a greeting or instructions for the user.
+        If reset_conversation is True, sends "reset" message after initialization.
 
         Returns:
             The agent's initialization message as a string
@@ -111,6 +115,21 @@ class OpenShiftChatClient:
 
         agent_message = self._read_full_agent_message()
         logger.debug(f"Agent initialization: {agent_message[:100]}...")
+
+        # Send reset message if requested
+        if self.reset_conversation:
+            logger.info("Sending reset message to start fresh conversation")
+            reset_response = self.send_message("reset")
+            logger.info(f"Reset response: {reset_response[:100] if reset_response else 'empty'}...")
+
+            # After reset, ask for introduction
+            logger.info("Requesting agent introduction after reset")
+            intro_response = self.send_message("please introduce yourself and tell me how you can help")
+            logger.info(f"Introduction response: {intro_response[:100] if intro_response else 'empty'}...")
+
+            # Return the introduction response instead of the original initialization
+            return intro_response
+
         return agent_message
 
     def send_message(self, message: str, timeout: int = 30) -> str:
@@ -171,9 +190,11 @@ class OpenShiftChatClient:
         response_parts: List[str] = []
         start_time = time.time()
         agent_started = False
+        lines_read = 0
 
         while time.time() - start_time < timeout:
             if self.process.poll() is not None:
+                logger.debug("Process terminated while reading message")
                 break
 
             try:
@@ -183,6 +204,7 @@ class OpenShiftChatClient:
                     continue
 
                 s = line.strip()
+                lines_read += 1
 
                 # Capture all output for potential token parsing
                 self.session_output.append(s)
@@ -196,12 +218,14 @@ class OpenShiftChatClient:
                         continue
                     agent_started = True
                     s = s[start_idx + len("agent:") :].strip()
+                    logger.debug(f"Agent message started, read {lines_read} lines to get here")
 
                 end_idx = s.find(AGENT_MESSAGE_TERMINATOR)
                 if end_idx != -1:
                     part = s[:end_idx].strip()
                     if part:
                         response_parts.append(part)
+                    logger.debug(f"Agent message completed after {lines_read} total lines")
                     break
                 else:
                     if s:
@@ -211,6 +235,9 @@ class OpenShiftChatClient:
                 logger.debug(f"Read error: {e}")
                 time.sleep(0.1)
                 continue
+
+        if time.time() - start_time >= timeout:
+            logger.warning(f"Timeout reading agent message after {timeout}s, read {lines_read} lines, agent_started={agent_started}")
 
         return "\n".join(response_parts).strip()
 

--- a/evaluations/helpers/run_conversation_flow.py
+++ b/evaluations/helpers/run_conversation_flow.py
@@ -15,14 +15,18 @@ logger = logging.getLogger(__name__)
 class ConversationFlowTester:
     """Test runner for conversation flows"""
 
-    def __init__(self, test_script: str = "chat.py") -> None:
+    def __init__(
+        self, test_script: str = "chat.py", reset_conversation: bool = False
+    ) -> None:
         """
         Initialize the ConversationFlowTester.
 
         Args:
             test_script: Name of the test script to execute (default: "chat.py")
+            reset_conversation: If True, send 'reset' message at the start of each conversation
         """
         self.test_script = test_script
+        self.reset_conversation = reset_conversation
         self.conversation_history = []
         self.total_app_tokens = {"input": 0, "output": 0, "total": 0, "calls": 0}
 
@@ -47,7 +51,9 @@ class ConversationFlowTester:
 
         # Create a new client for this flow with the specific authoritative_user_id
         client = OpenShiftChatClient(
-            authoritative_user_id, test_script=self.test_script
+            authoritative_user_id,
+            test_script=self.test_script,
+            reset_conversation=self.reset_conversation,
         )
 
         try:

--- a/evaluations/run_conversations.py
+++ b/evaluations/run_conversations.py
@@ -21,13 +21,20 @@ def _parse_arguments() -> argparse.Namespace:
         action="store_true",
         help="Use alternative conversation files from no-employee-id subdirectory",
     )
+    parser.add_argument(
+        "--reset-conversation",
+        action="store_true",
+        help="Send 'reset' message at the start of each conversation",
+    )
     return parser.parse_args()
 
 
 if __name__ == "__main__":
     args = _parse_arguments()
 
-    tester = ConversationFlowTester(test_script=args.test_script)
+    tester = ConversationFlowTester(
+        test_script=args.test_script, reset_conversation=args.reset_conversation
+    )
     tester.run_flows(
         "conversations_config/conversations",
         "results/conversation_results",

--- a/shared-clients/src/shared_clients/request_manager_client.py
+++ b/shared-clients/src/shared_clients/request_manager_client.py
@@ -330,11 +330,6 @@ class CLIChatClient(RequestManagerClient):
                 if message.lower() in ["quit", "exit"]:
                     break
 
-                if message.lower() == "reset":
-                    await self.reset_session()
-                    print("Session reset")
-                    continue
-
                 agent_response = await self.send_message(message, debug=debug)
                 print(f"agent: {agent_response}")
                 print(AGENT_MESSAGE_TERMINATOR)


### PR DESCRIPTION
- update eval framework to add new --reset-conversation option to reset the session at the start of each conversation. Need to run evaluations with the request manager in place

- tweak request manager so reset works correctly from eval test framework