### PR TITLE
feat(helm): Zammad Phase 0 — deploy, ticketing profile, embed & bootstrap

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Makefile for RAG Deployment
 ifeq ($(NAMESPACE),)
-ifneq (,$(filter namespace install uninstall helm-install-test helm-install-prod helm-install-demo helm-export-demo helm-export-validate-demo ansible-apply-demo ansible-teardown-demo helm-uninstall helm-status helm-cleanup-eventing helm-cleanup-jobs deploy-email-server undeploy-email-server print-urls verify-triggers jaeger-deploy jaeger-undeploy test-session-serialization-integration test-session-reclaim-integration test-session-background-reclaim-integration,$(MAKECMDGOALS)))
+ifneq (,$(filter namespace install uninstall helm-install-test helm-install-prod helm-install-demo helm-install-ticketing helm-export-demo helm-export-validate-demo ansible-apply-demo ansible-teardown-demo helm-uninstall helm-status helm-cleanup-eventing helm-cleanup-jobs deploy-email-server undeploy-email-server deploy-zammad undeploy-zammad zammad-set-token zammad-bootstrap-token zammad-trigger-autowizard zammad-update-embed-url print-urls verify-triggers jaeger-deploy jaeger-undeploy test-session-serialization-integration test-session-reclaim-integration test-session-background-reclaim-integration,$(MAKECMDGOALS)))
 $(error NAMESPACE is not set)
 endif
 endif
@@ -239,6 +239,18 @@ helm_demo_email_args = \
 	--set-string security.email.smtpHost=test-email-server-smtp.$(NAMESPACE).svc.cluster.local \
 	--set-string security.email.imapHost=test-email-server-imap.$(NAMESPACE).svc.cluster.local
 
+# Ticketing: Zammad in-cluster URL and MCP secret wiring (exec bootstrap uses railsserver)
+ZAMMAD_CREDENTIALS_SECRET ?= $(MAIN_CHART_NAME)-zammad-credentials
+ZAMMAD_ADMIN_EMAIL ?= admin@zammad.local
+ZAMMAD_ADMIN_PASSWORD ?= ZammadR0cks!
+ZAMMAD_AUTOWIZARD_TOKEN ?= ssa-zammad-autowizard-9f3a2b1c
+helm_ticketing_args = \
+	--set zammad.url=$(ZAMMAD_URL) \
+	--set mcp-servers.mcp-servers.zammad-mcp.envSecrets.ZAMMAD_URL.name=$(ZAMMAD_CREDENTIALS_SECRET) \
+	--set mcp-servers.mcp-servers.zammad-mcp.envSecrets.ZAMMAD_URL.key=zammad-url \
+	--set mcp-servers.mcp-servers.zammad-mcp.envSecrets.ZAMMAD_HTTP_TOKEN.name=$(ZAMMAD_CREDENTIALS_SECRET) \
+	--set mcp-servers.mcp-servers.zammad-mcp.envSecrets.ZAMMAD_HTTP_TOKEN.key=zammad-http-token
+
 # Version target
 .PHONY: version
 version:
@@ -264,6 +276,7 @@ help:
 	@echo "  helm-install-test                   - Install with mock eventing service (testing/development/CI - default)"
 	@echo "  helm-install-prod                   - Install with full Knative eventing (production)"
 	@echo "  helm-install-demo                  - Install demo config (mock eventing, Greenmail, resource constraints)"
+	@echo "  helm-install-ticketing             - Install with ticketing channel (Zammad + MCP; one-shot deploy)"
 	@echo "  helm-export-demo                    - Export demo manifests to ansible/helm-export/ (from NAMESPACE, VERSION, REGISTRY, SERVICENOW_*, etc.)"
 	@echo "  helm-export-validate-demo           - Export then validate with kubeconform (no cluster; CI)"
 	@echo "  ansible-apply-demo                  - Export then apply demo via Ansible (requires ansible-playbook)"
@@ -353,6 +366,12 @@ help:
 	@echo "Test Email Server Commands:"
 	@echo "  deploy-email-server                 - Deploy test email server (Greenmail with custom UI)"
 	@echo "  undeploy-email-server               - Remove test email server from namespace"
+	@echo "  deploy-zammad                       - Deploy Zammad instance (prerequisite for ticketing channel)"
+	@echo "  undeploy-zammad                     - Remove Zammad instance from namespace"
+	@echo "  zammad-set-token                    - Set Zammad API token in secret and restart MCP (ZAMMAD_TOKEN=xxx, NAMESPACE=)"
+	@echo "  zammad-bootstrap-token              - Create API token via Zammad API (autoWizard admin); update secret and restart MCP"
+	@echo "  zammad-trigger-autowizard           - Trigger autoWizard via HTTP (run before bootstrap if 401)"
+	@echo "  zammad-update-embed-url             - Update embed page with Zammad Route URL (fixes YOUR-ZAMMAD-URL placeholder)"
 	@echo ""
 	@echo "Lockfile Management:"
 	@echo "  check-lockfiles                     - Check if all uv.lock files are up-to-date"
@@ -1546,6 +1565,115 @@ helm-install-demo: namespace helm-depend deploy-email-server
 		true)
 	@$(MAKE) print-urls
 
+# Install with ticketing channel (Zammad + MCP).
+# Order: install our chart first (creates Route), deploy Zammad with FQDN from Route, then bootstrap token.
+# Zammad gets correct FQDN at deploy (passed from Route host).
+.PHONY: helm-install-ticketing
+helm-install-ticketing: namespace helm-depend
+	@echo "Step 1/4: Creating placeholder secret and installing our chart (creates Route)..."
+	@ZAMMAD_URL="http://zammad-nginx.$(NAMESPACE).svc.cluster.local:8080"; \
+	kubectl create secret generic $(ZAMMAD_CREDENTIALS_SECRET) \
+		--from-literal=zammad-url="$$ZAMMAD_URL/api/v1" \
+		--from-literal=zammad-http-token="" \
+		-n $(NAMESPACE) --dry-run=client -o yaml | kubectl apply -f -; \
+	$(MAKE) _helm-install-ticketing-single ZAMMAD_URL="$$ZAMMAD_URL"
+	@echo "Step 2/4: Getting Route host and deploying Zammad with FQDN..."
+	@ZAMMAD_ROUTE=$$(oc get route ssa-zammad -n $(NAMESPACE) -o jsonpath='{.spec.host}' 2>/dev/null); \
+	if [ -z "$$ZAMMAD_ROUTE" ]; then ZAMMAD_ROUTE=$$(oc get route -n $(NAMESPACE) -l app.kubernetes.io/component=zammad -o jsonpath='{.items[0].spec.host}' 2>/dev/null); fi; \
+	if [ -z "$$ZAMMAD_ROUTE" ]; then ZAMMAD_ROUTE=$$(oc get route -n $(NAMESPACE) -l app.kubernetes.io/instance=zammad -o jsonpath='{.items[0].spec.host}' 2>/dev/null); fi; \
+		if [ -n "$$ZAMMAD_ROUTE" ]; then \
+		echo "Route host: $$ZAMMAD_ROUTE (passing as ZAMMAD_FQDN)"; \
+		$(MAKE) _zammad-patch-embed-configmap NAMESPACE=$(NAMESPACE) ZAMMAD_ROUTE="$$ZAMMAD_ROUTE"; \
+		$(MAKE) deploy-zammad NAMESPACE=$(NAMESPACE) ZAMMAD_FQDN="$$ZAMMAD_ROUTE"; \
+	else \
+		echo "No Route found; deploying Zammad without FQDN (port-forward will work)"; \
+		$(MAKE) deploy-zammad NAMESPACE=$(NAMESPACE); \
+	fi
+	@echo "Step 3/4: Triggering autoWizard and creating API token..."
+	@$(MAKE) zammad-trigger-autowizard NAMESPACE=$(NAMESPACE) 2>/dev/null || true; \
+	ZAMMAD_URL="http://zammad-nginx.$(NAMESPACE).svc.cluster.local:8080"; \
+	ZAMMAD_TOKEN=$$(kubectl get secret $(ZAMMAD_CREDENTIALS_SECRET) -n $(NAMESPACE) -o jsonpath='{.data.zammad-http-token}' 2>/dev/null | base64 -d 2>/dev/null || true); \
+	if [ -z "$$ZAMMAD_TOKEN" ]; then \
+		echo "Creating Zammad API token via exec..."; \
+		ZAMMAD_TOKEN=$$(kubectl exec deploy/zammad-railsserver -n $(NAMESPACE) -- env ZAMMAD_ADMIN_EMAIL='$(ZAMMAD_ADMIN_EMAIL)' ZAMMAD_ADMIN_PASSWORD='$(ZAMMAD_ADMIN_PASSWORD)' ruby -rnet/http -rjson -e 'uri=URI("http://localhost:3000/api/v1/user_access_token");req=Net::HTTP::Post.new(uri);req.basic_auth(ENV["ZAMMAD_ADMIN_EMAIL"],ENV["ZAMMAD_ADMIN_PASSWORD"]);req["Content-Type"]="application/json";req.body=JSON.generate({"name"=>"mcp-agent","permission"=>["admin","ticket.agent"]});res=Net::HTTP.start(uri.hostname,uri.port){|h|h.request(req)};d=JSON.parse(res.body);t=d["token"];t ? puts(t) : ($$stderr.puts("Zammad API #{res.code}: #{res.body[0,500]}");exit 1)' ) || ZAMMAD_TOKEN=""; \
+	fi; \
+	if [ -n "$$ZAMMAD_TOKEN" ]; then \
+		echo "✅ Token created"; \
+		kubectl create secret generic $(ZAMMAD_CREDENTIALS_SECRET) \
+			--from-literal=zammad-url="$$ZAMMAD_URL/api/v1" \
+			--from-literal=zammad-http-token="$$ZAMMAD_TOKEN" \
+			-n $(NAMESPACE) --dry-run=client -o yaml | kubectl apply -f -; \
+		echo "Restarting Zammad MCP..."; \
+		kubectl rollout restart deployment/mcp-zammad-mcp -n $(NAMESPACE) 2>/dev/null || true; \
+		kubectl rollout status deployment/mcp-zammad-mcp -n $(NAMESPACE) --timeout=2m 2>/dev/null || true; \
+	else \
+		echo "⚠ Token creation failed (run make zammad-bootstrap-token NAMESPACE=$(NAMESPACE) after completing autoWizard)"; \
+	fi
+	@echo "Step 4/4: Printing checklist..."
+	@$(MAKE) _helm-install-ticketing-print-checklist NAMESPACE=$(NAMESPACE)
+
+.PHONY: _helm-install-ticketing-single
+_helm-install-ticketing-single:
+	@$(call helm_install_common,with ticketing config - Zammad MCP,\
+		-f helm/values-test.yaml \
+		-f helm/values-ticketing.yaml \
+		--set zammad.url=$(ZAMMAD_URL) \
+		--set mcp-servers.mcp-servers.zammad-mcp.enabled=true \
+		--set mcp-servers.mcp-servers.zammad-mcp.envSecrets.ZAMMAD_URL.name=$(ZAMMAD_CREDENTIALS_SECRET) \
+		--set mcp-servers.mcp-servers.zammad-mcp.envSecrets.ZAMMAD_URL.key=zammad-url \
+		--set mcp-servers.mcp-servers.zammad-mcp.envSecrets.ZAMMAD_HTTP_TOKEN.name=$(ZAMMAD_CREDENTIALS_SECRET) \
+		--set mcp-servers.mcp-servers.zammad-mcp.envSecrets.ZAMMAD_HTTP_TOKEN.key=zammad-http-token \
+		$(PROMPT_OVERRIDES),\
+		true)
+	@$(MAKE) print-urls
+
+# Patch embed ConfigMap with Zammad URL and restart deployment (no helm upgrade)
+.PHONY: _zammad-patch-embed-configmap
+_zammad-patch-embed-configmap: namespace
+	@ZAMMAD_URL="https://$(ZAMMAD_ROUTE)"; \
+	sed "s|__ZAMMAD_URL__|$$ZAMMAD_URL|g" helm/static/zammad-embed-index.html.template > /tmp/zammad-embed-index.$$$$.html; \
+	kubectl create configmap $(MAIN_CHART_NAME)-zammad-embed \
+		--from-file=index.html=/tmp/zammad-embed-index.$$$$.html \
+		-n $(NAMESPACE) --dry-run=client -o yaml | kubectl apply -f -; \
+	rm -f /tmp/zammad-embed-index.$$$$.html; \
+	kubectl rollout restart deployment/$(MAIN_CHART_NAME)-zammad-embed -n $(NAMESPACE) 2>/dev/null || true; \
+	echo "Embed ConfigMap updated with $$ZAMMAD_URL"
+
+.PHONY: _helm-install-ticketing-print-checklist
+_helm-install-ticketing-print-checklist:
+	@echo ""
+	@echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+	@echo "🎫 Ticketing Channel - Follow-up Steps"
+	@echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+	@echo ""
+	@echo "  1. Get the Zammad URL (Route or port-forward):"
+	@ZAMMAD_ROUTE=$$(oc get route ssa-zammad -n $(NAMESPACE) -o jsonpath='{.spec.host}' 2>/dev/null); \
+	ZAMMAD_EMBED_ROUTE=$$(oc get route ssa-zammad-embed -n $(NAMESPACE) -o jsonpath='{.spec.host}' 2>/dev/null); \
+	if [ -z "$$ZAMMAD_ROUTE" ]; then ZAMMAD_ROUTE=$$(oc get route -n $(NAMESPACE) -l app.kubernetes.io/instance=zammad -o jsonpath='{.items[0].spec.host}' 2>/dev/null); fi; \
+	if [ -n "$$ZAMMAD_ROUTE" ]; then \
+		echo "     Web UI: https://$$ZAMMAD_ROUTE"; \
+		echo "     API:    https://$$ZAMMAD_ROUTE/api/v1"; \
+		if [ -n "$$ZAMMAD_EMBED_ROUTE" ]; then echo "     Embed:  https://$$ZAMMAD_EMBED_ROUTE (copy-paste chat widget code)"; fi; \
+	else \
+		echo "     Port-forward: kubectl port-forward -n $(NAMESPACE) svc/zammad-nginx 8080:8080"; \
+		echo "     Web UI: http://localhost:8080"; \
+		echo "     API:    http://localhost:8080/api/v1"; \
+	fi
+	@echo ""
+	@echo "  2. Zammad FQDN: configured at deploy (from Route host) so Route loads correctly"
+	@echo ""
+	@echo "  3. If token was not auto-created:"
+	@echo "     - make zammad-bootstrap-token NAMESPACE=$(NAMESPACE)"
+	@echo "     - Or create token in Zammad UI, then: make zammad-set-token NAMESPACE=$(NAMESPACE) ZAMMAD_TOKEN=<token>"
+	@echo ""
+	@echo "  4. Enable chat widget: Admin → Channels → Chat (Section 5.3; full flow: chat → agent → reply)"
+	@echo ""
+	@echo "  5. (Optional) Configure webhook trigger: docs/TICKETING_CHANNEL_GAMEPLAN.md Section 5.2"
+	@echo "     If embed page shows YOUR-ZAMMAD-URL: make zammad-update-embed-url NAMESPACE=$(NAMESPACE)"
+	@echo ""
+	@echo "  See docs/TICKETING_CHANNEL_GAMEPLAN.md for full integration steps."
+	@echo ""
+
 # Install with full Knative eventing (production mode)
 .PHONY: helm-install-prod
 helm-install-prod: namespace helm-depend
@@ -1736,8 +1864,11 @@ helm-uninstall:
 	@echo "Step 4: Final cleanup of namespace $(NAMESPACE)..."
 	@$(MAKE) helm-cleanup-jobs
 	@$(MAKE) undeploy-email-server
+	@$(MAKE) undeploy-zammad
 	@echo "Removing ServiceNow credentials secret from $(NAMESPACE)"
 	@kubectl delete secret $(MAIN_CHART_NAME)-servicenow-credentials -n $(NAMESPACE) --ignore-not-found || true
+	@echo "Removing Zammad credentials secret from $(NAMESPACE)"
+	@kubectl delete secret $(ZAMMAD_CREDENTIALS_SECRET) -n $(NAMESPACE) --ignore-not-found || true
 	@echo "Removing pgvector, init job, and LangFuse PVCs from $(NAMESPACE)"
 	@kubectl get pvc -n $(NAMESPACE) -o custom-columns=NAME:.metadata.name 2>/dev/null | grep -E '^(pg.*-data|self-service-agent-init-status|data-self-service-agent-(clickhouse|redis|minio)-.*)' | xargs -I {} kubectl delete pvc -n $(NAMESPACE) {} --ignore-not-found ||:
 	@echo "Deleting remaining pods in namespace $(NAMESPACE)"
@@ -1910,6 +2041,158 @@ undeploy-email-server:
 	@echo "Removing test email server from namespace $(NAMESPACE)..."
 	@kubectl delete -f test-email-server/test-email-server-greenmail.yaml -n $(NAMESPACE) --ignore-not-found 2>/dev/null || true
 	@echo "✅ Test email server removed successfully!"
+
+# Zammad deployment (prerequisite for ticketing channel)
+ZAMMAD_HELM_REPO ?= https://zammad.github.io/zammad-helm
+ZAMMAD_CHART_VERSION ?= 16.0.4
+
+# ZAMMAD_FQDN: when set (e.g. from Route host), passed as extraEnv so Zammad accepts Route requests.
+# Used by helm-install-ticketing which installs our chart first (creates Route), then deploys Zammad.
+.PHONY: deploy-zammad
+deploy-zammad: namespace
+	@echo "Deploying Zammad instance to namespace $(NAMESPACE)..."
+	@echo "This may take 10-15 minutes (Zammad brings elasticsearch, postgresql, redis, memcached)..."
+	@helm repo add zammad $(ZAMMAD_HELM_REPO) 2>/dev/null || helm repo add zammad $(ZAMMAD_HELM_REPO) --force-update
+	@helm repo update zammad
+	@ZAMMAD_UID=$$(kubectl get namespace $(NAMESPACE) -o jsonpath='{.metadata.annotations.openshift\.io/sa\.scc\.uid-range}' 2>/dev/null | cut -d'/' -f1); \
+	ZAMMAD_ARGS="-f helm/values-zammad-deploy.yaml"; \
+	if [ -n "$$ZAMMAD_UID" ]; then \
+		ZAMMAD_ARGS="$$ZAMMAD_ARGS --set securityContext.runAsUser=$$ZAMMAD_UID --set securityContext.runAsGroup=$$ZAMMAD_UID --set securityContext.fsGroup=$$ZAMMAD_UID"; \
+		echo "OpenShift: using namespace UID $$ZAMMAD_UID for restricted SCC"; \
+	fi; \
+	if [ -n "$(ZAMMAD_FQDN)" ]; then \
+		echo "Configuring Zammad FQDN for Route: $(ZAMMAD_FQDN)"; \
+		TMPFQDN=$$(mktemp); \
+		echo "extraEnv:" > $$TMPFQDN; \
+		echo "  - name: ZAMMAD_FQDN" >> $$TMPFQDN; \
+		echo "    value: \"$(ZAMMAD_FQDN)\"" >> $$TMPFQDN; \
+		echo "  - name: ZAMMAD_HTTP_TYPE" >> $$TMPFQDN; \
+		echo "    value: \"https\"" >> $$TMPFQDN; \
+		ZAMMAD_ARGS="$$ZAMMAD_ARGS -f $$TMPFQDN"; \
+	fi; \
+	helm upgrade --install zammad zammad/zammad \
+		--version $(ZAMMAD_CHART_VERSION) \
+		-n $(NAMESPACE) \
+		$$ZAMMAD_ARGS \
+		--timeout 20m \
+		--wait; \
+	if [ -n "$(ZAMMAD_FQDN)" ] && [ -n "$$TMPFQDN" ]; then rm -f $$TMPFQDN; fi
+	@echo ""
+	@echo "✅ Zammad instance deployed successfully!"
+	@echo ""
+	@echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+	@echo "🎫 Zammad Ticketing Instance"
+	@echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+	@echo ""
+	@echo "📋 Next steps:"
+	@echo "  1. Get the Zammad URL (Route or port-forward):"
+	@ZAMMAD_ROUTE=$$(oc get route ssa-zammad -n $(NAMESPACE) -o jsonpath='{.spec.host}' 2>/dev/null); \
+	if [ -z "$$ZAMMAD_ROUTE" ]; then ZAMMAD_ROUTE=$$(oc get route -n $(NAMESPACE) -l app.kubernetes.io/instance=zammad -o jsonpath='{.items[0].spec.host}' 2>/dev/null); fi; \
+	if [ -n "$$ZAMMAD_ROUTE" ]; then \
+		echo "     Web UI: https://$$ZAMMAD_ROUTE"; \
+		echo "     API:    https://$$ZAMMAD_ROUTE/api/v1"; \
+	else \
+		echo "     Port-forward: kubectl port-forward -n $(NAMESPACE) svc/zammad-nginx 8080:8080"; \
+		echo "     Web UI: http://localhost:8080"; \
+		echo "     API:    http://localhost:8080/api/v1"; \
+	fi
+	@echo ""
+	@echo "  2. Complete autoWizard: visit <zammad-url>/#getting_started/auto_wizard/$(ZAMMAD_AUTOWIZARD_TOKEN)"
+	@echo "  3. Create API token: make zammad-bootstrap-token NAMESPACE=$(NAMESPACE)  (or Admin → Token Access)"
+	@echo "  4. Enable chat widget: Admin → Channels → Chat (full flow: chat → webhook → agent → reply in chat)"
+	@echo "  5. Enable ticketing in quickstart: set zammad.enabled=true, zammad.url, create Secret with token"
+	@echo ""
+	@echo "  See docs/TICKETING_CHANNEL_GAMEPLAN.md for full integration steps."
+	@echo ""
+
+.PHONY: undeploy-zammad
+undeploy-zammad:
+	@echo "Removing Zammad instance from namespace $(NAMESPACE)..."
+	@helm uninstall zammad -n $(NAMESPACE) --ignore-not-found 2>/dev/null || true
+	@echo "Waiting for pods to terminate, then removing Zammad PVCs..."
+	@sleep 5
+	@kubectl delete pvc -n $(NAMESPACE) -l app.kubernetes.io/instance=zammad --ignore-not-found 2>/dev/null || true
+	@for pvc in $$(kubectl get pvc -n $(NAMESPACE) -o jsonpath='{.items[*].metadata.name}' 2>/dev/null | tr ' ' '\n' | grep -E '^data-zammad-' || true); do kubectl delete pvc $$pvc -n $(NAMESPACE) --ignore-not-found; done
+	@echo "✅ Zammad instance removed successfully!"
+
+# Trigger autoWizard via HTTP (creates admin user). Run once before zammad-bootstrap-token.
+# Uses GET /api/v1/getting_started/auto_wizard/:token
+.PHONY: zammad-trigger-autowizard
+zammad-trigger-autowizard: namespace
+	@echo "Triggering autoWizard via HTTP..."; \
+	RES=$$(kubectl exec deploy/zammad-railsserver -n $(NAMESPACE) -- ruby -rnet/http -e 'uri=URI("http://zammad-nginx:8080/api/v1/getting_started/auto_wizard/$(ZAMMAD_AUTOWIZARD_TOKEN)");res=Net::HTTP.get_response(uri);puts res.code' 2>/dev/null) || RES=""; \
+	if [ "$$RES" = "200" ] || [ "$$RES" = "204" ]; then \
+		echo "✅ autoWizard triggered (HTTP $$RES). Waiting 5s for setup..."; \
+		sleep 5; \
+	else \
+		echo "⚠ autoWizard request returned HTTP $$RES (may already be done or system not ready)"; \
+	fi
+
+# Create Zammad API token via exec into railsserver (uses admin from autoWizard), update secret, restart MCP.
+# Idempotent: if secret already has a token, skips creation. Use ZAMMAD_FORCE_BOOTSTRAP=1 to recreate.
+.PHONY: zammad-bootstrap-token
+zammad-bootstrap-token: namespace zammad-trigger-autowizard
+	@ZAMMAD_URL="http://zammad-nginx.$(NAMESPACE).svc.cluster.local:8080"; \
+	ZAMMAD_TOKEN=$$(kubectl get secret $(ZAMMAD_CREDENTIALS_SECRET) -n $(NAMESPACE) -o jsonpath='{.data.zammad-http-token}' 2>/dev/null | base64 -d 2>/dev/null || true); \
+	if [ -n "$$ZAMMAD_TOKEN" ] && [ "$(ZAMMAD_FORCE_BOOTSTRAP)" != "1" ]; then \
+		echo "Secret already has token (idempotent). Use ZAMMAD_FORCE_BOOTSTRAP=1 to recreate."; \
+		exit 0; \
+	fi; \
+	echo "Creating Zammad API token via exec..."; \
+	ZAMMAD_TOKEN=$$(kubectl exec deploy/zammad-railsserver -n $(NAMESPACE) -- env ZAMMAD_ADMIN_EMAIL='$(ZAMMAD_ADMIN_EMAIL)' ZAMMAD_ADMIN_PASSWORD='$(ZAMMAD_ADMIN_PASSWORD)' ruby -rnet/http -rjson -e 'uri=URI("http://localhost:3000/api/v1/user_access_token");req=Net::HTTP::Post.new(uri);req.basic_auth(ENV["ZAMMAD_ADMIN_EMAIL"],ENV["ZAMMAD_ADMIN_PASSWORD"]);req["Content-Type"]="application/json";req.body=JSON.generate({"name"=>"mcp-agent","permission"=>["admin","ticket.agent"]});res=Net::HTTP.start(uri.hostname,uri.port){|h|h.request(req)};d=JSON.parse(res.body);t=d["token"];t ? puts(t) : ($$stderr.puts("Zammad API #{res.code}: #{res.body[0,500]}");exit 1)' ) || ZAMMAD_TOKEN=""; \
+	if [ -z "$$ZAMMAD_TOKEN" ]; then \
+		echo "❌ Token creation failed (401 = invalid credentials)."; \
+		echo "   Complete autoWizard first: visit <zammad-url>/#getting_started/auto_wizard/$(ZAMMAD_AUTOWIZARD_TOKEN)"; \
+		echo "   (Port-forward: kubectl port-forward -n $(NAMESPACE) svc/zammad-nginx 8080:8080, then http://localhost:8080/...)"; \
+		exit 1; \
+	fi; \
+	kubectl create secret generic $(ZAMMAD_CREDENTIALS_SECRET) \
+		--from-literal=zammad-url="$$ZAMMAD_URL/api/v1" \
+		--from-literal=zammad-http-token="$$ZAMMAD_TOKEN" \
+		-n $(NAMESPACE) --dry-run=client -o yaml | kubectl apply -f -; \
+	echo "Restarting Zammad MCP..."; \
+	kubectl rollout restart deployment/mcp-zammad-mcp -n $(NAMESPACE); \
+	kubectl rollout status deployment/mcp-zammad-mcp -n $(NAMESPACE) --timeout=2m; \
+	echo "✅ Zammad token created and MCP restarted."
+
+# Update Zammad API token and restart MCP. Run after creating token in Zammad Admin → Token Access.
+# Update embed page with actual Zammad URL (fixes placeholder when embed shows YOUR-ZAMMAD-URL)
+.PHONY: zammad-update-embed-url
+zammad-update-embed-url: namespace
+	@ZAMMAD_ROUTE=$$(oc get route ssa-zammad -n $(NAMESPACE) -o jsonpath='{.spec.host}' 2>/dev/null); \
+	if [ -z "$$ZAMMAD_ROUTE" ]; then \
+		ZAMMAD_ROUTE=$$(oc get route -n $(NAMESPACE) -l app.kubernetes.io/component=zammad -o jsonpath='{.items[0].spec.host}' 2>/dev/null); \
+	fi; \
+	if [ -z "$$ZAMMAD_ROUTE" ]; then \
+		ZAMMAD_ROUTE=$$(oc get route -n $(NAMESPACE) -l app.kubernetes.io/instance=zammad -o jsonpath='{.items[0].spec.host}' 2>/dev/null); \
+	fi; \
+	if [ -z "$$ZAMMAD_ROUTE" ]; then \
+		echo "❌ No Zammad Route found in $(NAMESPACE). Deploy Zammad and ensure ssa-zammad Route exists."; \
+		exit 1; \
+	fi; \
+	$(MAKE) _zammad-patch-embed-configmap NAMESPACE=$(NAMESPACE) ZAMMAD_ROUTE="$$ZAMMAD_ROUTE"; \
+	EMBED_HOST=$$(oc get route ssa-zammad-embed -n $(NAMESPACE) -o jsonpath='{.spec.host}' 2>/dev/null); \
+	if [ -n "$$EMBED_HOST" ]; then echo "✅ Embed page updated. Visit https://$$EMBED_HOST to verify."; \
+	else echo "✅ Embed ConfigMap updated."; fi
+
+.PHONY: zammad-set-token
+zammad-set-token: namespace
+	@if [ -z "$(ZAMMAD_TOKEN)" ]; then \
+		echo "❌ Error: ZAMMAD_TOKEN is required."; \
+		echo "  1. Create token in Zammad: Admin → Token Access → add HTTP Token"; \
+		echo "  2. Run: make zammad-set-token NAMESPACE=$(NAMESPACE) ZAMMAD_TOKEN=<your-token>"; \
+		exit 1; \
+	fi
+	@ZAMMAD_URL="http://zammad-nginx.$(NAMESPACE).svc.cluster.local:8080"; \
+	echo "Updating Zammad credentials secret with token..."; \
+	kubectl create secret generic $(ZAMMAD_CREDENTIALS_SECRET) \
+		--from-literal=zammad-url="$$ZAMMAD_URL/api/v1" \
+		--from-literal=zammad-http-token="$(ZAMMAD_TOKEN)" \
+		-n $(NAMESPACE) --dry-run=client -o yaml | kubectl apply -f -; \
+	echo "Restarting Zammad MCP deployment..."; \
+	kubectl rollout restart deployment/mcp-zammad-mcp -n $(NAMESPACE); \
+	kubectl rollout status deployment/mcp-zammad-mcp -n $(NAMESPACE) --timeout=2m; \
+	echo "✅ Zammad token set and MCP restarted."
 
 # ServiceNow PDI wake-up
 .PHONY: servicenow-wake-install

--- a/agent-service/config/agents/ticket-resolution-agent.yaml
+++ b/agent-service/config/agents/ticket-resolution-agent.yaml
@@ -1,0 +1,32 @@
+name: "ticket-resolution-agent"
+description: "An agent that resolves IT support tickets via Zammad."
+system_message: |
+  You are a helpful IT support assistant. You help users resolve issues by:
+  - Pointing to existing documentation or open tickets when relevant
+  - Answering from the knowledge base (printer locations, common fixes, SOPs)
+  - Asking "Has this resolved your issue?" when you've provided a solution
+  - Escalating to human support when needed
+
+  Speak directly to users in a conversational and professional manner. CRITICAL: do not share your internal thinking.
+# Defense-in-depth shield configuration (pattern: laptop-refresh-agent)
+input_shields:
+  - "llama-prompt-guard-2-86m/meta-llama/Llama-Prompt-Guard-2-86M"
+  - "llama-guard-3-8b/meta-llama/Llama-Guard-3-8B"
+output_shields: []
+ignored_input_shield_categories:
+  - "Code Interpreter Abuse"
+  - "Specialized Advice"
+  - "Privacy"
+  - "Self-Harm"
+ignored_output_shield_categories: []
+lg_state_machine_config: "config/lg-prompts/lg-prompt-big.yaml"
+sampling_params:
+  strategy:
+    type: "top_p"
+    temperature: 0.7
+    top_p: 0.95
+mcp_servers:
+  - name: "zammad"
+    uri: "http://mcp-zammad:8000/mcp"
+    require_approval: "never"
+knowledge_bases: ["ticket-resolution"]

--- a/agent-service/config/knowledge_bases/ticket-resolution/common_errors.txt
+++ b/agent-service/config/knowledge_bases/ticket-resolution/common_errors.txt
@@ -1,0 +1,26 @@
+Common IT Support Errors - Quick Fixes
+
+"Access Denied" or "Permission Denied":
+- Verify you're logged in with your corporate account
+- Check if you're connected to VPN (required for some resources)
+- Request access via ServiceNow if you need a new resource
+
+"Network drive not found" or "Z: drive missing":
+- Reconnect to VPN
+- Manually map: File Explorer → This PC → Map network drive → \\fileserver.company.com\shared
+
+"Outlook not connecting":
+- Restart Outlook
+- Check VPN connection
+- Verify credentials in Windows Credential Manager
+- If MFA required, use app password
+
+"Printer offline" or "Print job stuck":
+- Power cycle the printer (wait 30 seconds)
+- Clear print queue: Control Panel → Devices and Printers → Right-click printer → See what's printing → Cancel all
+- Re-add printer if issue persists
+
+"WiFi connected but no internet":
+- Forget the network and reconnect
+- Restart your laptop
+- Try ethernet cable if available (helps isolate WiFi vs network issue)

--- a/agent-service/config/knowledge_bases/ticket-resolution/password_reset_sop.txt
+++ b/agent-service/config/knowledge_bases/ticket-resolution/password_reset_sop.txt
@@ -1,0 +1,19 @@
+Password Reset - Self-Service SOP
+
+Users can reset their password without IT help:
+
+1. Go to https://portal.company.com/password-reset
+2. Enter your corporate email address
+3. Click "Send reset link"
+4. Check your email (including spam folder) for the reset link
+5. Link expires in 1 hour
+
+If self-service does not work:
+- Verify you're using your primary corporate email
+- Ensure your account is not locked (multiple failed attempts)
+- Contact IT Help Desk for manual reset: helpdesk@company.com or extension 5555
+
+IT Staff manual reset (requires admin):
+- Use Active Directory Users and Computers or equivalent
+- Right-click user → Reset Password
+- Set "User must change password at next logon"

--- a/agent-service/config/knowledge_bases/ticket-resolution/printer_locations.txt
+++ b/agent-service/config/knowledge_bases/ticket-resolution/printer_locations.txt
@@ -1,0 +1,14 @@
+Printer Locations - Office Guide
+
+Building A:
+- Main printer: 1st floor, near reception. Model: HP LaserJet Pro. Name: A1-Main.
+- Color printer: 2nd floor, break room. Model: Canon imageCLASS. Name: A2-Color.
+
+Building B:
+- Main printer: 1st floor lobby. Model: HP LaserJet Pro. Name: B1-Main.
+- Department printer: 3rd floor, IT wing. Model: Xerox. Name: B3-IT.
+
+Building C:
+- Main printer: Ground floor, near elevators. Model: HP LaserJet Pro. Name: C0-Main.
+
+Network printing: All printers are on the corporate network. Add via Print Server: print.company.local. Use your corporate credentials.

--- a/agent-service/src/agent_service/main.py
+++ b/agent-service/src/agent_service/main.py
@@ -542,6 +542,8 @@ class AgentService:
                 response_content = await session_manager.handle_responses_message(
                     text=request.content,
                     request_manager_session_id=request.session_id,
+                    target_agent_id=request.target_agent_id,
+                    requires_routing=request.requires_routing,
                 )
 
                 # Create response with automatic timing calculation
@@ -558,6 +560,8 @@ class AgentService:
                             await session_manager.handle_responses_message(
                                 text=request.content,
                                 request_manager_session_id=request.session_id,
+                                target_agent_id=request.target_agent_id,
+                                requires_routing=request.requires_routing,
                             )
                         )
                         # Check again after retry

--- a/agent-service/src/agent_service/session_manager.py
+++ b/agent-service/src/agent_service/session_manager.py
@@ -101,6 +101,8 @@ class ResponsesSessionManager(BaseSessionManager):
         text: str,
         request_manager_session_id: Optional[str] = None,
         session_name: Optional[str] = None,
+        target_agent_id: Optional[str] = None,
+        requires_routing: bool = True,
     ) -> str:
         """Handle a message in responses mode with full conversation management."""
         if not self.user_id:
@@ -121,6 +123,8 @@ class ResponsesSessionManager(BaseSessionManager):
             message_preview=text[:100],
             request_manager_session_id=request_manager_session_id,
             session_name=session_name,
+            target_agent_id=target_agent_id,
+            requires_routing=requires_routing,
             has_current_session=bool(self.current_session),
             current_agent=self.current_agent_name,
         )
@@ -162,8 +166,14 @@ class ResponsesSessionManager(BaseSessionManager):
                         "Creating initial session for responses mode",
                         user_id=self.user_id,
                         session_name=session_name,
+                        target_agent_id=target_agent_id,
+                        requires_routing=requires_routing,
                     )
-                    success = await self._create_initial_session(session_name)
+                    success = await self._create_initial_session(
+                        session_name,
+                        target_agent_id=target_agent_id,
+                        requires_routing=requires_routing,
+                    )
                     if not success:
                         logger.error(
                             "Failed to create initial session",
@@ -205,8 +215,13 @@ class ResponsesSessionManager(BaseSessionManager):
                 )
                 await self._reset_conversation_state()
                 # Recursively call with the actual user message to create new routing session
+                # Return to routing agent - pass None/True to create routing session
                 return await self.handle_responses_message(
-                    text, request_manager_session_id, session_name
+                    text,
+                    request_manager_session_id,
+                    session_name,
+                    target_agent_id=None,
+                    requires_routing=True,
                 )
 
             # Intercept special commands before passing to conversation
@@ -272,28 +287,42 @@ class ResponsesSessionManager(BaseSessionManager):
             )
             return f"Error: {str(e)}"
 
-    async def _create_initial_session(self, session_name: Optional[str] = None) -> bool:
+    async def _create_initial_session(
+        self,
+        session_name: Optional[str] = None,
+        target_agent_id: Optional[str] = None,
+        requires_routing: bool = True,
+    ) -> bool:
         """Create an initial session for responses mode."""
         try:
             logger.debug(
                 "Creating initial session for responses mode",
                 user_id=self.user_id,
                 session_name=session_name,
+                target_agent_id=target_agent_id,
+                requires_routing=requires_routing,
             )
 
-            # Get routing agent
+            # Get agent: specialist when target_agent_id set and requires_routing=False
             if self.agent_manager is None:
                 logger.error(
                     "Agent manager not initialized. Cannot create initial session."
                 )
                 return False
 
-            routing_agent = self.agent_manager.get_agent(self.ROUTING_AGENT_NAME)
-            if not routing_agent:
+            use_specialist = target_agent_id is not None and not requires_routing
+            agent_name: str = (
+                target_agent_id
+                if (use_specialist and target_agent_id)
+                else self.ROUTING_AGENT_NAME
+            )
+
+            agent = self.agent_manager.get_agent(agent_name)
+            if not agent:
                 logger.error(
-                    "Core routing agent not available",
+                    "Agent not available",
                     user_id=self.user_id,
-                    routing_agent_name=self.ROUTING_AGENT_NAME,
+                    agent_name=agent_name,
                     available_agents=(
                         list(self.agent_manager.agents_dict.keys())
                         if self.agent_manager
@@ -302,11 +331,12 @@ class ResponsesSessionManager(BaseSessionManager):
                 )
                 return False
 
-            # Debug: Check routing agent configuration
-            lg_config = routing_agent.config.get("lg_state_machine_config")
+            # Debug: Check agent configuration
+            lg_config = agent.config.get("lg_state_machine_config")
             logger.info(
-                "Routing agent configuration",
+                "Agent configuration",
                 lg_state_machine_config=lg_config,
+                agent_name=agent_name,
             )
 
             # Generate session name and create session
@@ -315,12 +345,12 @@ class ResponsesSessionManager(BaseSessionManager):
                 "Creating LangGraph session",
                 user_id=self.user_id,
                 session_name=session_name,
-                routing_agent=self.ROUTING_AGENT_NAME,
+                agent_name=agent_name,
             )
 
             session = await self._create_session_for_agent(
-                routing_agent,
-                self.ROUTING_AGENT_NAME,
+                agent,
+                agent_name,
                 session_name=session_name,
             )
 
@@ -335,9 +365,9 @@ class ResponsesSessionManager(BaseSessionManager):
 
             # Set up the new session
             self.conversation_session = session
-            self.current_agent_name = self.ROUTING_AGENT_NAME
+            self.current_agent_name = agent_name
             self.current_session = self._build_session_data(
-                routing_agent, self.ROUTING_AGENT_NAME, session, session_name
+                agent, agent_name, session, session_name
             )
 
             logger.debug(
@@ -357,7 +387,7 @@ class ResponsesSessionManager(BaseSessionManager):
             )
 
             await self._update_database_session_state(
-                self.ROUTING_AGENT_NAME,
+                agent_name,
                 session.thread_id,
                 self.request_manager_session_id,
             )

--- a/docs/HELM_EXPORT_ANSIBLE.md
+++ b/docs/HELM_EXPORT_ANSIBLE.md
@@ -60,6 +60,7 @@ ansible-playbook -i localhost, ansible/playbooks/apply-demo-manifests.yml \
 | **install** | Deploy to cluster (alias for `helm-install-$(INSTALL_MODE)`, default: test). Use `INSTALL_MODE=demo|prod` to change. |
 | **uninstall** | `helm-uninstall` + delete namespace (full teardown). |
 | **helm-install-demo** | Helm-only: deploy Greenmail + install with demo values (no Ansible). Use `uninstall` to remove (includes test-email-server). |
+| **helm-install-ticketing** | One-shot: deploy Zammad + install with ticketing channel (zammad.enabled, zammad-mcp). Requires manual API token creation after Zammad is ready. See [TICKETING_CHANNEL_GAMEPLAN.md](TICKETING_CHANNEL_GAMEPLAN.md). |
 | **helm-export-demo** | Export demo manifests to `ansible/helm-export/` from passed-in vars (NAMESPACE, VERSION, REGISTRY, SERVICENOW_*, etc.) |
 | **ansible-apply-demo** | Export then apply demo via Ansible |
 | **ansible-teardown-demo** | Delete demo namespace |

--- a/docs/MEETING_NOTES_AGENT_CAPABILITIES_AND_WORKFLOW.md
+++ b/docs/MEETING_NOTES_AGENT_CAPABILITIES_AND_WORKFLOW.md
@@ -1,0 +1,53 @@
+Meeting Notes: IT Self-Service Agent Extension — Ticketing Channel
+
+Date: March 10, 2025
+Meeting: Continue to discuss / define extension to IT self-service agent
+Topic: Ticketing channel — agent capabilities, workflow, safeguards
+
+
+1. Agent Capabilities and Workflow (From Discussion)
+
+Login and conversation management
+   • Users should be able to start new conversations/tickets or continue existing ones
+
+Point to existing content before opening new tickets
+   • When docs or open tickets address the query, point users there rather than open a new ticket
+
+Autonomous resolution (A to Z)
+   • Some scenarios should be resolvable end-to-end without human interaction (e.g., "What's the printer?")
+   • Agent asks "Has this resolved your issue?" — if yes, close ticket
+
+Safeguards
+   • Safeguards from knowledge base or shields (LlamaStack)
+   • Promptguards for certain scenarios (LlamaStack) — e.g., gate Windows laptop request
+
+Escalation
+   • Mechanism to ask for human intervention; ticket escalation when needed
+   • Zammad MCP supports this (zammad_add_article for escalation note, zammad_update_ticket to assign/change state)
+
+Agent on existing tickets (later phase)
+   • How can the agent solve or comment on existing tickets? Jobs vs direct API?
+   • Goal: reduce duration of tickets
+   • Agent always uses MCP. Chat is the user view of ticket articles; agent posts via zammad_add_article. For user-initiated (user adds article → webhook → agent replies via MCP). For proactive work on idle tickets: a scheduled or trigger-based job invokes the agent → agent uses MCP to add articles. Zammad trigger preferred — Zammad has Time Event activators (e.g., "Ticket Pending Time Reached") designed for this; reuses our webhook; no CronJob to maintain.
+
+
+2. Knowledge Base (KB)
+
+   • Only docs loaded into vector db for now
+   • Zammad has no wiki; use quickstart pipeline (static files, RAG)
+   • KBs managed as static files; no sync from Zammad
+
+
+3. Zammad Deployment (High Level)
+
+   • Phase 1: Deploy Zammad instance first
+   • Phase 2: Deploy MCP, wire to agent, add ticket-resolution-agent config
+   • Phase 3: Add webhook route, extend IntegrationType, add schemas and normalizer. Session ID = zammad-{ticket_id}
+   • Phase 4: Chat widget setup (AI agent user, availability)
+   • Phase 5: Helm integration, demo seed data
+
+   Optional later phase: Zammad Time Event trigger for proactive work on idle tickets (e.g., "Ticket Pending Time Reached" fires webhook → agent adds suggested resolution via MCP).
+
+   Flow: webhook → Integration Dispatcher → broker → Request Manager → Agent → MCP. Agent uses MCP only; replies go directly via MCP.
+
+   Feedback loop: Filter webhooks where article creator = our AI agent user. Don't process our own replies.

--- a/docs/TICKETING_CHANNEL_GAMEPLAN.md
+++ b/docs/TICKETING_CHANNEL_GAMEPLAN.md
@@ -1,0 +1,449 @@
+# Ticketing Channel: Game Plan
+
+**Status**: Phase 1 Complete (PR 1 ready)  
+**Branch**: ticketingChannel  
+**Last updated**: 2025-03-16
+
+---
+
+## 1. Branch Audit Summary
+
+### What Changed (ticketingChannel vs dev)
+
+| Category | Details |
+|----------|---------|
+| **Commits** | 7 commits, all titled "zammad" |
+| **Code changes** | **None** — documentation only |
+| **Files added** | 3 docs (gameplan + 2 supporting; see below) |
+
+### New Documents
+
+| Document | Purpose |
+|----------|---------|
+| `MEETING_NOTES_AGENT_CAPABILITIES_AND_WORKFLOW.md` | Meeting outcomes: login, point-first, A-to-Z, safeguards, escalation |
+| `ZAMMAD_TICKETING_CHANNEL_PLAN.md` | Full Zammad technical reference (payloads, MCP tools, phases) |
+
+### Key Decision: Zammad
+
+Zammad is the ticketing channel because it provides:
+
+- Purpose-built helpdesk
+- Built-in chat widget (no custom UI)
+- Straightforward webhooks and official Helm chart
+- Mature community MCP (basher83/Zammad-MCP)
+
+---
+
+## 2. Implementation Touchpoints (from Audit)
+
+All references verified against current codebase. *Note: Line numbers approximate; reqMgrOrder rebase altered request-manager structure (session_orchestrator, etc.).*
+
+| Component | Location | Current State | Required Change |
+|-----------|----------|----------------|-----------------|
+| **IntegrationType enum** | `shared-models/.../models.py` (L51–64) | SLACK, WEB, CLI, TOOL, EMAIL, SMS, WEBHOOK, TEAMS, DISCORD, TEST | Add `ZAMMAD` |
+| **Request schemas** | `request-manager/.../schemas.py` | SlackRequest, WebRequest, CLIRequest, EmailRequest, ToolRequest | Add ZammadRequest |
+| **Request Manager handler** | `request-manager/.../main.py` (L636–746) | Branches for SLACK, EMAIL | Add branch for ZAMMAD |
+| **Normalizer** | `request-manager/.../normalizer.py` | Handles Slack/Web/CLI/Email/Tool | Add `_normalize_zammad_request`; set `target_agent_id="ticket-resolution-agent"`, `requires_routing=False` |
+| **Integration Dispatcher** | `integration-dispatcher/.../main.py` | Slack routes, Email (IMAP) | Add `POST /zammad/webhook` |
+| **Webhook services** | `integration-dispatcher/` | slack_service, email_service | Add zammad_service |
+| **Helm MCP blocks** | `helm/values.yaml` | self-service-agent-snow | Add zammad-mcp |
+| **Agent config** | `agent-service/config/agents/` | laptop-refresh-agent, routing-agent | Add `ticket-resolution-agent.yaml` |
+| **Agent Service** | `agent-service/.../main.py`, `session_manager.py` | Ignores `target_agent_id`; always creates routing-agent sessions | Pass `target_agent_id` and `requires_routing` to session manager; when set, create specialist session directly |
+
+**DB migration:** Adding enum values to PostgreSQL `IntegrationType` requires an Alembic migration (used in `UserIntegrationConfig`, `RequestLog`, etc.).
+
+### 2.0 Rebase: reqMgrOrder (Session Serialization)
+
+*Rebased on reqMgrOrder; 3 commits: session request serialization, retry docs, legacy resolver.*
+
+**Migration chain:** Session serialization consolidated migrations into `001_consolidated_schema.py`. Our `002_add_zammad_integration_type.py` has `down_revision = "001"`. Migrations 002, 003 (old) were removed and consolidated; our Zammad migration is the new 002.
+
+**Session serialization:** Zammad requests participate in the same FIFO/session-lock pipeline. `session_id="zammad-{ticket_id}"` is used as partition key for broker ordering. No Zammad-specific changes needed—flows through `session_orchestrator`, `RequestLog`, advisory lock like Slack/Email.
+
+**Integration Dispatcher:** reqMgrOrder adds `outbox_publisher`, `thread_lock`, `outbox_metrics`. Phase 2 `zammad_service` should follow the same event-send pattern as `slack_service`/`email_service` (e.g. outbox for durable publish if they use it).
+
+**Reference:** [SESSION_SERIALIZATION_RUNBOOK.md](SESSION_SERIALIZATION_RUNBOOK.md) — ordering, partition keys, reclaim, 503 behavior. Zammad aligns with existing model.
+
+### 2.1 ZammadRequest Schema & event_data Structure
+
+**ZammadRequest fields** (per [ZAMMAD_TICKETING_CHANNEL_PLAN.md](ZAMMAD_TICKETING_CHANNEL_PLAN.md)):
+
+| Field | Type | Required | Purpose |
+|-------|------|----------|---------|
+| `integration_type` | IntegrationType | yes | ZAMMAD |
+| `user_id` | str | yes | From `customer_id`/`origin_by_id` mapping |
+| `content` | str | yes | Article body (user message) |
+| `ticket_id` | int | yes | Ticket ID for session continuity |
+| `article_id` | int | yes | Article ID |
+| `group_id` | int | yes | For allowlist check |
+| `group_name` | str | no | Human-readable |
+| `owner_id` | int | no | Ticket owner |
+| `created_by_id` | int | yes | Article creator (for feedback-loop filter) |
+| `zammad_delivery_id` | str | yes | From X-Zammad-Delivery header; idempotency |
+| `request_type` | str | yes | e.g. `zammad_ticket_article` |
+| `metadata` | dict | no | Additional context |
+
+**event_data** (what `zammad_service` must produce for `send_request_event`):
+
+```python
+{
+    "user_id": str,                    # Required
+    "content": str,                   # Article body
+    "integration_type": "ZAMMAD",
+    "request_type": "zammad_ticket_article",
+    "session_id": f"zammad-{ticket_id}",
+    "metadata": {"ticket_id": int, "article_id": int, "group_id": int, ...},
+    "integration_context": {"ticket_id": int, "article_id": int, "group_id": int, "zammad_delivery_id": str},
+    "ticket_id": int,
+    "article_id": int,
+    "group_id": int,
+    "created_by_id": int,
+    "zammad_delivery_id": str,
+}
+```
+
+### 2.2 Agent Service target_agent_id Flow (Critical)
+
+**Current gap:** `agent-service/main.py` calls `session_manager.handle_responses_message(text, request_manager_session_id)` but does **not** pass `target_agent_id` or `requires_routing`. The session manager always creates a routing-agent session via `_create_initial_session`.
+
+**Required change:**
+
+1. **agent-service/main.py** `_handle_responses_mode_request`: Pass `target_agent_id=request.target_agent_id` and `requires_routing=request.requires_routing` to `handle_responses_message`.
+2. **session_manager.py** `handle_responses_message`: Add params `target_agent_id`, `requires_routing`; pass to `_create_initial_session`.
+3. **session_manager.py** `_create_initial_session`: When `target_agent_id` is set and `requires_routing=False`, create specialist session for that agent directly (skip routing-agent).
+
+---
+
+## 3. Meeting Notes Direction & Discussion Points
+
+Per [MEETING_NOTES_AGENT_CAPABILITIES_AND_WORKFLOW.md](MEETING_NOTES_AGENT_CAPABILITIES_AND_WORKFLOW.md).
+
+### Agent Capabilities (Aligned Outcomes)
+
+| Capability | Direction |
+|------------|-----------|
+| **Login & conversation** | Users can start new tickets or continue existing ones; session continuity via `ticket_id` |
+| **Point-first** | When docs or open tickets address the query, point users there rather than open new tickets |
+| **A-to-Z resolution** | Some scenarios resolvable end-to-end (e.g., "What's the printer?"); agent asks "Has this resolved your issue?" → close ticket if yes |
+| **Safeguards** | KB content + shields (LlamaStack); promptguards for controlled scenarios (e.g., Windows laptop request — approval authority TBD) |
+| **Escalation** | Mechanism for human intervention; Zammad MCP supports (`zammad_add_article`, `zammad_update_ticket`) |
+| **Agent on existing tickets** | Later phase: Zammad Time Event trigger preferred (e.g., "Ticket Pending Time Reached" → webhook → agent adds resolution via MCP); no CronJob |
+
+### Knowledge Base
+
+- **Source:** Static files only; no Zammad wiki sync
+- **Path:** `agent-service/config/knowledge_bases/ticket-resolution/` — .txt files
+- **Pipeline:** Existing quickstart pipeline (RAG via LlamaStack vector store)
+- **Agent reference:** `knowledge_bases: ["ticket-resolution"]`
+
+### Discussion Points (Open / TBD)
+
+- Escalation flow: trigger logic, state names, owner resolution
+- Promptguards: Windows laptop approval authority (manager vs IT manager per request tier)
+- Zammad Time Event trigger for idle tickets — later phase
+
+---
+
+## 4. Possibilities & Trade-offs
+
+### 4.1 Phase Ordering
+
+**Meeting notes alignment:** Per [MEETING_NOTES_AGENT_CAPABILITIES_AND_WORKFLOW.md](MEETING_NOTES_AGENT_CAPABILITIES_AND_WORKFLOW.md), the meeting specified: Phase 1 = Deploy Zammad instance first; Phase 2 = Deploy MCP, wire to agent; Phase 3 = Webhook route; Phase 4 = Chat widget; Phase 5 = Helm integration.
+
+**Quickstart scope:** The quickstart assumes **Zammad is already deployed** (or teams bring their own). Quickstart phases focus on webhook + MCP integration, not Zammad deployment.
+
+**Quickstart phases:**
+
+0. **Prerequisite:** Deploy Zammad instance via Helm (`zammad.enabled`, `make deploy-zammad`, or external) — needed to test MCP and webhooks as we progress
+1. Deploy MCP + agent config (ticket-resolution-agent)
+2. Webhook route + IntegrationType + schemas + normalizer
+3. Chat widget setup (AI agent user, availability)
+4. Demo seed data, Helm integration
+
+**Recommendation:** Stick with plan order — MCP without incoming requests is hard to validate end-to-end. Webhook in Phase 2 gives a real trigger.
+
+---
+
+### 4.2 Outgoing Delivery: MCP Only
+
+Ticketing differs from Slack/Email: the agent delivers replies directly via MCP (`zammad_add_article`), not through the Integration Dispatcher. However, the delivery pipeline may still receive delivery requests for Zammad sessions (e.g. from response events). The dispatcher's `handlers` dict requires a handler for each `IntegrationType` it may encounter—otherwise it raises `ValueError("No handler for integration type: ZAMMAD")`.
+
+**Implication:** Add a **no-op `ZammadIntegrationHandler`** that immediately returns success without delivering. The agent has already posted via MCP; this avoids dispatch errors when ZAMMAD appears in user configs or delivery context.
+
+---
+
+### 4.3 Alembic Migration Strategy
+
+`IntegrationType` is stored in DB (enum column). Adding new values:
+
+- PostgreSQL: `ALTER TYPE integrationtype ADD VALUE 'ZAMMAD'`
+- Alembic: Migration that runs the `ALTER TYPE` for each new value
+- Order: Add migration in same PR as IntegrationType code change, or in a preceding migration-only PR
+
+---
+
+## 5. Proposed Implementation Roadmap
+
+*Phase ordering vs. meeting notes: See [Section 4.1](#41-phase-ordering). Quickstart phases assume Zammad is available.*
+
+### PR Strategy — Usable Functionality Per PR
+
+Each PR delivers something testable and working:
+
+| PR | Scope | Usable outcome | How to verify |
+|----|-------|----------------|---------------|
+| **PR 0** | Docs only | Planning docs on dev | Merge; no code change |
+| **PR 1** | Phase 1 (Foundation) | Inject Zammad-like CloudEvent → agent processes → MCP | Unit tests + inject test event (or Request Manager integration test) |
+| **PR 2** | Phase 2 (Webhook) | Real Zammad webhook → agent → MCP | POST mock payload to `/zammad/webhook`; E2E with Zammad instance |
+| **PR 3** | Phase 3 (Chat & Seeding) | Chat widget demo | `make deploy-zammad` + chat; optional, can be follow-up |
+
+**Phase 1 as one PR:** Foundation is kept as a single PR because splitting it (e.g. schema-only vs agent-only) would leave an intermediate state where Zammad events flow but the agent lacks the ticket-resolution agent and would fail. One PR ensures the first merge delivers end-to-end flow for injected events.
+
+---
+
+### Phase 0: Zammad Instance Deployment — Prerequisite
+
+**Goal:** Deploy a Zammad instance for local/dev testing of MCP and webhooks (or use external Zammad).
+
+- [x] `make deploy-zammad` — Helm install of official Zammad chart (`zammad/zammad` 16.0.4)
+- [x] `make undeploy-zammad` — Remove Zammad from namespace (also runs during `helm-uninstall`)
+- [x] `helm/values-zammad-deploy.yaml` — Optional overrides for dev deployment
+- [ ] **Manual:** Complete Zammad Web UI setup (admin user, org), create API token
+- [ ] **Manual:** Set `zammad.url` and create Secret with `zammad.mcp.token` when enabling ticketing
+
+**Zammad chart: autoWizard** — The official Zammad Helm chart supports `autoWizard.enabled` with a JSON config that can seed:
+  - **Users** (admin: login, email, password, organization)
+  - **Organizations**
+  - **Settings** (e.g. product_name, system_online_service)
+  - **Token** (for the autowizard URL itself; not the API token)
+
+Example (`helm show values zammad/zammad`):
+```yaml
+autoWizard:
+  enabled: false
+  config: |
+    {
+      "Token": "secret_zammad_autowizard_token",
+      "Users": [{"login": "admin@example.org", "firstname": "Admin", "lastname": "User", "email": "...", "organization": "Demo", "password": "..."}],
+      "Organizations": [{"name": "Demo"}],
+      "Settings": [{"name": "product_name", "value": "..."}]
+    }
+```
+
+**API token:** Not configurable via autowizard. Token creation (Admin → Token Access → HTTP Token) is manual, or can be automated via Zammad API: `POST /api/v1/user_access_token` (requires auth). A post-install script/job could: sign in with admin creds from autowizard → create token via API → `kubectl create secret`. TBD whether to implement.
+
+**Usage:** `make deploy-zammad NAMESPACE=my-namespace` (requires NAMESPACE). First deploy takes ~10–15 minutes (elasticsearch, postgresql, redis, memcached).
+
+**Idempotency:** `deploy-zammad` is idempotent. If `--wait` times out (20m), re-run the same command—the release is already deployed; the next run will wait again and succeed once Zammad is ready. Worst case: zammad-init job may run again; init jobs are typically safe to re-run.
+
+### Phase 0.5: One-Shot Ticketing Deploy (helm-install-ticketing)
+
+**Goal:** Single-command deploy for ticketing dev/demo—mirrors `helm-install-demo` (email + Greenmail) pattern.
+
+- [x] Add `helm-install-ticketing` Makefile target
+- [x] Target flow: `deploy-zammad` → create zammad-credentials secret → `helm upgrade --install` main chart with `-f helm/values-ticketing.yaml` (zammad.enabled, zammad-mcp, envSecrets for ZAMMAD_URL/ZAMMAD_HTTP_TOKEN)
+- [x] Print follow-up checklist (match deploy-zammad output):
+  1. Get the Zammad URL (Route or port-forward)
+  2. Complete initial setup at the Web UI (create admin, org, etc.)
+  3. Create API token: Admin → Token Access → add HTTP Token
+  4. Enable ticketing in quickstart: set `zammad.enabled=true`, `zammad.url`, create Secret with token
+  5. (Optional) Configure webhook trigger (see Section 5.2)
+- [x] Document in `make help` and HELM_EXPORT_ANSIBLE.md (or quickstart)
+
+**Design / token chicken-and-egg:** Implemented **option (2) allow broken state** plus **automation**: autoWizard seeds admin; token creation runs via `kubectl exec` into `zammad-railsserver` (Ruby one-liner to call Zammad REST API). No external reachability required; always uses in-cluster exec.
+
+### Phase 0 (legacy): Merge Docs (Ready Now)
+
+- [ ] PR: Merge ticketingChannel into dev (docs only, no code risk)
+- [ ] Outcome: Planning docs live on dev; team has single source of truth
+
+### Phase 1: Foundation (Zammad) — PR 1 ✅ Complete
+
+**Dependency order:** shared-models (IntegrationType) → Alembic migration → request-manager, agent-service, helm. Integration Dispatcher Phase 2 depends on shared-models for IntegrationType.ZAMMAD.
+
+- [x] Alembic migration: Add `ZAMMAD` to IntegrationType enum (`002_add_zammad_integration_type.py`)
+- [x] shared-models: Add `ZAMMAD` to IntegrationType
+- [x] request-manager: Add ZammadRequest schema
+- [x] request-manager: Add ZAMMAD branch in CloudEvent handler
+- [x] normalizer: Add `_normalize_zammad_request`; set `target_agent_id="ticket-resolution-agent"`, `requires_routing=False`, `session_id="zammad-{ticket_id}"`; populate `integration_context` with `ticket_id`, `article_id`, `group_id`, `zammad_delivery_id` for agent use
+- [x] agent-service: Create ticket-resolution-agent.yaml (Zammad MCP + `knowledge_bases: ["ticket-resolution"]`); configure input/output shields (pattern: laptop-refresh-agent)
+- [x] agent-service: Pass `target_agent_id` and `requires_routing` from NormalizedRequest to session manager; when `target_agent_id` set and `requires_routing=False`, create specialist session directly (skip routing-agent)
+- [x] agent-service: Create `config/knowledge_bases/ticket-resolution/` with seed .txt files (SOPs, FAQs for RAG)
+- [x] helm: Add `zammad-mcp` block to `mcp-servers.mcp-servers`; add `zammad` values block (see Section 5.1)
+- [x] integration-dispatcher: Add no-op `ZammadIntegrationHandler` (done in Phase 1 so delivery pipeline works when Zammad events are processed)
+- [x] **Deliverable:** Agent can receive ZammadRequests and process them (no webhook yet — test via mock/inject); unit test `test_normalize_zammad_request` added
+
+**Agent config details:** File `agent-service/config/agents/ticket-resolution-agent.yaml` with `name: "ticket-resolution-agent"` (must match for `get_agent()`). MCP config: `uri` from Helm (`http://mcp-zammad:8000/mcp` or similar); `knowledge_bases: ["ticket-resolution"]`. Shields: pattern from `laptop-refresh-agent.yaml` (`input_shields`, `output_shields`, `ignored_input_shield_categories`).
+
+### Phase 2: Incoming Webhook — PR 2
+
+- [ ] integration-dispatcher: Add `POST /zammad/webhook` route
+- [ ] integration-dispatcher: Add `zammad_service.py` (follow `slack_service`/`email_service` pattern—outbox, `send_request_event`, etc. per reqMgrOrder):
+  - Parse Zammad trigger payload (`ticket`, `article` objects; payload structure in [ZAMMAD_TICKETING_CHANNEL_PLAN.md](ZAMMAD_TICKETING_CHANNEL_PLAN.md#technical-details))
+  - Verify `X-Hub-Signature` (HMAC-SHA1 with `webhookSecret`); reject 401 if invalid
+  - **Event filtering:** Process only ticket create + article create (customer/external); skip internal notes, agent articles
+  - **Feedback-loop filter:** Skip when `article.origin_by_id` or `article.created_by_id` == `aiAgentUserId` (from `zammad.aiAgentUserId` Helm value)
+  - **Group allowlist:** Only process when `ticket.group_id` in `zammad.allowedGroups` (empty = allow all)
+  - Build `event_data` per Section 2.1; call `cloudevent_sender.send_request_event()`
+- [ ] integration-dispatcher: **user_id derivation:** Use `ticket.customer_id` or `article.origin_by_id`; for v1 use synthetic `zammad-{customer_id}` unless UserIntegrationMapping supports ZAMMAD (customer email → canonical user)
+- [ ] integration-dispatcher: **Idempotency:** Use `X-Zammad-Delivery` header as `event_id`; check `ProcessedEvent` table before sending (pattern: Slack/Email); skip if already seen; Zammad retries up to 4× on failure
+- [x] integration-dispatcher: Add no-op `ZammadIntegrationHandler` — *completed in Phase 1*
+- [ ] **Deliverable:** Real Zammad webhook → Integration Dispatcher → Request Manager → Agent → MCP
+
+### Phase 3: Chat Widget & Seeding — PR 3
+
+- [ ] Zammad instance deployment (optional component or external; pattern: `make deploy-zammad` like `deploy-email-server`)
+- [ ] AI agent user in Zammad, Agent role, availability config (or "Leave a message" mode)
+- [ ] Chat widget config in Zammad Admin (Channels → Chat); embed script on target site
+- [ ] **Seeding** (see below)
+- [ ] **Deliverable:** End-to-end demo: user sends chat → agent replies via MCP → reply in chat
+
+---
+
+### 5.1 Helm Values Structure
+
+```yaml
+# helm/values.yaml additions
+zammad:
+  enabled: false
+  url: "https://zammad.example.com"   # MCP needs url + /api/v1
+  webhookSecret: ""                    # From K8s Secret; HMAC key for X-Hub-Signature
+  allowedGroups: []                    # Empty = allow all; e.g. [1, 3] = only groups 1, 3
+  aiAgentUserId: null                 # Zammad user ID of AI agent; required for feedback-loop filter
+  mcp:
+    enabled: true
+    uri: "http://mcp-zammad:8000/mcp"
+    # Env from Secret: ZAMMAD_URL (url + /api/v1), ZAMMAD_HTTP_TOKEN
+```
+
+**MCP block** (add to `mcp-servers.mcp-servers`):
+```yaml
+zammad-mcp:
+  enabled: true
+  replicas: 1
+  image:
+    repository: ghcr.io/basher83/zammad-mcp
+    tag: latest
+  env:
+    ZAMMAD_URL: "{{ .Values.zammad.url }}/api/v1"
+    ZAMMAD_HTTP_TOKEN: "..."  # From Secret
+    MCP_TRANSPORT: "http"
+```
+
+---
+
+### Seeding Checklist
+
+All components must be seeded for a working demo. Pattern: init jobs or `make deploy-zammad`-style targets.
+
+| Component | What to seed | Location / mechanism |
+|-----------|--------------|------------------------|
+| **Knowledge bases** | Ticket-resolution KB content | `agent-service/config/knowledge_bases/ticket-resolution/*.txt` — SOPs, FAQs, known fixes (e.g., printer locations, common errors) |
+| **Zammad instance** | Zammad stack (postgres, redis, app) | Helm subchart or `zammad/zammad-helm`; `make deploy-zammad` or `helm/values.yaml` `zammad.enabled` |
+| **Zammad MCP** | Deployed, connected to Zammad API | Helm `zammad-mcp` block; `ZAMMAD_URL`, `ZAMMAD_HTTP_TOKEN` from Secret |
+| **AI agent user** | Zammad user for AI; Agent role | Init job or manual; **record user ID** and set `zammad.aiAgentUserId` in Helm values — required for feedback-loop filter |
+| **Groups** | Sample support groups | Init job or Zammad Admin; add group IDs to `zammad.allowedGroups` if restricting |
+| **Sample tickets** | 1–2 demo tickets | Optional; for demo/testing; no GH sync (Zammad is not git-based) |
+| **Webhook trigger** | Zammad trigger → POST `/zammad/webhook` | See Section 5.2 |
+
+**KB content examples:** Printer locations, common error resolutions, "how to reset password" SOPs — enough for agent to demonstrate point-first and A-to-Z resolution.
+
+**Zammad instance:** External Zammad — teams bring their own; quickstart adds webhook + MCP. Optional: deploy via Helm (`zammad.enabled` or `make deploy-zammad`) as Phase 1 prerequisite for local/dev validation (per meeting notes: deploy Zammad first).
+
+### 5.2 Zammad Webhook Trigger Configuration
+
+In Zammad Admin (Manage → Triggers):
+
+1. **Create trigger:** e.g. "Ticket Article Created (Customer)"
+2. **Conditions:** Ticket → Article → Created; Article → Sender → Customer (or External)
+3. **Perform:** Webhook → URL: `https://<integration-dispatcher>/zammad/webhook`; Method: POST
+4. **Secret:** Generate and store in K8s Secret; set in trigger for X-Hub-Signature
+5. **Exclude:** Add condition to skip when article created by AI agent user (or rely on backend filter via `aiAgentUserId`)
+
+Alternative: "Ticket Created" trigger for new tickets; "Article Created" for follow-up messages. Both POST to same endpoint.
+
+### 5.3 Chat Widget Setup (for full flow understanding)
+
+Enable Zammad's built-in chat to see the end-to-end flow: user sends chat → webhook → agent → MCP adds article → reply appears in chat.
+
+1. **Channels → Chat:** Zammad Admin → Channels → Chat → Add website
+2. **AI agent availability:** Chat widget appears only when an agent is available. Options:
+   - Create a dedicated AI agent user (Agent role); keep it "online" or use triggers to auto-assign
+   - Or use "Leave a message" mode: messages become tickets when no agent is online; agent processes asynchronously
+3. **Embed:** Copy the widget script; embed on a test page (or use Zammad's preview)
+4. **Flow:** User sends message → Zammad creates ticket + article → webhook fires (if trigger configured) → agent replies via MCP → reply appears in chat
+
+Reference: [Zammad Chat docs](https://admin-docs.zammad.org/en/latest/channels/chat.html)
+
+---
+
+### Success Criteria
+
+- [ ] Agent can read and update Zammad tickets via MCP
+- [ ] New ticket or customer article triggers agent processing
+- [ ] Agent reply posted as ticket article via MCP
+- [ ] No feedback loop (agent's own articles ignored)
+- [ ] Chat widget: user sends message → agent reply appears in chat
+- [ ] Session continuity via `ticket_id`; multi-turn works (user article → agent article → repeat)
+- [ ] Documented in README or quickstart guide
+
+---
+
+## 6. Security & Performance
+
+### Security
+
+| Item | Action |
+|------|--------|
+| Webhook signature | Verify X-Hub-Signature (HMAC-SHA1) with trigger secret; reject invalid; store secret in K8s Secret; never log |
+| Group allowlist | Only process webhooks for tickets in configured groups (zammad.allowedGroups) |
+| MCP token | Store ZAMMAD_HTTP_TOKEN in K8s Secret; never log or expose |
+| Safety shields | Input/output shields on ticket-resolution-agent (see Phase 1) |
+
+### Performance
+
+| Item | Action |
+|------|--------|
+| Idempotency | X-Zammad-Delivery for dedup; Zammad retries up to 4× on failure |
+| Rate limiting | Rate-limit POST /zammad/webhook (middleware or ingress) |
+| MCP monitoring | Monitor MCP call volume; back off on Zammad API errors |
+
+---
+
+## 7. Testing Strategy
+
+| Phase | Test scope |
+|-------|------------|
+| **Phase 1** | Unit tests: ZammadRequest schema validation; `_normalize_zammad_request` output (`target_agent_id`, `requires_routing`, `session_id`); Request Manager ZAMMAD branch creates ZammadRequest; agent-service passes `target_agent_id` to session manager; session manager creates specialist session when `requires_routing=False` |
+| **Phase 2** | Integration: POST to `/zammad/webhook` with mock payload; verify signature rejection (invalid HMAC → 401); verify event_data shape and `send_request_event` called; verify idempotency (duplicate X-Zammad-Delivery → skip); verify feedback-loop (article from aiAgentUserId → skip); verify group allowlist; ZammadIntegrationHandler no-op returns success |
+| **Phase 3** | E2E or manual: Inject Zammad-like CloudEvent → agent processes → verify MCP `zammad_add_article` called (or mock); chat widget: user sends message → reply appears |
+
+---
+
+## 8. Open Questions
+
+| Question | Owner / Next Step |
+|----------|-------------------|
+| KB sync: static files only? | Per meeting notes: static files for now; no Zammad wiki |
+| Escalation flow: trigger logic, state names, owner resolution | TBD; MCP supports it; flow details pending |
+| Promptguards: Windows laptop approval authority | TBD per meeting notes |
+| Zammad Time Event trigger for idle tickets | Later phase; Zammad trigger preferred over CronJob |
+
+---
+
+## 9. Risk Summary
+
+| Risk | Mitigation |
+|------|------------|
+| Feedback loop (agent’s own articles) | Filter webhooks where article creator = AI agent’s Zammad user |
+| Zammad MCP community-maintained | Review code; consider contributing; fallback: minimal MCP wrapper |
+| Chat requires agent available | AI agent user + availability config; or “Leave a message” mode |
+| Agent Service ignores target_agent_id | Phase 1: Pass to session manager; create specialist session when requires_routing=False (Section 2.2) |
+| No ZAMMAD delivery handler | Phase 2: Add no-op ZammadIntegrationHandler to prevent `ValueError` when ZAMMAD in delivery configs |
+
+---
+
+## 10. Related Documents
+
+- [Meeting Notes: Agent Capabilities](MEETING_NOTES_AGENT_CAPABILITIES_AND_WORKFLOW.md) — Meeting outcomes
+- [Zammad Ticketing Channel Plan](ZAMMAD_TICKETING_CHANNEL_PLAN.md) — Technical reference (payloads, MCP tools)

--- a/docs/ZAMMAD_TICKETING_CHANNEL_PLAN.md
+++ b/docs/ZAMMAD_TICKETING_CHANNEL_PLAN.md
@@ -1,0 +1,362 @@
+# Zammad Ticketing Channel Integration Plan
+
+**Status**: Planning  
+**Related**: [ai-quickstart-contrib #18](https://github.com/rh-ai-quickstart/ai-quickstart-contrib/issues/18) — speeding up ticket resolution time  
+**Last updated**: 2025-03-09
+
+**Implementation touchpoints:** See [Ticketing Channel Game Plan](TICKETING_CHANNEL_GAMEPLAN.md) for codebase locations and required changes.
+
+---
+
+## Executive Summary
+
+Add **Zammad** as the primary ticketing-native channel to the self-service agent blueprint. Zammad is **free and open source** (AGPL v3, no license fee). Tickets and articles = support cases; the agent uses the community [Zammad-MCP](https://github.com/basher83/Zammad-MCP) for ticket actions. **Leverage the built-in chat widget**: when a user sends a message via the chat, Zammad creates a ticket with articles; our agent replies via MCP (add article); the reply appears in the chat UI in real time — no standalone chat UI needed.
+
+User posts via chat, email, or web form → webhook triggers agent → agent replies via MCP → user sees response in chat or ticket view. Multi-turn conversation lives in the ticket article thread.
+
+---
+
+## Why Zammad as Primary Ticketing-Native Option?
+
+| Criterion | Zammad | Znuny | Gitea |
+|-----------|--------|-------|-------|
+| **Purpose-built ticketing** | Yes (helpdesk) | Yes (OTRS fork) | No (git issues) |
+| **Free / open source** | Yes (AGPL) | Yes (GPL) | Yes |
+| **Self-hosted** | Yes | Yes | Yes |
+| **Built-in chat widget** | **Yes** — real-time UI | No | No |
+| **Webhooks** | Triggers, X-Hub-Signature, retries | Web Service Notification | Gitea webhooks |
+| **Helm chart** | Official (zammad-helm) | Community | Official |
+| **MCP server** | Community ([Zammad-MCP](https://github.com/basher83/Zammad-MCP)) | Community (znuny_mcp) | Official (gitea-mcp) |
+| **Stack complexity** | Elasticsearch (optional) | Lighter | Lightest |
+
+Zammad’s built-in chat widget suits our needs: chat messages become ticket articles; our agent’s replies (added via MCP/REST API) appear in the chat in real time. No need to build a custom chat UI.
+
+---
+
+## Incoming vs Outgoing
+
+| Direction | Mechanism | Who initiates | Notes |
+|-----------|-----------|---------------|-------|
+| **Incoming** (Zammad → blueprint) | Zammad triggers (webhooks) | Zammad POSTs to our endpoint on ticket/article create | New `POST /zammad/webhook` route. Configure trigger in Zammad Admin. |
+| **Outgoing** (blueprint → Zammad) | Agent uses Zammad MCP | Agent calls `zammad_add_article`, `zammad_get_ticket`, etc. | MCP server calls Zammad REST API; no ZammadIntegrationHandler |
+
+**Why MCP for outgoing:** Agent can add articles, update status, assign, search tickets — not just post a single reply. Single integration surface (MCP) for read + write.
+
+---
+
+## Interaction Model: Ticket Articles + Chat Widget
+
+- **Chat flow**: User opens chat widget (embedded on site) → sends message → Zammad creates ticket with article → webhook fires → agent processes → agent adds article via MCP → **reply appears in chat UI** (chat is backed by ticket articles)
+- **Email / web form flow**: Same pattern — ticket created → webhook → agent replies via MCP → user sees reply in ticket view or via email notification
+- Full conversation in ticket article thread; session continuity via `ticket_id`
+
+### Delivery Path: Chat Widget Responses via MCP
+
+**Agent responses to the Zammad chat widget are delivered exclusively via MCP.** There is no Integration Dispatcher delivery handler for Zammad. The flow:
+
+1. User sends message in chat widget → Zammad creates ticket article → webhook → agent processes
+2. Agent calls `zammad_add_article` via Zammad MCP
+3. MCP server posts to Zammad REST API → ticket article created
+4. Chat widget displays the new article (chat is a view of ticket articles)
+
+This differs from Slack/Email, where responses go through the Integration Dispatcher delivery pipeline and handlers post to each configured channel. For Zammad, the agent performs delivery directly via MCP; no `ZammadIntegrationHandler` exists.
+
+**Chat widget behavior:** Zammad shows the chat only when at least one agent is available. To support an AI-first flow, create a dedicated Zammad agent user for the AI and keep it “available” (or use triggers to auto-assign chat sessions). The AI agent responds via MCP; its articles appear in the chat. Alternatively, configure “Leave a message” mode if chat should work when no human is online — messages become tickets; our agent processes asynchronously.
+
+---
+
+## Knowledge Base & RAG
+
+**No built-in wiki in Zammad.** KB comes from the quickstart’s existing pipeline:
+
+- `config/knowledge_bases/ticket-resolution/` — .txt files
+- LlamaStack vector store → RAG
+- Agent references via `knowledge_bases: ["ticket-resolution"]`
+
+No sync from Zammad; KB is managed as static files or via ingestion pipeline. Simpler than Gitea’s wiki options.
+
+---
+
+## Agent Resolution Logic (Desired Behavior)
+
+**Ideally**, the ticket-resolution agent should (per [issue #18](https://github.com/rh-ai-quickstart/ai-quickstart-contrib/issues/18)):
+
+1. **Ask clarifying questions** — Multi-turn conversation allows the agent to request more detail (e.g. "What error message do you see?", "Which version are you on?") before suggesting a fix.
+2. **Collect additional data** — Agent can ask for logs, screenshots, or reproduction steps. Zammad-MCP supports attachments (`zammad_get_article_attachments`, `zammad_download_attachment`).
+3. **Recommend fixes from KB** — Use RAG over `knowledge_bases: ["ticket-resolution"]` to find solutions, SOPs, and known resolutions. Reply with recommended fixes, steps, or links to relevant docs.
+4. **Match existing issues** — Search for similar open/resolved tickets (via `zammad_search_tickets`) and reference them when applicable.
+5. **Confirm / update ticket status** — Use `zammad_update_ticket` to change state, priority, assignee.
+6. **Close resolved tickets** — Agent asks "Has this resolved your issue?"; if yes, update ticket state to closed/resolved with success tag.
+7. **Escalate to human** — When no KB or similar ticket helps, add escalation article and assign to support (see [Escalation Flow](#escalation-flow)).
+8. **Create new ticket only when needed** — If no KB solution and no existing ticket covers the problem, create a new ticket via `zammad_create_ticket`.
+
+**Flow:** User describes issue → agent queries KB + searches tickets → if solution found, reply with fix (optionally close when resolved) → if not, create new ticket and add summary article.
+
+**Bypass case:** If a user creates a ticket directly (email, web form, Zammad UI) without going through the chat agent first, the webhook still fires. The agent should treat the incoming ticket the same way: query KB and search similar tickets. If it finds existing resolutions, add an article to the ticket with the recommended fix. The agent can attempt to resolve these tickets proactively by commenting with solutions when they exist in the KB.
+
+**Safeguards:** Use KB content and input/output shields (Llama Guard) for compliance and accuracy. Add promptguards for controlled scenarios requiring policy checks or approvals (e.g., Windows laptop request — approval authority TBD: manager vs IT manager per request tier).
+
+---
+
+## Escalation Flow
+
+**MCP actions (Zammad-MCP):**
+
+| Action | MCP tool | Purpose |
+|--------|----------|---------|
+| Add escalation article | `zammad_add_article` | "Escalating — [summary]. Recommended fix: [X]." |
+| Update ticket | `zammad_update_ticket` | Assign, change state, priority |
+| Assign to human | `zammad_update_ticket` (owner) | Assign to support agent |
+
+**Flow TBD:** Trigger logic (when to escalate), state names, owner resolution.
+
+---
+
+## Implementation Phases
+
+### Phase 1: Zammad MCP + Agent Config (Foundation)
+
+**Goal**: Agent can read/update Zammad tickets via MCP.
+
+| Task | Details |
+|------|---------|
+| Deploy Zammad MCP | Use [Zammad-MCP](https://github.com/basher83/Zammad-MCP) (AGPL-3.0). Deploy via Docker (`ghcr.io/basher83/zammad-mcp`) or uvx. Requires `ZAMMAD_URL` (include `/api/v1`), `ZAMMAD_HTTP_TOKEN`. Supports stdio and HTTP transports. |
+| Helm integration | Add Zammad MCP deployment; config similar to Snow MCP (`mcp_servers` in agent YAML). |
+| Agent config | Add Zammad MCP to ticketing/resolution agent; expose `zammad_get_ticket`, `zammad_add_article`, `zammad_search_tickets`, `zammad_update_ticket`, etc. |
+| Ticketing agent | New agent (e.g. `ticket-resolution-agent`) with Zammad MCP + `knowledge_bases: ["ticket-resolution"]`. Input/output shields (Llama Guard). |
+
+**Deliverables**: Agent can create tickets, add articles, search tickets via MCP.
+
+---
+
+### Phase 2: Zammad Webhook → Request Manager (Incoming Channel)
+
+**Goal**: Ticket/article events trigger agent processing.
+
+| Task | Details |
+|------|---------|
+| IntegrationType | Add `ZAMMAD` to `IntegrationType` enum in shared-models. |
+| Zammad webhook handler | **New** route `POST /zammad/webhook`. Zammad triggers POST to our endpoint. Verify `X-Hub-Signature` (HMAC-SHA1) with trigger secret. **Filter:** ignore events where article creator is the agent’s Zammad user (prevent feedback loop). Group allowlist: only process configured groups. |
+| Event mapping | Map ticket create / article create (customer/external) → CloudEvent `request.created`. Skip internal notes, agent articles. Use `X-Zammad-Delivery` for deduplication. |
+| Request schema | `ZammadRequest` in `request-manager/.../schemas.py` with `ticket_id`, `article_id`, `group_id`, `group_name`, `owner_id`, `created_by_id`, `zammad_delivery_id`. |
+| Normalizer | Add `_normalize_zammad_request` in `request-manager/.../normalizer.py`; set `target_agent_id="ticket-resolution-agent"`, `requires_routing=False`; pass ticket metadata in `integration_context`. Session ID: `zammad-{ticket_id}`. |
+| Request Manager | Add `elif integration_type == IntegrationType.ZAMMAD:` branch; create `ZammadRequest`. |
+| Response delivery | **None.** Agent delivers via MCP; no ZammadIntegrationHandler. |
+
+**Deliverables**: New ticket or customer article triggers agent; agent replies via MCP; reply appears in chat or ticket view.
+
+---
+
+### Phase 3: Chat Widget Integration (Leverage Built-in UI)
+
+**Goal**: Ensure chat widget is usable for AI-assisted support.
+
+| Task | Details |
+|------|---------|
+| AI agent user | Create Zammad user for AI agent; assign Agent role. |
+| Agent availability | Keep AI agent “available” (or use triggers to auto-assign) so chat widget is visible. Alternatively, use “Leave a message” mode. |
+| Chat widget config | Configure chat in Zammad Admin (Channels → Chat). Embed widget script on target site. |
+| Validation | User sends chat message → webhook → agent replies via MCP → reply appears in chat. |
+
+**Deliverables**: Chat widget provides real-time UI; AI replies visible in chat. No custom chat UI needed.
+
+---
+
+### Phase 4: Demo Pre-population (Deployment / Demo)
+
+**Goal**: Seed Zammad with sample data at quickstart boot.
+
+| Task | Details |
+|------|---------|
+| Zammad deployment | Add Zammad as optional component; `make deploy-zammad` or similar. |
+| Init / seed | Create sample groups, sample tickets. No GH sync (Zammad is not git-based). |
+| Helm integration | Zammad ticketing ties into `make helm-install-test`, `helm/values.yaml`. Zammad, Zammad MCP as conditional blocks (`zammad.enabled`). |
+
+---
+
+## Future / v2
+
+Per [issue #18](https://github.com/rh-ai-quickstart/ai-quickstart-contrib/issues/18):
+
+| Feature | Description |
+|---------|-------------|
+| **Docling for PDFs** | Extract information from PDFs (attachments, KB docs) into the knowledge base. |
+| **Multi-model for images** | Analyze screenshots attached to tickets (e.g. error dialogs, UI issues) with vision-capable models. |
+| **Optional resolved-ticket creation** | When the agent resolves via chat, create a summarized "resolved" ticket for audit (per Pete Davis comment in issue #18). |
+| **Zammad AI Provider integration** | Optional: Point Zammad's built-in AI (Ticket Summary, Writing Assistant, AI Agents) at LlamaStack via Custom/OpenAI-compatible provider. For human agents using Zammad UI; separate from our webhook+MCP agent. See [Zammad AI Provider docs](https://admin-docs.zammad.org/en/pre-release/ai/provider.html). |
+| **Proactive work on idle tickets** | Zammad Time Event trigger (e.g., "Ticket Pending Time Reached") fires webhook when ticket idle; agent adds suggested resolution via MCP. Preferred over CronJob — reuses webhook, no extra infra. |
+
+Out of scope for v1.
+
+---
+
+## Deployment & Helm Integration
+
+**Assumption:** Zammad ticketing integrates with the existing Helm install mechanism.
+
+| Existing mechanism | Zammad ticketing fit |
+|--------------------|----------------------|
+| `make helm-install-test` / `helm-install-prod` | Add `zammad.enabled`, `zammad.mcp.enabled` flags |
+| `helm/values.yaml` | Add `zammad` block (url, webhookSecret, defaultGroup, mcp.uri) |
+| `make deploy-email-server` | Pattern for `make deploy-zammad` (optional Zammad instance) |
+| Init job | Optional: create AI agent user, sample groups |
+
+**Zammad official Helm chart:** [zammad/zammad-helm](https://github.com/zammad/zammad-helm) — use as subchart or dependency.
+
+---
+
+## Technical Details
+
+### Zammad Webhook Payload (Relevant Fields)
+
+```json
+{
+  "ticket": {
+    "id": 81,
+    "number": "10081",
+    "title": "...",
+    "state": "open",
+    "group_id": 3,
+    "owner_id": 5,
+    "article_ids": [104],
+    "created_by_id": 3,
+    "customer_id": 8
+  },
+  "article": {
+    "id": 104,
+    "ticket_id": 81,
+    "body": "User's message...",
+    "sender": "Customer",
+    "sender_id": 2,
+    "internal": false,
+    "origin_by_id": 8
+  }
+}
+```
+
+### Zammad Webhook Headers
+
+- `X-Zammad-Trigger`: Trigger name
+- `X-Zammad-Delivery`: Unique ID (deduplication)
+- `X-Hub-Signature`: HMAC-SHA1 (if configured)
+
+### Zammad MCP Tools (basher83/Zammad-MCP)
+
+- **Ticket:** `zammad_search_tickets`, `zammad_get_ticket`, `zammad_create_ticket`, `zammad_update_ticket`, `zammad_add_article`, `zammad_add_ticket_tag`, `zammad_remove_ticket_tag`
+- **Attachments:** `zammad_get_article_attachments`, `zammad_download_attachment`, `zammad_delete_attachment`
+- **Users & orgs:** `zammad_get_user`, `zammad_search_users`, `zammad_get_organization`, `zammad_search_organizations`, `zammad_get_current_user`
+- **System:** `zammad_list_groups`, `zammad_list_ticket_states`, `zammad_list_ticket_priorities`, `zammad_get_ticket_stats`
+
+### Database / Schema Changes
+
+- `IntegrationType`: add `ZAMMAD`
+- Alembic migration for enum
+- `ZammadRequest` schema
+
+### Configuration
+
+```yaml
+# Helm values
+zammad:
+  enabled: true
+  url: "https://zammad.example.com"        # Zammad-MCP needs url + /api/v1
+  webhookSecret: "<trigger-secret>"
+  defaultGroup: "Support"
+  mcp:
+    enabled: true
+    uri: "http://zammad-mcp:8000/mcp"       # HTTP transport (MCP_TRANSPORT=http)
+    # Env: ZAMMAD_URL, ZAMMAD_HTTP_TOKEN
+  chat:
+    enabled: true  # Use built-in chat widget
+```
+
+---
+
+## Dependencies
+
+| Dependency | Purpose |
+|------------|---------|
+| Zammad instance | Self-hosted; Docker or Helm |
+| Zammad MCP server | [Zammad-MCP](https://github.com/basher83/Zammad-MCP) — community; holds Zammad API token |
+| Zammad trigger | Configured in Zammad Admin for webhook POST |
+| Request Manager | Add `ZammadRequest` handling |
+| Integration Dispatcher | Add `POST /zammad/webhook` route |
+| Agent Service | Add Zammad MCP config |
+
+---
+
+## Risks and Mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| Zammad MCP community-maintained | Review codebase; consider contributing. Fallback: minimal MCP wrapper around Zammad REST API. |
+| Feedback loop | Filter webhooks where article creator is AI agent’s Zammad user. |
+| Chat requires agent available | Create AI agent user; keep available or use “Leave a message” mode. |
+| Elasticsearch (optional) | Zammad can run without ES for smaller deployments. |
+
+---
+
+## Audit: Gaps, Security, Performance
+
+### Critical Gaps
+
+| Gap | Mitigation |
+|-----|------------|
+| **Feedback loop** | Ignore webhooks where `article.created_by_id` matches AI agent’s Zammad user. |
+| **Request Manager** | Add ZAMMAD branch. |
+| **Session ID** | `zammad-{ticket_id}`. |
+| **Event filtering** | Only process ticket create + article create (customer/external). Skip internal notes, agent articles. |
+
+### Security
+
+| Item | Recommendation |
+|------|----------------|
+| **Webhook signature** | Verify `X-Hub-Signature` (HMAC-SHA1) with trigger secret. |
+| **Group allowlist** | Only process configured groups. |
+| **MCP token** | Store in K8s Secret; never log. |
+| **Rate limiting** | Rate-limit webhook endpoint. |
+| **Safety shields** | Input/output shields on ticket-resolution agent. |
+
+### Performance
+
+| Item | Recommendation |
+|------|----------------|
+| **MCP call volume** | Agent may make multiple ticket/article calls. Monitor; back off on errors. |
+| **Webhook retries** | Zammad retries up to 4 times on failure. Handle idempotently via `X-Zammad-Delivery`. |
+| **Deduplication** | Use `X-Zammad-Delivery` for idempotency. |
+
+---
+
+## Success Criteria
+
+- [ ] Agent can read and update Zammad tickets via MCP
+- [ ] New ticket or customer article triggers agent processing (Zammad webhook → Integration Dispatcher)
+- [ ] Agent reply is posted as ticket article via MCP
+- [ ] No feedback loop (agent’s own articles ignored)
+- [ ] Multi-turn conversation works (user article → agent article → repeat)
+- [ ] **Chat widget:** User sends message → agent reply appears in chat UI
+- [ ] Session continuity via `ticket_id`
+- [ ] Documented in README / quickstart guide
+
+---
+
+## Gitea vs Zammad vs Znuny: When to Choose Which?
+
+| Choose Gitea when | Choose Zammad when | Choose Znuny when |
+|-------------------|--------------------|-------------------|
+| Aligning with ai-quickstart-contrib #18 | Need purpose-built ticketing + **chat UI** | Need ITSM (queues, CMDB, time accounting) |
+| Want wiki-as-KB in same platform | Free, modern helpdesk, simpler webhooks | Heavier OTRS-style workflows |
+| Git-centric workflow | Official Helm, chat widget, good MCP | Community MCP, Web Service config |
+
+---
+
+## References
+
+- [ai-quickstart-contrib #18](https://github.com/rh-ai-quickstart/ai-quickstart-contrib/issues/18)
+- [Zammad-MCP](https://github.com/basher83/Zammad-MCP) — Zammad MCP server (tickets, attachments, users, orgs, prompts)
+- [Zammad documentation](https://docs.zammad.org/)
+- [Zammad Webhooks](https://admin-docs.zammad.org/en/3.x/manage/trigger/webhooks.html)
+- [Zammad Chat](https://admin-docs.zammad.org/en/4.x/channels/chat.html)
+- [zammad/zammad-helm](https://github.com/zammad/zammad-helm) — Official Helm chart
+- [Ticketing Channel Game Plan](TICKETING_CHANNEL_GAMEPLAN.md) — Implementation touchpoints
+- Blueprint: `guides/INTEGRATION_GUIDE.md`, `docs/ARCHITECTURE_DIAGRAMS.md`

--- a/helm/static/zammad-embed-index.html.template
+++ b/helm/static/zammad-embed-index.html.template
@@ -1,0 +1,27 @@
+    <!DOCTYPE html>
+    <html lang="en">
+    <head>
+      <meta charset="UTF-8">
+      <meta name="viewport" content="width=device-width, initial-scale=1.0">
+      <title>Zammad Chat Embed</title>
+      <style>
+        body { font-family: system-ui, sans-serif; max-width: 680px; margin: 2rem auto; padding: 0 1rem; line-height: 1.6; }
+        pre { background: #f5f5f5; padding: 1rem; overflow-x: auto; border-radius: 4px; }
+        code { font-size: 0.9em; }
+        h1 { font-size: 1.25rem; }
+      </style>
+    </head>
+    <body>
+      <h1>Zammad Chat - Embed Code</h1>
+      <p>Insert the widget code into the source code of every page the chat shall be visible on. It should be placed at the end of the page's source code before the <code>&lt;/body&gt;</code> closing tag.</p>
+      <pre><code>&lt;script src="__ZAMMAD_URL__/assets/chat/chat-no-jquery.min.js"&gt;&lt;/script&gt;
+&lt;script&gt;
+(function() { new ZammadChat({ fontSize: '12px', chatId: 1 }); })();
+&lt;/script&gt;</code></pre>
+      <p><strong>Note:</strong> The chat widget only appears when at least one agent is available (Admin → Channels → Chat).</p>
+      <script src="__ZAMMAD_URL__/assets/chat/chat-no-jquery.min.js"></script>
+      <script>
+      (function() { new ZammadChat({ fontSize: '12px', chatId: 1 }); })();
+      </script>
+    </body>
+    </html>

--- a/helm/templates/_env-helpers.tpl
+++ b/helm/templates/_env-helpers.tpl
@@ -115,7 +115,7 @@ Generate common environment variables for all services
 - name: SQL_DEBUG
   value: "false"
 - name: EXPECTED_MIGRATION_VERSION
-  value: {{ .Values.database.expectedMigrationVersion | default "001" | quote }}
+  value: {{ .Values.database.expectedMigrationVersion | default "002" | quote }}
 {{/* Eventing Configuration - Always enabled (mock or full Knative) */}}
 - name: BROKER_URL
   value: {{ if .Values.requestManagement.knative.eventing.enabled }}{{ printf "%s/%s/%s" .Values.requestManagement.knative.broker.url .Release.Namespace .Values.requestManagement.knative.broker.name | quote }}{{ else }}{{ printf "http://%s-mock-eventing.%s.svc.cluster.local:8080/%s/%s" (include "self-service-agent.fullname" .) .Release.Namespace .Release.Namespace .Values.requestManagement.knative.broker.name | quote }}{{ end }}

--- a/helm/templates/external-routes.yaml
+++ b/helm/templates/external-routes.yaml
@@ -53,3 +53,52 @@ spec:
     termination: edge
     insecureEdgeTerminationPolicy: Redirect
 {{- end }}
+
+{{- if and .Values.zammad.enabled .Values.zammad.externalRoute.enabled }}
+---
+# OpenShift Route for Zammad Web UI (ticketing channel)
+# Targets zammad-nginx service created by Zammad chart (deploy-zammad)
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: ssa-zammad
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "self-service-agent.labels" . | nindent 4 }}
+    app.kubernetes.io/component: zammad
+  annotations:
+    haproxy.router.openshift.io/timeout: "300s"
+spec:
+  to:
+    kind: Service
+    name: {{ .Values.zammad.externalRoute.serviceName | default "zammad-nginx" }}
+    weight: 100
+  port:
+    targetPort: http
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect
+{{- end }}
+
+{{- if and .Values.zammad.enabled .Values.zammad.embedPage.enabled }}
+---
+# OpenShift Route for Zammad chat embed page (copy-paste embed code)
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: ssa-zammad-embed
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "self-service-agent.labels" . | nindent 4 }}
+    app.kubernetes.io/component: zammad-embed
+spec:
+  to:
+    kind: Service
+    name: {{ include "self-service-agent.fullname" . }}-zammad-embed
+    weight: 100
+  port:
+    targetPort: http
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect
+{{- end }}

--- a/helm/templates/network-policies.yaml
+++ b/helm/templates/network-policies.yaml
@@ -147,6 +147,35 @@ spec:
 {{- end }}
 {{- end }}
 
+{{- if and .Values.zammad.enabled .Values.zammad.externalRoute.enabled (eq .Values.requestManagement.networkPolicies.platform "openshift") }}
+---
+# Allow ingress from OpenShift router to Zammad nginx (for ssa-zammad Route)
+# Zammad pods use app.kubernetes.io/instance=zammad, not self-service-agent
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "self-service-agent.fullname" . }}-allow-zammad-ingress
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "self-service-agent.labels" . | nindent 4 }}
+    component: network-policy
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: zammad
+      app.kubernetes.io/component: zammad-nginx
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          network.openshift.io/policy-group: ingress
+    ports:
+    - protocol: TCP
+      port: 8080
+{{- end }}
+
 {{- if .Values.requestManagement.networkPolicies.additionalIngressRules }}
 ---
 # Additional custom ingress rules from values

--- a/helm/templates/zammad-embed-configmap.yaml
+++ b/helm/templates/zammad-embed-configmap.yaml
@@ -1,0 +1,37 @@
+{{- if and .Values.zammad.enabled .Values.zammad.embedPage.enabled }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "self-service-agent.fullname" . }}-zammad-embed
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "self-service-agent.labels" . | nindent 4 }}
+    app.kubernetes.io/component: zammad-embed
+data:
+  index.html: |
+    <!DOCTYPE html>
+    <html lang="en">
+    <head>
+      <meta charset="UTF-8">
+      <meta name="viewport" content="width=device-width, initial-scale=1.0">
+      <title>Zammad Chat Embed</title>
+      <style>
+        body { font-family: system-ui, sans-serif; max-width: 680px; margin: 2rem auto; padding: 0 1rem; line-height: 1.6; }
+        pre { background: #f5f5f5; padding: 1rem; overflow-x: auto; border-radius: 4px; }
+        code { font-size: 0.9em; }
+        h1 { font-size: 1.25rem; }
+      </style>
+    </head>
+    <body>
+      <h1>Zammad Chat - Embed Code</h1>
+      <p>Copy the following code into your website before the closing <code>&lt;/body&gt;</code> tag:</p>
+      <pre><code>{{- $zammadUrl := (.Values.zammad.embedPage.publicUrl | default "https://YOUR-ZAMMAD-URL") | trimSuffix "/" -}}
+    &lt;script src="{{ $zammadUrl }}/assets/chat/chat-no-jquery.min.js"&gt;&lt;/script&gt;
+    &lt;script&gt;
+    (function() { new ZammadChat({{ "{" }} fontSize: '12px', chatId: {{ default 1 .Values.zammad.embedPage.chatId }} {{ "}" }}); })();
+    &lt;/script&gt;</code></pre>
+      <p><strong>Note:</strong> The chat widget only appears when at least one agent is available (Admin → Channels → Chat).</p>
+    </body>
+    </html>
+{{- end }}

--- a/helm/templates/zammad-embed-deployment.yaml
+++ b/helm/templates/zammad-embed-deployment.yaml
@@ -1,0 +1,57 @@
+{{- if and .Values.zammad.enabled .Values.zammad.embedPage.enabled }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "self-service-agent.fullname" . }}-zammad-embed
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "self-service-agent.labels" . | nindent 4 }}
+    app.kubernetes.io/component: zammad-embed
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "self-service-agent.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: zammad-embed
+  template:
+    metadata:
+      labels:
+        {{- include "self-service-agent.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: zammad-embed
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+      - name: nginx
+        image: nginxinc/nginx-unprivileged:alpine
+        imagePullPolicy: IfNotPresent
+        ports:
+        - name: http
+          containerPort: 8080
+          protocol: TCP
+        volumeMounts:
+        - name: embed-content
+          mountPath: /usr/share/nginx/html
+          readOnly: true
+        - name: tmp
+          mountPath: /tmp
+        resources:
+          requests:
+            cpu: 10m
+            memory: 16Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+      volumes:
+      - name: embed-content
+        configMap:
+          name: {{ include "self-service-agent.fullname" . }}-zammad-embed
+      - name: tmp
+        emptyDir: {}
+{{- end }}

--- a/helm/templates/zammad-embed-service.yaml
+++ b/helm/templates/zammad-embed-service.yaml
@@ -1,0 +1,21 @@
+{{- if and .Values.zammad.enabled .Values.zammad.embedPage.enabled }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "self-service-agent.fullname" . }}-zammad-embed
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "self-service-agent.labels" . | nindent 4 }}
+    app.kubernetes.io/component: zammad-embed
+spec:
+  type: ClusterIP
+  ports:
+  - name: http
+    port: 80
+    targetPort: http
+    protocol: TCP
+  selector:
+    {{- include "self-service-agent.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: zammad-embed
+{{- end }}

--- a/helm/values-ticketing.yaml
+++ b/helm/values-ticketing.yaml
@@ -1,0 +1,32 @@
+# Ticketing channel (Zammad) - use with helm-install-ticketing
+# Extends values-test. Requires: make deploy-zammad first (or external Zammad).
+# zammad.url is set via --set in Makefile (namespace-dependent: Route or in-cluster).
+#
+# After install: Create API token in Zammad, update the zammad-credentials Secret,
+# then restart the MCP pod. See printed checklist.
+
+# Enable Zammad ticketing channel and MCP
+zammad:
+  enabled: true
+  # url set via --set in Makefile (http://zammad-nginx.NAMESPACE.svc.cluster.local:8080 or Route)
+  url: ""  # Override required
+  webhookSecret: ""
+  allowedGroups: []
+  aiAgentUserId: null
+  mcp:
+    enabled: true
+    uri: "http://mcp-zammad:8000/mcp"
+  # OpenShift Route for Zammad Web UI (enabled for ticketing profile on OpenShift)
+  externalRoute:
+    enabled: true
+  # Embed page: copy-paste chat widget code (publicUrl set via Makefile from Route host)
+  embedPage:
+    enabled: true
+    publicUrl: ""  # Set by helm-install-ticketing from ssa-zammad Route host
+    chatId: 1
+
+# Enable zammad-mcp MCP server
+mcp-servers:
+  mcp-servers:
+    zammad-mcp:
+      enabled: true

--- a/helm/values-zammad-deploy.yaml
+++ b/helm/values-zammad-deploy.yaml
@@ -1,0 +1,100 @@
+# Values for make deploy-zammad (Zammad instance for dev/testing)
+# Use with: helm upgrade --install zammad zammad/zammad -n NAMESPACE -f helm/values-zammad-deploy.yaml
+#
+# After deployment:
+# - Set zammad.url in main chart to your Zammad instance URL (Route/Ingress or port-forward)
+#   With helm-install-ticketing: main chart can create OpenShift Route (zammad.externalRoute.enabled)
+# - Create an API token in Zammad Admin and set zammad.mcp.token in the Secret
+#   OR use: make zammad-bootstrap-token (automated, uses admin from autoWizard below)
+# - See docs/TICKETING_CHANNEL_GAMEPLAN.md Section 5.0
+#
+# Note: Zammad chart brings elasticsearch, postgresql, redis, memcached. First deploy may take 10+ minutes.
+
+# AutoWizard: seeds admin user so zammad-bootstrap-token can create API token via API.
+# First user = Admin+Agent; add Users with "roles": ["Customer"] for end users (view own tickets, open new ones).
+# Override via --set autoWizard.config=... or env ZAMMAD_ADMIN_EMAIL, ZAMMAD_ADMIN_PASSWORD.
+# Token must match ZAMMAD_AUTOWIZARD_TOKEN in Makefile (for zammad-trigger-autowizard).
+autoWizard:
+  enabled: true
+  config: |
+    {
+      "Token": "ssa-zammad-autowizard-9f3a2b1c",
+      "TextModuleLocale": { "Locale": "en-us" },
+      "Users": [
+        {
+          "login": "admin@zammad.local",
+          "firstname": "Admin",
+          "lastname": "User",
+          "email": "admin@zammad.local",
+          "organization": "Default",
+          "password": "ZammadR0cks!"
+        },
+        {
+          "login": "alice@example.com",
+          "firstname": "Alice",
+          "lastname": "Customer",
+          "email": "alice@example.com",
+          "organization": "Default",
+          "password": "Customer123!",
+          "roles": ["Customer"]
+        },
+        {
+          "login": "bob@example.com",
+          "firstname": "Bob",
+          "lastname": "Customer",
+          "email": "bob@example.com",
+          "organization": "Default",
+          "password": "Customer123!",
+          "roles": ["Customer"]
+        }
+      ],
+      "Organizations": [{"name": "Default"}],
+      "Settings": [
+        {"name": "product_name", "value": "Zammad Demo"},
+        {"name": "system_online_service", "value": true}
+      ]
+    }
+
+# Pod Security: disable privileged init containers (volumePermissions, sysctl).
+# Zammad chart defaults (runAsUser/fsGroup: 1000) conflict with OpenShift restricted SCC.
+# Makefile deploy-zammad auto-detects namespace UID range on OpenShift and passes via --set.
+#
+# FQDN: Zammad needs ZAMMAD_FQDN to accept requests via Route. helm-install-ticketing installs
+# our chart first (creates Route), then deploys Zammad with ZAMMAD_FQDN=<route-host> at deploy.
+# Port-forward works without it (Host: localhost).
+#
+# trustedProxies: Required for OpenShift Route. Traffic arrives from the router (cluster internal
+# IPs). Without this, Zammad may not trust X-Forwarded-Proto/Host and redirects/scheme break.
+zammadConfig:
+  initContainers:
+    volumePermissions:
+      enabled: false  # Privileged init container incompatible with restricted SCC
+  nginx:
+    # Trust cluster-internal IPs (OpenShift router forwards from these ranges)
+    trustedProxies:
+      - 10.0.0.0/8
+      - 172.16.0.0/12
+      - 192.168.0.0/16
+  railsserver:
+    # RAILS_TRUSTED_PROXIES: same ranges so Rails trusts X-Forwarded-* from the route
+    trustedProxies: "['127.0.0.1', '::1', '10.0.0.0/8', '172.16.0.0/12', '192.168.0.0/16']"
+  # ingress: set manually for deploy-zammad-only (helm-install-ticketing passes FQDN at deploy)
+  # ingress: { enabled: true, host: zammad.example.com }
+
+postgresql:
+  volumePermissions:
+    enabled: false  # Privileged; incompatible with restricted SCC
+  global:
+    compatibility:
+      openshift:
+        adaptSecurityContext: force  # Use OpenShift-allocated UIDs
+
+elasticsearch:
+  sysctlImage:
+    enabled: false  # Privileged; vm.max_map_count often set at node level on OpenShift
+  volumePermissions:
+    enabled: false
+  global:
+    compatibility:
+      openshift:
+        adaptSecurityContext: force  # Use OpenShift-allocated UIDs

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -29,7 +29,7 @@ testIntegrationEnabled: false
 # Database Configuration
 database:
   # Expected migration version that services should wait for
-  expectedMigrationVersion: "001"
+  expectedMigrationVersion: "002"
   
   # Database connection URL - leave empty to use default pgvector service
   # Format: postgresql://username:password@host:port/database
@@ -267,6 +267,45 @@ mcp-servers:
 
     oracle-sqlcl:
       enabled: false
+
+    # Zammad MCP server for ticketing integration
+    zammad-mcp:
+      enabled: false
+      replicas: 1
+      deploymentMode: deployment
+      image:
+        repository: ghcr.io/basher83/zammad-mcp
+        tag: "1.1.0"
+      port: 8000
+      targetPort: 8000
+      transport: http
+      imagePullPolicy: IfNotPresent
+      env:
+        MCP_TRANSPORT: "http"
+        MCP_PORT: "8000"
+        # ZAMMAD_URL and ZAMMAD_HTTP_TOKEN from Secret (zammad.url, zammad.mcp.token)
+
+# Zammad ticketing channel (optional)
+zammad:
+  enabled: false
+  url: "https://zammad.example.com"
+  webhookSecret: ""
+  allowedGroups: []
+  aiAgentUserId: null
+  mcp:
+    enabled: false
+    uri: "http://mcp-zammad:8000/mcp"
+  # OpenShift Route for external access to Zammad Web UI (when Zammad is deployed via deploy-zammad)
+  # Requires zammad-nginx service in namespace (created by Zammad chart)
+  externalRoute:
+    enabled: false  # Set to true to create OpenShift Route for Zammad (e.g. when using helm-install-ticketing)
+    serviceName: zammad-nginx  # Override if Zammad chart uses different service name (e.g. zammad-zammad-nginx)
+  # Embed page: small nginx serving copy-paste embed code for Zammad chat widget
+  # publicUrl: Zammad base URL for script src (e.g. https://ssa-zammad-<ns>.<cluster>). Set via Makefile when using helm-install-ticketing.
+  embedPage:
+    enabled: false
+    publicUrl: ""  # Required when enabled; e.g. https://ssa-zammad-mynamespace.apps.example.com
+    chatId: 1  # Zammad chat channel ID (Admin → Channels → Chat)
 
 # Enable/disable the llm-service dependency
 llm-service:

--- a/integration-dispatcher/src/integration_dispatcher/integrations/zammad.py
+++ b/integration-dispatcher/src/integration_dispatcher/integrations/zammad.py
@@ -1,0 +1,34 @@
+"""Zammad integration handler - no-op.
+
+Zammad responses are delivered via MCP (zammad_add_article) by the agent.
+This handler exists to satisfy the dispatcher's handler lookup; it returns
+success immediately without delivering.
+"""
+
+from typing import Any, Dict
+
+from shared_models.models import DeliveryRequest, DeliveryStatus, UserIntegrationConfig
+
+from .base import BaseIntegrationHandler, IntegrationResult
+
+
+class ZammadIntegrationHandler(BaseIntegrationHandler):
+    """No-op handler for Zammad. Agent delivers via MCP directly."""
+
+    async def deliver(
+        self,
+        request: DeliveryRequest,
+        config: UserIntegrationConfig,
+        template_content: Dict[str, str],
+    ) -> IntegrationResult:
+        """No-op: agent already delivered via zammad_add_article."""
+        return IntegrationResult(
+            success=True,
+            status=DeliveryStatus.DELIVERED,
+            message="Zammad delivery via MCP (no-op)",
+            metadata={"delivery_method": "zammad_mcp"},
+        )
+
+    async def validate_config(self, config: Dict[str, Any]) -> bool:
+        """Zammad requires no config for delivery (MCP handles it)."""
+        return True

--- a/integration-dispatcher/src/integration_dispatcher/main.py
+++ b/integration-dispatcher/src/integration_dispatcher/main.py
@@ -45,6 +45,7 @@ from .integrations.email import EmailIntegrationHandler
 from .integrations.slack import SlackIntegrationHandler
 from .integrations.test import TestIntegrationHandler
 from .integrations.webhook import WebhookIntegrationHandler
+from .integrations.zammad import ZammadIntegrationHandler
 from .outbox_publisher import run_outbox_publisher
 from .schemas import (
     DeliveryLogResponse,
@@ -72,6 +73,7 @@ class IntegrationDispatcher:
             IntegrationType.EMAIL: EmailIntegrationHandler(),
             IntegrationType.WEBHOOK: WebhookIntegrationHandler(),
             IntegrationType.TEST: TestIntegrationHandler(),
+            IntegrationType.ZAMMAD: ZammadIntegrationHandler(),
         }
         self.template_engine = TemplateEngine()
 

--- a/integration-dispatcher/src/integration_dispatcher/template_engine.py
+++ b/integration-dispatcher/src/integration_dispatcher/template_engine.py
@@ -99,6 +99,11 @@ class TemplateEngine:
             formatted_subject = f"[TEST] {subject or 'Agent Response'}"
             formatted_body = f"🧪 TEST DELIVERY\n\n{content}"
 
+        elif integration_type == IntegrationType.ZAMMAD:
+            # Zammad: No-op handler uses this; agent delivers via MCP
+            formatted_subject = subject or "Agent Response"
+            formatted_body = content
+
         else:
             # Default formatting
             formatted_subject = subject or "Agent Response"

--- a/request-manager/src/request_manager/main.py
+++ b/request-manager/src/request_manager/main.py
@@ -49,6 +49,7 @@ from .schemas import (
     SlackRequest,
     ToolRequest,
     WebRequest,
+    ZammadRequest,
 )
 
 # Configure structured logging and auto tracing
@@ -788,7 +789,7 @@ async def _handle_request_created_event_from_data(
         }
 
         # Create request object based on integration type
-        request: Union[SlackRequest, EmailRequest]
+        request: Union[SlackRequest, EmailRequest, ZammadRequest]
         if integration_type == IntegrationType.SLACK:
             slack_user_id = request_data.get("slack_user_id") or user_id
             slack_team_id = request_data.get("slack_team_id", "")
@@ -816,6 +817,43 @@ async def _handle_request_created_event_from_data(
                 email_message_id=request_data.get("email_message_id"),
                 email_in_reply_to=request_data.get("email_in_reply_to"),
                 email_references=request_data.get("email_references"),
+            )
+        elif integration_type == IntegrationType.ZAMMAD:
+            ticket_id = request_data.get("ticket_id")
+            article_id = request_data.get("article_id")
+            group_id = request_data.get("group_id")
+            zammad_delivery_id = request_data.get("zammad_delivery_id")
+            created_by_id = request_data.get("created_by_id")
+            if (
+                ticket_id is None
+                or article_id is None
+                or group_id is None
+                or not zammad_delivery_id
+                or created_by_id is None
+            ):
+                logger.error(
+                    "Missing required Zammad fields in request event data",
+                    ticket_id=ticket_id,
+                    article_id=article_id,
+                    group_id=group_id,
+                    zammad_delivery_id=bool(zammad_delivery_id),
+                    created_by_id=created_by_id,
+                )
+                return await create_cloudevent_response(
+                    status="error",
+                    message="Missing required Zammad fields (ticket_id, article_id, group_id, zammad_delivery_id, created_by_id)",
+                    details={"event_id": event_id},
+                )
+            request = ZammadRequest(
+                **base_fields,
+                request_type=request_data.get("request_type", "zammad_ticket_article"),
+                ticket_id=int(ticket_id),
+                article_id=int(article_id),
+                group_id=int(group_id),
+                group_name=request_data.get("group_name"),
+                owner_id=request_data.get("owner_id"),
+                created_by_id=int(created_by_id),
+                zammad_delivery_id=str(zammad_delivery_id),
             )
         else:
             logger.warning(

--- a/request-manager/src/request_manager/normalizer.py
+++ b/request-manager/src/request_manager/normalizer.py
@@ -14,6 +14,7 @@ from .schemas import (
     SlackRequest,
     ToolRequest,
     WebRequest,
+    ZammadRequest,
 )
 
 
@@ -23,7 +24,13 @@ class RequestNormalizer:
     def normalize_request(
         self,
         request: Union[
-            BaseRequest, SlackRequest, WebRequest, CLIRequest, EmailRequest, ToolRequest
+            BaseRequest,
+            SlackRequest,
+            WebRequest,
+            CLIRequest,
+            EmailRequest,
+            ToolRequest,
+            ZammadRequest,
         ],
         session_id: str,
         current_agent_id: Optional[str] = None,
@@ -61,6 +68,8 @@ class RequestNormalizer:
             return self._normalize_email_request(request, base_data)
         elif isinstance(request, ToolRequest):
             return self._normalize_tool_request(request, base_data)
+        elif isinstance(request, ZammadRequest):
+            return self._normalize_zammad_request(request, base_data)
         else:
             return self._normalize_base_request(request, base_data)
 
@@ -145,6 +154,30 @@ class RequestNormalizer:
             integration_context=integration_context,
             user_context=user_context,
             requires_routing=True,
+        )
+
+    def _normalize_zammad_request(
+        self, request: ZammadRequest, base_data: Dict[str, Any]
+    ) -> NormalizedRequest:
+        """Normalize Zammad ticketing request. Routes directly to ticket-resolution-agent."""
+        integration_context = {
+            "ticket_id": request.ticket_id,
+            "article_id": request.article_id,
+            "group_id": request.group_id,
+            "zammad_delivery_id": request.zammad_delivery_id,
+            "platform": "zammad",
+        }
+
+        # Zammad requests bypass routing; go directly to ticket-resolution-agent
+        base_data["target_agent_id"] = "ticket-resolution-agent"
+        # Session continuity: use ticket_id for session_id
+        base_data["session_id"] = f"zammad-{request.ticket_id}"
+
+        return NormalizedRequest(
+            **base_data,
+            integration_context=integration_context,
+            user_context={"platform_user_id": str(request.created_by_id)},
+            requires_routing=False,
         )
 
     def _normalize_tool_request(

--- a/request-manager/src/request_manager/schemas.py
+++ b/request-manager/src/request_manager/schemas.py
@@ -73,6 +73,19 @@ class ToolRequest(BaseRequest):
     tool_context: Dict[str, Any] = Field(default_factory=dict)
 
 
+class ZammadRequest(BaseRequest):
+    """Zammad ticketing request schema."""
+
+    integration_type: IntegrationType = IntegrationType.ZAMMAD
+    ticket_id: int = Field(..., ge=1)
+    article_id: int = Field(..., ge=1)
+    group_id: int = Field(..., ge=0)
+    group_name: Optional[str] = Field(None, max_length=255)
+    owner_id: Optional[int] = Field(None, ge=0)
+    created_by_id: int = Field(..., ge=0)
+    zammad_delivery_id: str = Field(..., min_length=1, max_length=255)
+
+
 # NormalizedRequest is now imported from shared_models.models
 
 

--- a/request-manager/tests/test_normalizer.py
+++ b/request-manager/tests/test_normalizer.py
@@ -1,7 +1,13 @@
 """Tests for request normalizer."""
 
 from request_manager.normalizer import RequestNormalizer
-from request_manager.schemas import CLIRequest, SlackRequest, ToolRequest, WebRequest
+from request_manager.schemas import (
+    CLIRequest,
+    SlackRequest,
+    ToolRequest,
+    WebRequest,
+    ZammadRequest,
+)
 from shared_models.models import IntegrationType
 
 
@@ -124,6 +130,32 @@ class TestRequestNormalizer:
         assert normalized.integration_context["platform"] == "cli"
         assert normalized.integration_context["cli_session_id"] == "cli-session-456"
         assert normalized.user_context["command_context"]["command"] == "agent"
+
+    def test_normalize_zammad_request(self) -> None:
+        """Test Zammad request normalization."""
+        zammad_request = ZammadRequest(
+            user_id="zammad-8",
+            content="Where is the printer?",
+            ticket_id=81,
+            article_id=104,
+            group_id=3,
+            group_name="Support",
+            owner_id=None,
+            created_by_id=8,
+            zammad_delivery_id="delivery-abc123",
+        )
+
+        normalized = self.normalizer.normalize_request(zammad_request, self.session_id)
+
+        assert normalized.integration_type == IntegrationType.ZAMMAD
+        assert normalized.target_agent_id == "ticket-resolution-agent"
+        assert normalized.requires_routing is False
+        assert normalized.session_id == "zammad-81"
+        assert normalized.integration_context["platform"] == "zammad"
+        assert normalized.integration_context["ticket_id"] == 81
+        assert normalized.integration_context["article_id"] == 104
+        assert normalized.integration_context["group_id"] == 3
+        assert normalized.integration_context["zammad_delivery_id"] == "delivery-abc123"
 
     def test_normalize_tool_request(self) -> None:
         """Test tool request normalization."""

--- a/request-manager/tests/test_session_serialization.py
+++ b/request-manager/tests/test_session_serialization.py
@@ -430,7 +430,7 @@ class TestWaitForTurnAndProcessOne:
         mock_db = AsyncMock()
         mock_lock_db = AsyncMock()
 
-        # Phase 1: check returns None (no existing row), so create_request_log_entry_unified is called
+        # check returns None (no existing row), so create_request_log_entry_unified is called
         check_result = MagicMock()
         check_result.scalar_one_or_none.return_value = None
         mock_lock_db.execute = AsyncMock(return_value=check_result)

--- a/shared-models/alembic/versions/002_add_zammad_integration_type.py
+++ b/shared-models/alembic/versions/002_add_zammad_integration_type.py
@@ -1,0 +1,44 @@
+"""Add ZAMMAD to IntegrationType enum
+
+Revision ID: 002
+Revises: 001
+Create Date: 2025-03-13 12:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "002"
+down_revision: Union[str, None] = "001"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add ZAMMAD value to integrationtype enum."""
+    # PostgreSQL: Add new enum value; safe if already exists (idempotent via DO block)
+    op.execute(
+        """
+        DO $$ BEGIN
+            IF NOT EXISTS (
+                SELECT 1 FROM pg_enum e
+                JOIN pg_type t ON e.enumtypid = t.oid
+                WHERE t.typname = 'integrationtype' AND e.enumlabel = 'ZAMMAD'
+            ) THEN
+                ALTER TYPE integrationtype ADD VALUE 'ZAMMAD';
+            END IF;
+        END $$;
+        """
+    )
+
+
+def downgrade() -> None:
+    """Remove ZAMMAD from integrationtype enum.
+
+    Note: PostgreSQL does not support removing enum values easily when they may be in use.
+    This migration's downgrade is a no-op; a full downgrade would require data migration.
+    """
+    pass

--- a/shared-models/src/shared_models/database.py
+++ b/shared-models/src/shared_models/database.py
@@ -313,7 +313,7 @@ class DatabaseManager:
 
         # Determine expected version from parameter, environment, or default
         if expected_version is None:
-            expected_version = os.getenv("EXPECTED_MIGRATION_VERSION", "001")
+            expected_version = os.getenv("EXPECTED_MIGRATION_VERSION", "002")
 
         start_time = time()
         logger.info(

--- a/shared-models/src/shared_models/models.py
+++ b/shared-models/src/shared_models/models.py
@@ -66,6 +66,7 @@ class IntegrationType(str, Enum):
     TEAMS = "TEAMS"
     DISCORD = "DISCORD"
     TEST = "TEST"
+    ZAMMAD = "ZAMMAD"
 
 
 class SessionStatus(str, Enum):


### PR DESCRIPTION
Adds Helm + Makefile support for the **ticketing channel prerequisite**: Zammad deployment, optional Routes (Zammad UI + embed helper), MCP wiring, and automation (autowizard trigger, in-cluster API token → secret, MCP restart).

**Primary:** one-shot install — `make helm-install-ticketing NAMESPACE=<ns>` (main chart with ticketing values + Zammad + bootstrap).

**Also available:** `make deploy-zammad` / `make undeploy-zammad` for Zammad only; other targets (`zammad-bootstrap-token`, `zammad-set-token`, `zammad-update-embed-url`, etc.) — see `make help`.
