### PR TITLE
chore: upgrade llama-stack to v0.5.0

### DIFF
--- a/agent-service/pyproject.toml
+++ b/agent-service/pyproject.toml
@@ -13,8 +13,8 @@ dependencies = [
     "cloudevents>=1.10.0",
     "httpx>=0.25.0",
     "structlog>=23.2.0",
-    # LlamaStack integration (matches server version 0.3.5)
-    "llama-stack-client==0.3.5",
+    # LlamaStack integration (matches server version 0.5.0)
+    "llama-stack-client==0.5.0",
     "requests>=2.31.0",
     "self-service-agent-shared-models",
     "protobuf>=6.33.5",

--- a/agent-service/requirements.txt
+++ b/agent-service/requirements.txt
@@ -403,9 +403,9 @@ langsmith==0.6.6 \
     --hash=sha256:64ba70e7b795cff3c498fe6f2586314da1cc855471a5e5b6a357950324af3874 \
     --hash=sha256:fe655e73b198cd00d0ecd00a26046eaf1f78cd0b2f0d94d1e5591f3143c5f592
     # via langchain-core
-llama-stack-client==0.3.5 \
-    --hash=sha256:2d954429347e920038709ae3e026c06f336ce570bd41245fc4e1e54c78879485 \
-    --hash=sha256:b98acdc660d60839da8b71d5ae59531ba7f059e3e9656ca5ca20edca70f7d6a2
+llama-stack-client==0.5.0 \
+    --hash=sha256:5e7272c7fb58cd169985191c42af78dc6c4d212b7050949b063788bfb9e7ed36 \
+    --hash=sha256:e005ae9d975cda30b3b86261057f228d700107e263e12b796b920cd1fb9ba968
     # via self-service-agent-service
 mako==1.3.10 \
     --hash=sha256:99579a6f39583fa7e5630a28c3c1f440e4e97a414b80372649c0ce338da2ea28 \

--- a/agent-service/src/agent_service/langgraph/responses_agent.py
+++ b/agent-service/src/agent_service/langgraph/responses_agent.py
@@ -100,7 +100,11 @@ class Agent:
 
         try:
             models = await self.async_llama_client.models.list()
-            model_id = next(m.identifier for m in models if m.api_model_type == "llm")
+            model_id = next(
+                m.id
+                for m in models
+                if m.custom_metadata and m.custom_metadata.get("model_type") == "llm"
+            )
             if model_id:
                 logger.info("Using first available LLM model", model_id=model_id)
                 return str(model_id)

--- a/agent-service/uv.lock
+++ b/agent-service/uv.lock
@@ -864,7 +864,7 @@ wheels = [
 
 [[package]]
 name = "llama-stack-client"
-version = "0.3.5"
+version = "0.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -883,9 +883,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/34/ff/b4bb891249379849e6e273a6254998c7e08562613ca4020817af2da9498e/llama_stack_client-0.3.5.tar.gz", hash = "sha256:2d954429347e920038709ae3e026c06f336ce570bd41245fc4e1e54c78879485", size = 335659, upload-time = "2025-12-15T14:10:16.444Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/a1/1bd9ed2b6982fb1edf0215be1a4569eb65c9354b86bfdcb5b1414b489162/llama_stack_client-0.5.0.tar.gz", hash = "sha256:e005ae9d975cda30b3b86261057f228d700107e263e12b796b920cd1fb9ba968", size = 368629, upload-time = "2026-02-05T17:23:06.688Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4d/10/84a4f0ef1cc13f44a692e55bed6a55792671e5320c95a8fd581e02848d61/llama_stack_client-0.3.5-py3-none-any.whl", hash = "sha256:b98acdc660d60839da8b71d5ae59531ba7f059e3e9656ca5ca20edca70f7d6a2", size = 425244, upload-time = "2025-12-15T14:10:14.726Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/93/63b434955cdb80d54c69bdb51ecd1a12595451ce238667fdaa125fb7d1ec/llama_stack_client-0.5.0-py3-none-any.whl", hash = "sha256:5e7272c7fb58cd169985191c42af78dc6c4d212b7050949b063788bfb9e7ed36", size = 391950, upload-time = "2026-02-05T17:23:04.238Z" },
 ]
 
 [[package]]
@@ -1903,7 +1903,7 @@ requires-dist = [
     { name = "langfuse", specifier = ">=3.0.0" },
     { name = "langgraph", specifier = "==1.0.7" },
     { name = "langgraph-checkpoint-postgres", specifier = ">=2.0.0" },
-    { name = "llama-stack-client", specifier = "==0.3.5" },
+    { name = "llama-stack-client", specifier = "==0.5.0" },
     { name = "openai", specifier = ">=1.0.0" },
     { name = "opentelemetry-exporter-otlp-proto-http", specifier = ">=1.37.0" },
     { name = "opentelemetry-instrumentation-fastapi", specifier = ">=0.58b0" },

--- a/helm/Chart.lock
+++ b/helm/Chart.lock
@@ -7,9 +7,9 @@ dependencies:
   version: 0.5.6
 - name: llama-stack
   repository: https://rh-ai-quickstart.github.io/ai-architecture-charts
-  version: 0.6.9
+  version: 0.7.0
 - name: mcp-servers
   repository: https://rh-ai-quickstart.github.io/ai-architecture-charts
   version: 0.5.8
-digest: sha256:916b7d31b0f432532ff850191d9160c657e4e70f8dc9d85c72a90c8eb49dbf2b
-generated: "2026-01-27T11:11:12.473555-06:00"
+digest: sha256:c62cab03c06360340f6cbbb33f730a3d568e863384436df79913472166bad5ac
+generated: "2026-03-19T16:31:41.746370982+02:00"

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -17,7 +17,7 @@ dependencies:
     repository: https://rh-ai-quickstart.github.io/ai-architecture-charts
     condition: llm-service.enabled
   - name: llama-stack
-    version: 0.6.9
+    version: 0.7.0
     repository: https://rh-ai-quickstart.github.io/ai-architecture-charts
   - name: mcp-servers
     version: 0.5.8

--- a/request-manager/requirements.txt
+++ b/request-manager/requirements.txt
@@ -510,9 +510,9 @@ langsmith==0.6.6 \
     --hash=sha256:64ba70e7b795cff3c498fe6f2586314da1cc855471a5e5b6a357950324af3874 \
     --hash=sha256:fe655e73b198cd00d0ecd00a26046eaf1f78cd0b2f0d94d1e5591f3143c5f592
     # via langchain-core
-llama-stack-client==0.3.5 \
-    --hash=sha256:2d954429347e920038709ae3e026c06f336ce570bd41245fc4e1e54c78879485 \
-    --hash=sha256:b98acdc660d60839da8b71d5ae59531ba7f059e3e9656ca5ca20edca70f7d6a2
+llama-stack-client==0.5.0 \
+    --hash=sha256:5e7272c7fb58cd169985191c42af78dc6c4d212b7050949b063788bfb9e7ed36 \
+    --hash=sha256:e005ae9d975cda30b3b86261057f228d700107e263e12b796b920cd1fb9ba968
     # via self-service-agent-service
 mako==1.3.10 \
     --hash=sha256:99579a6f39583fa7e5630a28c3c1f440e4e97a414b80372649c0ce338da2ea28 \

--- a/request-manager/uv.lock
+++ b/request-manager/uv.lock
@@ -974,7 +974,7 @@ wheels = [
 
 [[package]]
 name = "llama-stack-client"
-version = "0.3.5"
+version = "0.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -993,9 +993,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/34/ff/b4bb891249379849e6e273a6254998c7e08562613ca4020817af2da9498e/llama_stack_client-0.3.5.tar.gz", hash = "sha256:2d954429347e920038709ae3e026c06f336ce570bd41245fc4e1e54c78879485", size = 335659, upload-time = "2025-12-15T14:10:16.444Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/a1/1bd9ed2b6982fb1edf0215be1a4569eb65c9354b86bfdcb5b1414b489162/llama_stack_client-0.5.0.tar.gz", hash = "sha256:e005ae9d975cda30b3b86261057f228d700107e263e12b796b920cd1fb9ba968", size = 368629, upload-time = "2026-02-05T17:23:06.688Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4d/10/84a4f0ef1cc13f44a692e55bed6a55792671e5320c95a8fd581e02848d61/llama_stack_client-0.3.5-py3-none-any.whl", hash = "sha256:b98acdc660d60839da8b71d5ae59531ba7f059e3e9656ca5ca20edca70f7d6a2", size = 425244, upload-time = "2025-12-15T14:10:14.726Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/93/63b434955cdb80d54c69bdb51ecd1a12595451ce238667fdaa125fb7d1ec/llama_stack_client-0.5.0-py3-none-any.whl", hash = "sha256:5e7272c7fb58cd169985191c42af78dc6c4d212b7050949b063788bfb9e7ed36", size = 391950, upload-time = "2026-02-05T17:23:04.238Z" },
 ]
 
 [[package]]
@@ -2097,7 +2097,7 @@ requires-dist = [
     { name = "langfuse", specifier = ">=3.0.0" },
     { name = "langgraph", specifier = "==1.0.7" },
     { name = "langgraph-checkpoint-postgres", specifier = ">=2.0.0" },
-    { name = "llama-stack-client", specifier = "==0.3.5" },
+    { name = "llama-stack-client", specifier = "==0.5.0" },
     { name = "openai", specifier = ">=1.0.0" },
     { name = "opentelemetry-exporter-otlp-proto-http", specifier = ">=1.37.0" },
     { name = "opentelemetry-instrumentation-fastapi", specifier = ">=0.58b0" },


### PR DESCRIPTION
**ref:** https://redhat.atlassian.net/browse/APPENG-4642

Updates llama-stack chart to v0.5.0 (chart v0.7.0). Fixes breaking API changes in the Model class, which moved to an OpenAI-compatible schema.

## Changes
   - **Llama-stack chart:** Updated from `0.6.9` → `0.7.0`
   - **Llama-stack-client:** Updated from `0.3.5` → `0.5.0` in `agent-service` and `request-manager`
   - **Model API fix in `responses_agent.py`:** 
     - `Model.identifier` → `Model.id`
     - `Model.api_model_type` → `Model.custom_metadata.get("model_type")` 

Tested end-to-end following the [llama stack upgrade checks](https://docs.google.com/document/d/1b4sdWRlj1cvdus1tWyLQqrYa7WfCsHhJ6iuhPjiHK0o/edit?tab=t.0)


**Note:**  Upgrading to Llama Stack 0.5.0  to provide a compatible quickstart for OpenShift AI 3.3 users.