### PR TITLE
feat(helm): Zammad — deploy, ticketing profile, embed & bootstrap

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Makefile for RAG Deployment
 ifeq ($(NAMESPACE),)
-ifneq (,$(filter namespace install uninstall helm-install-test helm-install-prod helm-install-demo helm-export-demo helm-export-validate-demo ansible-apply-demo ansible-teardown-demo helm-uninstall helm-status helm-cleanup-eventing helm-cleanup-jobs deploy-email-server undeploy-email-server print-urls verify-triggers jaeger-deploy jaeger-undeploy test-session-serialization-integration test-session-reclaim-integration test-session-background-reclaim-integration,$(MAKECMDGOALS)))
+ifneq (,$(filter namespace install uninstall helm-install-test helm-install-prod helm-install-demo helm-install-ticketing helm-export-demo helm-export-validate-demo ansible-apply-demo ansible-teardown-demo helm-uninstall helm-status helm-cleanup-eventing helm-cleanup-jobs deploy-email-server undeploy-email-server deploy-zammad undeploy-zammad zammad-set-token zammad-bootstrap-token zammad-trigger-autowizard zammad-update-embed-url print-urls verify-triggers jaeger-deploy jaeger-undeploy test-session-serialization-integration test-session-reclaim-integration test-session-background-reclaim-integration,$(MAKECMDGOALS)))
 $(error NAMESPACE is not set)
 endif
 endif
@@ -239,6 +239,19 @@ helm_demo_email_args = \
 	--set-string security.email.smtpHost=test-email-server-smtp.$(NAMESPACE).svc.cluster.local \
 	--set-string security.email.imapHost=test-email-server-imap.$(NAMESPACE).svc.cluster.local
 
+# Ticketing: Zammad in-cluster URL and MCP secret wiring (exec bootstrap uses railsserver)
+ZAMMAD_CREDENTIALS_SECRET ?= $(MAIN_CHART_NAME)-zammad-credentials
+# Must match admin user in helm/values-zammad-deploy.yaml autoWizard.config (for zammad-bootstrap-token / UI login).
+ZAMMAD_ADMIN_EMAIL ?= admin@zammad.local
+ZAMMAD_ADMIN_PASSWORD ?= ZammadR0cks!
+ZAMMAD_AUTOWIZARD_TOKEN ?= ssa-zammad-autowizard-9f3a2b1c
+helm_ticketing_args = \
+	--set zammad.url=$(ZAMMAD_URL) \
+	--set mcp-servers.mcp-servers.zammad-mcp.envSecrets.ZAMMAD_URL.name=$(ZAMMAD_CREDENTIALS_SECRET) \
+	--set mcp-servers.mcp-servers.zammad-mcp.envSecrets.ZAMMAD_URL.key=zammad-url \
+	--set mcp-servers.mcp-servers.zammad-mcp.envSecrets.ZAMMAD_HTTP_TOKEN.name=$(ZAMMAD_CREDENTIALS_SECRET) \
+	--set mcp-servers.mcp-servers.zammad-mcp.envSecrets.ZAMMAD_HTTP_TOKEN.key=zammad-http-token
+
 # Version target
 .PHONY: version
 version:
@@ -264,6 +277,7 @@ help:
 	@echo "  helm-install-test                   - Install with mock eventing service (testing/development/CI - default)"
 	@echo "  helm-install-prod                   - Install with full Knative eventing (production)"
 	@echo "  helm-install-demo                  - Install demo config (mock eventing, Greenmail, resource constraints)"
+	@echo "  helm-install-ticketing             - Install with ticketing channel (Zammad + MCP; one-shot deploy)"
 	@echo "  helm-export-demo                    - Export demo manifests to ansible/helm-export/ (from NAMESPACE, VERSION, REGISTRY, SERVICENOW_*, etc.)"
 	@echo "  helm-export-validate-demo           - Export then validate with kubeconform (no cluster; CI)"
 	@echo "  ansible-apply-demo                  - Export then apply demo via Ansible (requires ansible-playbook)"
@@ -353,6 +367,12 @@ help:
 	@echo "Test Email Server Commands:"
 	@echo "  deploy-email-server                 - Deploy test email server (Greenmail with custom UI)"
 	@echo "  undeploy-email-server               - Remove test email server from namespace"
+	@echo "  deploy-zammad                       - Deploy Zammad instance (prerequisite for ticketing channel)"
+	@echo "  undeploy-zammad                     - Remove Zammad instance from namespace"
+	@echo "  zammad-set-token                    - Set Zammad API token in secret and restart MCP (ZAMMAD_TOKEN=xxx, NAMESPACE=)"
+	@echo "  zammad-bootstrap-token              - Create API token via Zammad API (autoWizard admin); update secret and restart MCP"
+	@echo "  zammad-trigger-autowizard           - Trigger autoWizard via HTTP (run before bootstrap if 401)"
+	@echo "  zammad-update-embed-url             - Update embed page with Zammad Route URL (fixes YOUR-ZAMMAD-URL placeholder)"
 	@echo ""
 	@echo "Lockfile Management:"
 	@echo "  check-lockfiles                     - Check if all uv.lock files are up-to-date"
@@ -1546,6 +1566,117 @@ helm-install-demo: namespace helm-depend deploy-email-server
 		true)
 	@$(MAKE) print-urls
 
+# Install with ticketing channel (Zammad + MCP).
+# Order: install our chart first (creates Route), deploy Zammad with FQDN from Route, then bootstrap token.
+# Zammad gets correct FQDN at deploy (passed from Route host).
+.PHONY: helm-install-ticketing
+helm-install-ticketing: namespace helm-depend
+	@echo "Step 1/4: Creating placeholder secret and installing our chart (creates Route)..."
+	@ZAMMAD_URL="http://zammad-nginx.$(NAMESPACE).svc.cluster.local:8080"; \
+	kubectl create secret generic $(ZAMMAD_CREDENTIALS_SECRET) \
+		--from-literal=zammad-url="$$ZAMMAD_URL/api/v1" \
+		--from-literal=zammad-http-token="" \
+		-n $(NAMESPACE) --dry-run=client -o yaml | kubectl apply -f -; \
+	$(MAKE) _helm-install-ticketing-single ZAMMAD_URL="$$ZAMMAD_URL"
+	@echo "Step 2/4: Getting Route host and deploying Zammad with FQDN..."
+	@ZAMMAD_ROUTE=$$(oc get route ssa-zammad -n $(NAMESPACE) -o jsonpath='{.spec.host}' 2>/dev/null); \
+	if [ -z "$$ZAMMAD_ROUTE" ]; then ZAMMAD_ROUTE=$$(oc get route -n $(NAMESPACE) -l app.kubernetes.io/component=zammad -o jsonpath='{.items[0].spec.host}' 2>/dev/null); fi; \
+	if [ -z "$$ZAMMAD_ROUTE" ]; then ZAMMAD_ROUTE=$$(oc get route -n $(NAMESPACE) -l app.kubernetes.io/instance=zammad -o jsonpath='{.items[0].spec.host}' 2>/dev/null); fi; \
+		if [ -n "$$ZAMMAD_ROUTE" ]; then \
+		echo "Route host: $$ZAMMAD_ROUTE (passing as ZAMMAD_FQDN)"; \
+		$(MAKE) _zammad-patch-embed-configmap NAMESPACE=$(NAMESPACE) ZAMMAD_ROUTE="$$ZAMMAD_ROUTE"; \
+		$(MAKE) deploy-zammad NAMESPACE=$(NAMESPACE) ZAMMAD_FQDN="$$ZAMMAD_ROUTE"; \
+	else \
+		echo "No Route found; deploying Zammad without FQDN (port-forward will work)"; \
+		$(MAKE) deploy-zammad NAMESPACE=$(NAMESPACE); \
+	fi
+	@echo "Step 3/4: Triggering autoWizard and creating API token..."
+	@$(MAKE) zammad-trigger-autowizard NAMESPACE=$(NAMESPACE) 2>/dev/null || true; \
+	ZAMMAD_URL="http://zammad-nginx.$(NAMESPACE).svc.cluster.local:8080"; \
+	ZAMMAD_TOKEN=$$(kubectl get secret $(ZAMMAD_CREDENTIALS_SECRET) -n $(NAMESPACE) -o jsonpath='{.data.zammad-http-token}' 2>/dev/null | base64 -d 2>/dev/null || true); \
+	if [ -z "$$ZAMMAD_TOKEN" ]; then \
+		echo "Creating Zammad API token via exec..."; \
+		ZAMMAD_TOKEN=$$(kubectl exec deploy/zammad-railsserver -n $(NAMESPACE) -- env ZAMMAD_ADMIN_EMAIL='$(ZAMMAD_ADMIN_EMAIL)' ZAMMAD_ADMIN_PASSWORD='$(ZAMMAD_ADMIN_PASSWORD)' ruby -rnet/http -rjson -e 'uri=URI("http://localhost:3000/api/v1/user_access_token");req=Net::HTTP::Post.new(uri);req.basic_auth(ENV["ZAMMAD_ADMIN_EMAIL"],ENV["ZAMMAD_ADMIN_PASSWORD"]);req["Content-Type"]="application/json";req.body=JSON.generate({"name"=>"mcp-agent","permission"=>["admin","ticket.agent"]});res=Net::HTTP.start(uri.hostname,uri.port){|h|h.request(req)};d=JSON.parse(res.body);t=d["token"];t ? puts(t) : ($$stderr.puts("Zammad API #{res.code}: #{res.body[0,500]}");exit 1)' ) || ZAMMAD_TOKEN=""; \
+	fi; \
+	if [ -n "$$ZAMMAD_TOKEN" ]; then \
+		echo "✅ Token created"; \
+		kubectl create secret generic $(ZAMMAD_CREDENTIALS_SECRET) \
+			--from-literal=zammad-url="$$ZAMMAD_URL/api/v1" \
+			--from-literal=zammad-http-token="$$ZAMMAD_TOKEN" \
+			-n $(NAMESPACE) --dry-run=client -o yaml | kubectl apply -f -; \
+		echo "Restarting Zammad MCP..."; \
+		kubectl rollout restart deployment/mcp-zammad-mcp -n $(NAMESPACE) 2>/dev/null || true; \
+		kubectl rollout status deployment/mcp-zammad-mcp -n $(NAMESPACE) --timeout=2m 2>/dev/null || true; \
+	else \
+		echo "⚠ Token creation failed (run make zammad-bootstrap-token NAMESPACE=$(NAMESPACE) after completing autoWizard)"; \
+	fi
+	@echo "Step 4/4: Printing checklist..."
+	@$(MAKE) _helm-install-ticketing-print-checklist NAMESPACE=$(NAMESPACE)
+
+.PHONY: _helm-install-ticketing-single
+_helm-install-ticketing-single:
+	@$(call helm_install_common,with ticketing config - Zammad MCP,\
+		-f helm/values-test.yaml \
+		-f helm/values-ticketing.yaml \
+		--set zammad.url=$(ZAMMAD_URL) \
+		--set mcp-servers.mcp-servers.zammad-mcp.enabled=true \
+		--set mcp-servers.mcp-servers.zammad-mcp.envSecrets.ZAMMAD_URL.name=$(ZAMMAD_CREDENTIALS_SECRET) \
+		--set mcp-servers.mcp-servers.zammad-mcp.envSecrets.ZAMMAD_URL.key=zammad-url \
+		--set mcp-servers.mcp-servers.zammad-mcp.envSecrets.ZAMMAD_HTTP_TOKEN.name=$(ZAMMAD_CREDENTIALS_SECRET) \
+		--set mcp-servers.mcp-servers.zammad-mcp.envSecrets.ZAMMAD_HTTP_TOKEN.key=zammad-http-token \
+		$(PROMPT_OVERRIDES),\
+		true)
+	@$(MAKE) print-urls
+
+# Patch embed ConfigMap with Zammad URL and restart deployment (no helm upgrade)
+.PHONY: _zammad-patch-embed-configmap
+_zammad-patch-embed-configmap: namespace
+	@ZAMMAD_URL="https://$(ZAMMAD_ROUTE)"; \
+	sed "s|__ZAMMAD_URL__|$$ZAMMAD_URL|g" helm/static/zammad-embed-index.html.template > /tmp/zammad-embed-index.$$$$.html; \
+	kubectl create configmap $(MAIN_CHART_NAME)-zammad-embed \
+		--from-file=index.html=/tmp/zammad-embed-index.$$$$.html \
+		-n $(NAMESPACE) --dry-run=client -o yaml | kubectl apply -f -; \
+	rm -f /tmp/zammad-embed-index.$$$$.html; \
+	kubectl rollout restart deployment/$(MAIN_CHART_NAME)-zammad-embed -n $(NAMESPACE) 2>/dev/null || true; \
+	echo "Embed ConfigMap updated with $$ZAMMAD_URL"
+
+.PHONY: _helm-install-ticketing-print-checklist
+_helm-install-ticketing-print-checklist:
+	@echo ""
+	@echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+	@echo "🎫 Ticketing Channel - Follow-up Steps"
+	@echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+	@echo ""
+	@echo "  1. Get the Zammad URL (Route or port-forward):"
+	@ZAMMAD_ROUTE=$$(oc get route ssa-zammad -n $(NAMESPACE) -o jsonpath='{.spec.host}' 2>/dev/null); \
+	ZAMMAD_EMBED_ROUTE=$$(oc get route ssa-zammad-embed -n $(NAMESPACE) -o jsonpath='{.spec.host}' 2>/dev/null); \
+	if [ -z "$$ZAMMAD_ROUTE" ]; then ZAMMAD_ROUTE=$$(oc get route -n $(NAMESPACE) -l app.kubernetes.io/instance=zammad -o jsonpath='{.items[0].spec.host}' 2>/dev/null); fi; \
+	if [ -n "$$ZAMMAD_ROUTE" ]; then \
+		echo "     Web UI: https://$$ZAMMAD_ROUTE"; \
+		echo "     API:    https://$$ZAMMAD_ROUTE/api/v1"; \
+		if [ -n "$$ZAMMAD_EMBED_ROUTE" ]; then echo "     Embed:  https://$$ZAMMAD_EMBED_ROUTE (Zammad chat widget — embed snippet + live preview)"; fi; \
+	else \
+		echo "     Port-forward: kubectl port-forward -n $(NAMESPACE) svc/zammad-nginx 8080:8080"; \
+		echo "     Web UI: http://localhost:8080"; \
+		echo "     API:    http://localhost:8080/api/v1"; \
+	fi
+	@echo ""
+	@echo "  2. Zammad FQDN: configured at deploy (from Route host) so Route loads correctly"
+	@echo ""
+	@echo "  3. If token was not auto-created:"
+	@echo "     - make zammad-bootstrap-token NAMESPACE=$(NAMESPACE)"
+	@echo "     - Or create token in Zammad UI, then: make zammad-set-token NAMESPACE=$(NAMESPACE) ZAMMAD_TOKEN=<token>"
+	@echo ""
+	@echo "  4. Chat widget: Admin → Channels → Chat (agents must be available)."
+	@echo "     Full chat → agent reply loop needs app integration (webhook/MCP/agent) when enabled."
+	@echo ""
+	@echo "  5. (Optional) Webhook trigger for Zammad → blueprint (when that integration is merged)."
+	@echo "     If embed page shows YOUR-ZAMMAD-URL: make zammad-update-embed-url NAMESPACE=$(NAMESPACE)"
+	@echo ""
+	@echo "  Admin login defaults: ZAMMAD_ADMIN_EMAIL / ZAMMAD_ADMIN_PASSWORD (see Makefile; must match autoWizard in helm/values-zammad-deploy.yaml)."
+	@echo "  More: README.md, docs/HELM_EXPORT_ANSIBLE.md"
+	@echo ""
+
 # Install with full Knative eventing (production mode)
 .PHONY: helm-install-prod
 helm-install-prod: namespace helm-depend
@@ -1736,8 +1867,11 @@ helm-uninstall:
 	@echo "Step 4: Final cleanup of namespace $(NAMESPACE)..."
 	@$(MAKE) helm-cleanup-jobs
 	@$(MAKE) undeploy-email-server
+	@$(MAKE) undeploy-zammad
 	@echo "Removing ServiceNow credentials secret from $(NAMESPACE)"
 	@kubectl delete secret $(MAIN_CHART_NAME)-servicenow-credentials -n $(NAMESPACE) --ignore-not-found || true
+	@echo "Removing Zammad credentials secret from $(NAMESPACE)"
+	@kubectl delete secret $(ZAMMAD_CREDENTIALS_SECRET) -n $(NAMESPACE) --ignore-not-found || true
 	@echo "Removing pgvector, init job, and LangFuse PVCs from $(NAMESPACE)"
 	@kubectl get pvc -n $(NAMESPACE) -o custom-columns=NAME:.metadata.name 2>/dev/null | grep -E '^(pg.*-data|self-service-agent-init-status|data-self-service-agent-(clickhouse|redis|minio)-.*)' | xargs -I {} kubectl delete pvc -n $(NAMESPACE) {} --ignore-not-found ||:
 	@echo "Deleting remaining pods in namespace $(NAMESPACE)"
@@ -1910,6 +2044,167 @@ undeploy-email-server:
 	@echo "Removing test email server from namespace $(NAMESPACE)..."
 	@kubectl delete -f test-email-server/test-email-server-greenmail.yaml -n $(NAMESPACE) --ignore-not-found 2>/dev/null || true
 	@echo "✅ Test email server removed successfully!"
+
+# Zammad deployment (prerequisite for ticketing channel)
+ZAMMAD_HELM_REPO ?= https://zammad.github.io/zammad-helm
+ZAMMAD_CHART_VERSION ?= 16.0.4
+
+# ZAMMAD_FQDN: when set (e.g. from Route host), passed as extraEnv so Zammad accepts Route requests.
+# Used by helm-install-ticketing which installs our chart first (creates Route), then deploys Zammad.
+.PHONY: deploy-zammad
+deploy-zammad: namespace
+	@echo "Deploying Zammad instance to namespace $(NAMESPACE)..."
+	@echo "This may take 10-15 minutes (Zammad brings elasticsearch, postgresql, redis, memcached)..."
+	@helm repo add zammad $(ZAMMAD_HELM_REPO) 2>/dev/null || helm repo add zammad $(ZAMMAD_HELM_REPO) --force-update
+	@helm repo update zammad
+	@ZAMMAD_UID=$$(kubectl get namespace $(NAMESPACE) -o jsonpath='{.metadata.annotations.openshift\.io/sa\.scc\.uid-range}' 2>/dev/null | cut -d'/' -f1); \
+	ZAMMAD_ARGS="-f helm/values-zammad-deploy.yaml"; \
+	if [ -n "$$ZAMMAD_UID" ]; then \
+		ZAMMAD_ARGS="$$ZAMMAD_ARGS --set securityContext.runAsUser=$$ZAMMAD_UID --set securityContext.runAsGroup=$$ZAMMAD_UID --set securityContext.fsGroup=$$ZAMMAD_UID"; \
+		echo "OpenShift: using namespace UID $$ZAMMAD_UID for restricted SCC"; \
+	fi; \
+	if [ -n "$(ZAMMAD_FQDN)" ]; then \
+		echo "Configuring Zammad FQDN for Route: $(ZAMMAD_FQDN)"; \
+		TMPFQDN=$$(mktemp); \
+		echo "extraEnv:" > $$TMPFQDN; \
+		echo "  - name: ZAMMAD_FQDN" >> $$TMPFQDN; \
+		echo "    value: \"$(ZAMMAD_FQDN)\"" >> $$TMPFQDN; \
+		echo "  - name: ZAMMAD_HTTP_TYPE" >> $$TMPFQDN; \
+		echo "    value: \"https\"" >> $$TMPFQDN; \
+		ZAMMAD_ARGS="$$ZAMMAD_ARGS -f $$TMPFQDN"; \
+	fi; \
+	helm upgrade --install zammad zammad/zammad \
+		--version $(ZAMMAD_CHART_VERSION) \
+		-n $(NAMESPACE) \
+		$$ZAMMAD_ARGS \
+		--timeout 20m \
+		--wait; \
+	if [ -n "$(ZAMMAD_FQDN)" ] && [ -n "$$TMPFQDN" ]; then rm -f $$TMPFQDN; fi
+	@echo ""
+	@echo "✅ Zammad instance deployed successfully!"
+	@echo ""
+	@echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+	@echo "🎫 Zammad Ticketing Instance"
+	@echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+	@echo ""
+	@echo "📋 Next steps:"
+	@ZAMMAD_ROUTE=$$(oc get route ssa-zammad -n $(NAMESPACE) -o jsonpath='{.spec.host}' 2>/dev/null); \
+	if [ -z "$$ZAMMAD_ROUTE" ]; then ZAMMAD_ROUTE=$$(oc get route -n $(NAMESPACE) -l app.kubernetes.io/instance=zammad -o jsonpath='{.items[0].spec.host}' 2>/dev/null); fi; \
+	echo "  1. Zammad URLs (Route or port-forward):"; \
+	if [ -n "$$ZAMMAD_ROUTE" ]; then \
+		echo "     Web UI: https://$$ZAMMAD_ROUTE"; \
+		echo "     API:    https://$$ZAMMAD_ROUTE/api/v1"; \
+		AUTO_WIZ_URL="https://$$ZAMMAD_ROUTE/#getting_started/auto_wizard/$(ZAMMAD_AUTOWIZARD_TOKEN)"; \
+	else \
+		echo "     Port-forward: kubectl port-forward -n $(NAMESPACE) svc/zammad-nginx 8080:8080"; \
+		echo "     Web UI / API: http://localhost:8080 (and /api/v1)"; \
+		AUTO_WIZ_URL="http://localhost:8080/#getting_started/auto_wizard/$(ZAMMAD_AUTOWIZARD_TOKEN)"; \
+	fi; \
+	echo ""; \
+	echo "  2. Admin login (autoWizard seed; must match helm/values-zammad-deploy.yaml unless you overrode it):"; \
+	echo "       Email:    $(ZAMMAD_ADMIN_EMAIL)"; \
+	echo "       Password: same as Users[0].password in helm/values-zammad-deploy.yaml (Makefile: ZAMMAD_ADMIN_PASSWORD; not printed—override on make targets if you customized autoWizard)"; \
+	echo ""; \
+	echo "  3. Finish autoWizard if needed (or run make zammad-trigger-autowizard):"; \
+	echo "       $$AUTO_WIZ_URL"; \
+	echo ""; \
+	echo "  4. HTTP API token for MCP: make zammad-bootstrap-token NAMESPACE=$(NAMESPACE)"; \
+	echo "     If you ran this deploy via make helm-install-ticketing, token bootstrap runs next in that recipe—skip 3–4 if you see success below."; \
+	echo ""; \
+	echo "  5. Chat widget: Admin → Channels → Chat (agents must be available for the widget to appear)."; \
+	echo "  6. Main chart: zammad.enabled, zammad.url, credentials Secret (use helm-install-ticketing or manual Secret)."; \
+	echo ""; \
+	echo "  More: README.md, docs/HELM_EXPORT_ANSIBLE.md"
+	@echo ""
+
+.PHONY: undeploy-zammad
+undeploy-zammad:
+	@echo "Removing Zammad instance from namespace $(NAMESPACE)..."
+	@helm uninstall zammad -n $(NAMESPACE) --ignore-not-found 2>/dev/null || true
+	@echo "Waiting for pods to terminate, then removing Zammad PVCs..."
+	@sleep 5
+	@kubectl delete pvc -n $(NAMESPACE) -l app.kubernetes.io/instance=zammad --ignore-not-found 2>/dev/null || true
+	@for pvc in $$(kubectl get pvc -n $(NAMESPACE) -o jsonpath='{.items[*].metadata.name}' 2>/dev/null | tr ' ' '\n' | grep -E '^data-zammad-' || true); do kubectl delete pvc $$pvc -n $(NAMESPACE) --ignore-not-found; done
+	@echo "✅ Zammad instance removed successfully!"
+
+# Trigger autoWizard via HTTP (creates admin user). Run once before zammad-bootstrap-token.
+# Uses GET /api/v1/getting_started/auto_wizard/:token
+.PHONY: zammad-trigger-autowizard
+zammad-trigger-autowizard: namespace
+	@echo "Triggering autoWizard via HTTP..."; \
+	RES=$$(kubectl exec deploy/zammad-railsserver -n $(NAMESPACE) -- ruby -rnet/http -e 'uri=URI("http://zammad-nginx:8080/api/v1/getting_started/auto_wizard/$(ZAMMAD_AUTOWIZARD_TOKEN)");res=Net::HTTP.get_response(uri);puts res.code' 2>/dev/null) || RES=""; \
+	if [ "$$RES" = "200" ] || [ "$$RES" = "204" ]; then \
+		echo "✅ autoWizard triggered (HTTP $$RES). Waiting 5s for setup..."; \
+		sleep 5; \
+	else \
+		echo "⚠ autoWizard request returned HTTP $$RES (may already be done or system not ready)"; \
+	fi
+
+# Create Zammad API token via exec into railsserver (uses admin from autoWizard), update secret, restart MCP.
+# Idempotent: if secret already has a token, skips creation. Use ZAMMAD_FORCE_BOOTSTRAP=1 to recreate.
+.PHONY: zammad-bootstrap-token
+zammad-bootstrap-token: namespace zammad-trigger-autowizard
+	@ZAMMAD_URL="http://zammad-nginx.$(NAMESPACE).svc.cluster.local:8080"; \
+	ZAMMAD_TOKEN=$$(kubectl get secret $(ZAMMAD_CREDENTIALS_SECRET) -n $(NAMESPACE) -o jsonpath='{.data.zammad-http-token}' 2>/dev/null | base64 -d 2>/dev/null || true); \
+	if [ -n "$$ZAMMAD_TOKEN" ] && [ "$(ZAMMAD_FORCE_BOOTSTRAP)" != "1" ]; then \
+		echo "Secret already has token (idempotent). Use ZAMMAD_FORCE_BOOTSTRAP=1 to recreate."; \
+		exit 0; \
+	fi; \
+	echo "Creating Zammad API token via exec..."; \
+	ZAMMAD_TOKEN=$$(kubectl exec deploy/zammad-railsserver -n $(NAMESPACE) -- env ZAMMAD_ADMIN_EMAIL='$(ZAMMAD_ADMIN_EMAIL)' ZAMMAD_ADMIN_PASSWORD='$(ZAMMAD_ADMIN_PASSWORD)' ruby -rnet/http -rjson -e 'uri=URI("http://localhost:3000/api/v1/user_access_token");req=Net::HTTP::Post.new(uri);req.basic_auth(ENV["ZAMMAD_ADMIN_EMAIL"],ENV["ZAMMAD_ADMIN_PASSWORD"]);req["Content-Type"]="application/json";req.body=JSON.generate({"name"=>"mcp-agent","permission"=>["admin","ticket.agent"]});res=Net::HTTP.start(uri.hostname,uri.port){|h|h.request(req)};d=JSON.parse(res.body);t=d["token"];t ? puts(t) : ($$stderr.puts("Zammad API #{res.code}: #{res.body[0,500]}");exit 1)' ) || ZAMMAD_TOKEN=""; \
+	if [ -z "$$ZAMMAD_TOKEN" ]; then \
+		echo "❌ Token creation failed (401 = invalid credentials)."; \
+		echo "   Complete autoWizard first: visit <zammad-url>/#getting_started/auto_wizard/$(ZAMMAD_AUTOWIZARD_TOKEN)"; \
+		echo "   (Port-forward: kubectl port-forward -n $(NAMESPACE) svc/zammad-nginx 8080:8080, then http://localhost:8080/...)"; \
+		exit 1; \
+	fi; \
+	kubectl create secret generic $(ZAMMAD_CREDENTIALS_SECRET) \
+		--from-literal=zammad-url="$$ZAMMAD_URL/api/v1" \
+		--from-literal=zammad-http-token="$$ZAMMAD_TOKEN" \
+		-n $(NAMESPACE) --dry-run=client -o yaml | kubectl apply -f -; \
+	echo "Restarting Zammad MCP..."; \
+	kubectl rollout restart deployment/mcp-zammad-mcp -n $(NAMESPACE); \
+	kubectl rollout status deployment/mcp-zammad-mcp -n $(NAMESPACE) --timeout=2m; \
+	echo "✅ Zammad token created and MCP restarted."
+
+# Update Zammad API token and restart MCP. Run after creating token in Zammad Admin → Token Access.
+# Update embed page with actual Zammad URL (fixes placeholder when embed shows YOUR-ZAMMAD-URL)
+.PHONY: zammad-update-embed-url
+zammad-update-embed-url: namespace
+	@ZAMMAD_ROUTE=$$(oc get route ssa-zammad -n $(NAMESPACE) -o jsonpath='{.spec.host}' 2>/dev/null); \
+	if [ -z "$$ZAMMAD_ROUTE" ]; then \
+		ZAMMAD_ROUTE=$$(oc get route -n $(NAMESPACE) -l app.kubernetes.io/component=zammad -o jsonpath='{.items[0].spec.host}' 2>/dev/null); \
+	fi; \
+	if [ -z "$$ZAMMAD_ROUTE" ]; then \
+		ZAMMAD_ROUTE=$$(oc get route -n $(NAMESPACE) -l app.kubernetes.io/instance=zammad -o jsonpath='{.items[0].spec.host}' 2>/dev/null); \
+	fi; \
+	if [ -z "$$ZAMMAD_ROUTE" ]; then \
+		echo "❌ No Zammad Route found in $(NAMESPACE). Deploy Zammad and ensure ssa-zammad Route exists."; \
+		exit 1; \
+	fi; \
+	$(MAKE) _zammad-patch-embed-configmap NAMESPACE=$(NAMESPACE) ZAMMAD_ROUTE="$$ZAMMAD_ROUTE"; \
+	EMBED_HOST=$$(oc get route ssa-zammad-embed -n $(NAMESPACE) -o jsonpath='{.spec.host}' 2>/dev/null); \
+	if [ -n "$$EMBED_HOST" ]; then echo "✅ Embed page updated. Visit https://$$EMBED_HOST to verify."; \
+	else echo "✅ Embed ConfigMap updated."; fi
+
+.PHONY: zammad-set-token
+zammad-set-token: namespace
+	@if [ -z "$(ZAMMAD_TOKEN)" ]; then \
+		echo "❌ Error: ZAMMAD_TOKEN is required."; \
+		echo "  1. Create token in Zammad: Admin → Token Access → add HTTP Token"; \
+		echo "  2. Run: make zammad-set-token NAMESPACE=$(NAMESPACE) ZAMMAD_TOKEN=<your-token>"; \
+		exit 1; \
+	fi
+	@ZAMMAD_URL="http://zammad-nginx.$(NAMESPACE).svc.cluster.local:8080"; \
+	echo "Updating Zammad credentials secret with token..."; \
+	kubectl create secret generic $(ZAMMAD_CREDENTIALS_SECRET) \
+		--from-literal=zammad-url="$$ZAMMAD_URL/api/v1" \
+		--from-literal=zammad-http-token="$(ZAMMAD_TOKEN)" \
+		-n $(NAMESPACE) --dry-run=client -o yaml | kubectl apply -f -; \
+	echo "Restarting Zammad MCP deployment..."; \
+	kubectl rollout restart deployment/mcp-zammad-mcp -n $(NAMESPACE); \
+	kubectl rollout status deployment/mcp-zammad-mcp -n $(NAMESPACE) --timeout=2m; \
+	echo "✅ Zammad token set and MCP restarted."
 
 # ServiceNow PDI wake-up
 .PHONY: servicenow-wake-install

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Transform IT service delivery using AI to lower support effort, improve complian
   - [Integration with Slack (optional)](#integration-with-slack-optional)
   - [Integration with real ServiceNow (optional)](#integration-with-real-servicenow-optional)
   - [Integration with email (optional)](#integration-with-email-optional)
+  - [Zammad ticketing (optional)](#zammad-ticketing-optional)
   - [Run evaluations](#run-evaluations)
   - [Follow the flow with tracing](#follow-the-flow-with-tracing)
   - [Trying out smaller prompts](#trying-out-smaller-prompts)
@@ -106,6 +107,7 @@ By the end of this quickstart, you will have:
 - (Optional) PromptGuard for prompt injection protection
 - (Optional) Safety shields for content moderation
 - (Optional) Langfuse for session-level observability of multi-turn conversations
+- (Optional) Zammad helpdesk deployment and ticketing Helm profile (`make helm-install-ticketing`) for future ticketing-channel integration
 - Understanding of how to customize for your own use cases
 
 #### Key technologies you'll learn
@@ -962,6 +964,30 @@ on your email client or the test email server UI):
 - ✓ Receive email notifications and responses
 - ✓ Maintain conversation context through email threads
 - ✓ Test email integration end-to-end
+
+---
+
+### Zammad ticketing (optional)
+
+You can deploy **[Zammad](https://zammad.org/)** (helpdesk + chat widget) alongside the quickstart for experiments or future ticketing-channel work. This path is **infrastructure-focused**: Helm values, Makefile targets, and optional OpenShift Routes for the Zammad UI and a small **embed helper page** (chat widget snippet + preview). It does not by itself wire Zammad webhooks into the request-manager or agent—that is separate application work.
+
+**One-shot install (recommended):** installs the main chart with ticketing values, deploys Zammad, triggers autowizard seeding, and attempts in-cluster API token creation for the Zammad MCP server.
+
+```bash
+export NAMESPACE=your-namespace
+make helm-install-ticketing NAMESPACE=$NAMESPACE
+```
+
+**Zammad only** (e.g. bring-your-own main chart later):
+
+```bash
+make deploy-zammad NAMESPACE=$NAMESPACE
+make undeploy-zammad NAMESPACE=$NAMESPACE   # remove Zammad from the namespace
+```
+
+**Details:**
+
+- **Admin credentials** default to the seeded user in `helm/values-zammad-deploy.yaml` (must match `ZAMMAD_ADMIN_EMAIL` / `ZAMMAD_ADMIN_PASSWORD` in the Makefile when running token/bootstrap targets).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ Transform IT service delivery using AI to lower support effort, improve complian
   - [Integration with Slack (optional)](#integration-with-slack-optional)
   - [Integration with real ServiceNow (optional)](#integration-with-real-servicenow-optional)
   - [Integration with email (optional)](#integration-with-email-optional)
-  - [Zammad ticketing (optional)](#zammad-ticketing-optional)
   - [Run evaluations](#run-evaluations)
   - [Follow the flow with tracing](#follow-the-flow-with-tracing)
   - [Trying out smaller prompts](#trying-out-smaller-prompts)
@@ -107,7 +106,6 @@ By the end of this quickstart, you will have:
 - (Optional) PromptGuard for prompt injection protection
 - (Optional) Safety shields for content moderation
 - (Optional) Langfuse for session-level observability of multi-turn conversations
-- (Optional) Zammad helpdesk deployment and ticketing Helm profile (`make helm-install-ticketing`) for future ticketing-channel integration
 - Understanding of how to customize for your own use cases
 
 #### Key technologies you'll learn
@@ -964,30 +962,6 @@ on your email client or the test email server UI):
 - ✓ Receive email notifications and responses
 - ✓ Maintain conversation context through email threads
 - ✓ Test email integration end-to-end
-
----
-
-### Zammad ticketing (optional)
-
-You can deploy **[Zammad](https://zammad.org/)** (helpdesk + chat widget) alongside the quickstart for experiments or future ticketing-channel work. This path is **infrastructure-focused**: Helm values, Makefile targets, and optional OpenShift Routes for the Zammad UI and a small **embed helper page** (chat widget snippet + preview). It does not by itself wire Zammad webhooks into the request-manager or agent—that is separate application work.
-
-**One-shot install (recommended):** installs the main chart with ticketing values, deploys Zammad, triggers autowizard seeding, and attempts in-cluster API token creation for the Zammad MCP server.
-
-```bash
-export NAMESPACE=your-namespace
-make helm-install-ticketing NAMESPACE=$NAMESPACE
-```
-
-**Zammad only** (e.g. bring-your-own main chart later):
-
-```bash
-make deploy-zammad NAMESPACE=$NAMESPACE
-make undeploy-zammad NAMESPACE=$NAMESPACE   # remove Zammad from the namespace
-```
-
-**Details:**
-
-- **Admin credentials** default to the seeded user in `helm/values-zammad-deploy.yaml` (must match `ZAMMAD_ADMIN_EMAIL` / `ZAMMAD_ADMIN_PASSWORD` in the Makefile when running token/bootstrap targets).
 
 ---
 

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -88,6 +88,9 @@ make helm-install-demo NAMESPACE=your-namespace
 # Option B: Helm export + Ansible (ephemeral, conference demos)
 make ansible-apply-demo NAMESPACE=your-namespace
 # See docs/HELM_EXPORT_ANSIBLE.md for env vars and export-then-apply workflow
+
+# Optional: Zammad + ticketing profile (deploy Zammad, MCP wiring; see README)
+# make helm-install-ticketing NAMESPACE=your-namespace
 ```
 
 ## Architecture

--- a/helm/static/zammad-embed-index.html.template
+++ b/helm/static/zammad-embed-index.html.template
@@ -1,0 +1,27 @@
+    <!DOCTYPE html>
+    <html lang="en">
+    <head>
+      <meta charset="UTF-8">
+      <meta name="viewport" content="width=device-width, initial-scale=1.0">
+      <title>Zammad Chat Embed</title>
+      <style>
+        body { font-family: system-ui, sans-serif; max-width: 680px; margin: 2rem auto; padding: 0 1rem; line-height: 1.6; }
+        pre { background: #f5f5f5; padding: 1rem; overflow-x: auto; border-radius: 4px; }
+        code { font-size: 0.9em; }
+        h1 { font-size: 1.25rem; }
+      </style>
+    </head>
+    <body>
+      <h1>Zammad Chat - Embed Code</h1>
+      <p>Insert the widget code into the source code of every page the chat shall be visible on. It should be placed at the end of the page's source code before the <code>&lt;/body&gt;</code> closing tag.</p>
+      <pre><code>&lt;script src="__ZAMMAD_URL__/assets/chat/chat-no-jquery.min.js"&gt;&lt;/script&gt;
+&lt;script&gt;
+(function() { new ZammadChat({ fontSize: '12px', chatId: 1 }); })();
+&lt;/script&gt;</code></pre>
+      <p><strong>Note:</strong> The chat widget only appears when at least one agent is available (Admin → Channels → Chat).</p>
+      <script src="__ZAMMAD_URL__/assets/chat/chat-no-jquery.min.js"></script>
+      <script>
+      (function() { new ZammadChat({ fontSize: '12px', chatId: 1 }); })();
+      </script>
+    </body>
+    </html>

--- a/helm/templates/external-routes.yaml
+++ b/helm/templates/external-routes.yaml
@@ -53,3 +53,52 @@ spec:
     termination: edge
     insecureEdgeTerminationPolicy: Redirect
 {{- end }}
+
+{{- if and .Values.zammad.enabled .Values.zammad.externalRoute.enabled }}
+---
+# OpenShift Route for Zammad Web UI (ticketing channel)
+# Targets zammad-nginx service created by Zammad chart (deploy-zammad)
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: ssa-zammad
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "self-service-agent.labels" . | nindent 4 }}
+    app.kubernetes.io/component: zammad
+  annotations:
+    haproxy.router.openshift.io/timeout: "300s"
+spec:
+  to:
+    kind: Service
+    name: {{ .Values.zammad.externalRoute.serviceName | default "zammad-nginx" }}
+    weight: 100
+  port:
+    targetPort: http
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect
+{{- end }}
+
+{{- if and .Values.zammad.enabled .Values.zammad.embedPage.enabled }}
+---
+# OpenShift Route for Zammad chat widget embed page (snippet + live preview)
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: ssa-zammad-embed
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "self-service-agent.labels" . | nindent 4 }}
+    app.kubernetes.io/component: zammad-embed
+spec:
+  to:
+    kind: Service
+    name: {{ include "self-service-agent.fullname" . }}-zammad-embed
+    weight: 100
+  port:
+    targetPort: http
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect
+{{- end }}

--- a/helm/templates/network-policies.yaml
+++ b/helm/templates/network-policies.yaml
@@ -147,6 +147,35 @@ spec:
 {{- end }}
 {{- end }}
 
+{{- if and .Values.zammad.enabled .Values.zammad.externalRoute.enabled (eq .Values.requestManagement.networkPolicies.platform "openshift") }}
+---
+# Allow ingress from OpenShift router to Zammad nginx (for ssa-zammad Route)
+# Zammad pods use app.kubernetes.io/instance=zammad, not self-service-agent
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "self-service-agent.fullname" . }}-allow-zammad-ingress
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "self-service-agent.labels" . | nindent 4 }}
+    component: network-policy
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: zammad
+      app.kubernetes.io/component: zammad-nginx
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          network.openshift.io/policy-group: ingress
+    ports:
+    - protocol: TCP
+      port: 8080
+{{- end }}
+
 {{- if .Values.requestManagement.networkPolicies.additionalIngressRules }}
 ---
 # Additional custom ingress rules from values

--- a/helm/templates/zammad-embed-configmap.yaml
+++ b/helm/templates/zammad-embed-configmap.yaml
@@ -1,0 +1,37 @@
+{{- if and .Values.zammad.enabled .Values.zammad.embedPage.enabled }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "self-service-agent.fullname" . }}-zammad-embed
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "self-service-agent.labels" . | nindent 4 }}
+    app.kubernetes.io/component: zammad-embed
+data:
+  index.html: |
+    <!DOCTYPE html>
+    <html lang="en">
+    <head>
+      <meta charset="UTF-8">
+      <meta name="viewport" content="width=device-width, initial-scale=1.0">
+      <title>Zammad Chat Embed</title>
+      <style>
+        body { font-family: system-ui, sans-serif; max-width: 680px; margin: 2rem auto; padding: 0 1rem; line-height: 1.6; }
+        pre { background: #f5f5f5; padding: 1rem; overflow-x: auto; border-radius: 4px; }
+        code { font-size: 0.9em; }
+        h1 { font-size: 1.25rem; }
+      </style>
+    </head>
+    <body>
+      <h1>Zammad Chat - Embed Code</h1>
+      <p>Copy the following code into your website before the closing <code>&lt;/body&gt;</code> tag:</p>
+      <pre><code>{{- $zammadUrl := (.Values.zammad.embedPage.publicUrl | default "https://YOUR-ZAMMAD-URL") | trimSuffix "/" -}}
+    &lt;script src="{{ $zammadUrl }}/assets/chat/chat-no-jquery.min.js"&gt;&lt;/script&gt;
+    &lt;script&gt;
+    (function() { new ZammadChat({{ "{" }} fontSize: '12px', chatId: {{ default 1 .Values.zammad.embedPage.chatId }} {{ "}" }}); })();
+    &lt;/script&gt;</code></pre>
+      <p><strong>Note:</strong> The chat widget only appears when at least one agent is available (Admin → Channels → Chat).</p>
+    </body>
+    </html>
+{{- end }}

--- a/helm/templates/zammad-embed-deployment.yaml
+++ b/helm/templates/zammad-embed-deployment.yaml
@@ -1,0 +1,57 @@
+{{- if and .Values.zammad.enabled .Values.zammad.embedPage.enabled }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "self-service-agent.fullname" . }}-zammad-embed
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "self-service-agent.labels" . | nindent 4 }}
+    app.kubernetes.io/component: zammad-embed
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "self-service-agent.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: zammad-embed
+  template:
+    metadata:
+      labels:
+        {{- include "self-service-agent.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: zammad-embed
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+      - name: nginx
+        image: nginxinc/nginx-unprivileged:alpine
+        imagePullPolicy: IfNotPresent
+        ports:
+        - name: http
+          containerPort: 8080
+          protocol: TCP
+        volumeMounts:
+        - name: embed-content
+          mountPath: /usr/share/nginx/html
+          readOnly: true
+        - name: tmp
+          mountPath: /tmp
+        resources:
+          requests:
+            cpu: 10m
+            memory: 16Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+      volumes:
+      - name: embed-content
+        configMap:
+          name: {{ include "self-service-agent.fullname" . }}-zammad-embed
+      - name: tmp
+        emptyDir: {}
+{{- end }}

--- a/helm/templates/zammad-embed-service.yaml
+++ b/helm/templates/zammad-embed-service.yaml
@@ -1,0 +1,21 @@
+{{- if and .Values.zammad.enabled .Values.zammad.embedPage.enabled }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "self-service-agent.fullname" . }}-zammad-embed
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "self-service-agent.labels" . | nindent 4 }}
+    app.kubernetes.io/component: zammad-embed
+spec:
+  type: ClusterIP
+  ports:
+  - name: http
+    port: 80
+    targetPort: http
+    protocol: TCP
+  selector:
+    {{- include "self-service-agent.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: zammad-embed
+{{- end }}

--- a/helm/values-ticketing.yaml
+++ b/helm/values-ticketing.yaml
@@ -1,0 +1,32 @@
+# Ticketing channel (Zammad) - use with helm-install-ticketing
+# Extends values-test. Requires: make deploy-zammad first (or external Zammad).
+# zammad.url is set via --set in Makefile (namespace-dependent: Route or in-cluster).
+#
+# After install: Create API token in Zammad, update the zammad-credentials Secret,
+# then restart the MCP pod. See printed checklist.
+
+# Enable Zammad ticketing channel and MCP
+zammad:
+  enabled: true
+  # url set via --set in Makefile (http://zammad-nginx.NAMESPACE.svc.cluster.local:8080 or Route)
+  url: ""  # Override required
+  webhookSecret: ""
+  allowedGroups: []
+  aiAgentUserId: null
+  mcp:
+    enabled: true
+    uri: "http://mcp-zammad:8000/mcp"
+  # OpenShift Route for Zammad Web UI (enabled for ticketing profile on OpenShift)
+  externalRoute:
+    enabled: true
+  # Embed page: Zammad chat widget snippet + live preview (publicUrl set via Makefile from Route host)
+  embedPage:
+    enabled: true
+    publicUrl: ""  # Set by helm-install-ticketing from ssa-zammad Route host
+    chatId: 1
+
+# Enable zammad-mcp MCP server
+mcp-servers:
+  mcp-servers:
+    zammad-mcp:
+      enabled: true

--- a/helm/values-zammad-deploy.yaml
+++ b/helm/values-zammad-deploy.yaml
@@ -1,0 +1,100 @@
+# Values for make deploy-zammad (Zammad instance for dev/testing)
+# Use with: helm upgrade --install zammad zammad/zammad -n NAMESPACE -f helm/values-zammad-deploy.yaml
+#
+# After deployment (automated path — no UI required for token):
+# - `make helm-install-ticketing`: installs chart + Zammad, triggers autoWizard, creates API token
+#   in-cluster (`kubectl exec` → Zammad API), writes the zammad-credentials Secret (see Makefile), restarts MCP.
+# - If token step fails (Zammad still starting): `make zammad-bootstrap-token NAMESPACE=...` (same automation).
+# - Manual fallback only if needed: Admin → Token Access → `make zammad-set-token ZAMMAD_TOKEN=...`
+# - See root Makefile: `helm-install-ticketing`, `zammad-bootstrap-token`, `deploy-zammad`.
+#
+# Note: Zammad chart brings elasticsearch, postgresql, redis, memcached. First deploy may take 10+ minutes.
+
+# AutoWizard: seeds admin user so zammad-bootstrap-token can create API token via API.
+# First user = Admin+Agent; add Users with "roles": ["Customer"] for end users (view own tickets, open new ones).
+# Override via --set autoWizard.config=... or env ZAMMAD_ADMIN_EMAIL, ZAMMAD_ADMIN_PASSWORD.
+# Token must match ZAMMAD_AUTOWIZARD_TOKEN in Makefile (for zammad-trigger-autowizard).
+autoWizard:
+  enabled: true
+  config: |
+    {
+      "Token": "ssa-zammad-autowizard-9f3a2b1c",
+      "TextModuleLocale": { "Locale": "en-us" },
+      "Users": [
+        {
+          "login": "admin@zammad.local",
+          "firstname": "Admin",
+          "lastname": "User",
+          "email": "admin@zammad.local",
+          "organization": "Default",
+          "password": "ZammadR0cks!"
+        },
+        {
+          "login": "alice@example.com",
+          "firstname": "Alice",
+          "lastname": "Customer",
+          "email": "alice@example.com",
+          "organization": "Default",
+          "password": "Customer123!",
+          "roles": ["Customer"]
+        },
+        {
+          "login": "bob@example.com",
+          "firstname": "Bob",
+          "lastname": "Customer",
+          "email": "bob@example.com",
+          "organization": "Default",
+          "password": "Customer123!",
+          "roles": ["Customer"]
+        }
+      ],
+      "Organizations": [{"name": "Default"}],
+      "Settings": [
+        {"name": "product_name", "value": "Zammad Demo"},
+        {"name": "system_online_service", "value": true}
+      ]
+    }
+
+# Pod Security: disable privileged init containers (volumePermissions, sysctl).
+# Zammad chart defaults (runAsUser/fsGroup: 1000) conflict with OpenShift restricted SCC.
+# Makefile deploy-zammad auto-detects namespace UID range on OpenShift and passes via --set.
+#
+# FQDN: Zammad needs ZAMMAD_FQDN to accept requests via Route. helm-install-ticketing installs
+# our chart first (creates Route), then deploys Zammad with ZAMMAD_FQDN=<route-host> at deploy.
+# Port-forward works without it (Host: localhost).
+#
+# trustedProxies: Required for OpenShift Route. Traffic arrives from the router (cluster internal
+# IPs). Without this, Zammad may not trust X-Forwarded-Proto/Host and redirects/scheme break.
+zammadConfig:
+  initContainers:
+    volumePermissions:
+      enabled: false  # Privileged init container incompatible with restricted SCC
+  nginx:
+    # Trust cluster-internal IPs (OpenShift router forwards from these ranges)
+    trustedProxies:
+      - 10.0.0.0/8
+      - 172.16.0.0/12
+      - 192.168.0.0/16
+  railsserver:
+    # RAILS_TRUSTED_PROXIES: same ranges so Rails trusts X-Forwarded-* from the route
+    trustedProxies: "['127.0.0.1', '::1', '10.0.0.0/8', '172.16.0.0/12', '192.168.0.0/16']"
+  # ingress: set manually for deploy-zammad-only (helm-install-ticketing passes FQDN at deploy)
+  # ingress: { enabled: true, host: zammad.example.com }
+
+postgresql:
+  volumePermissions:
+    enabled: false  # Privileged; incompatible with restricted SCC
+  global:
+    compatibility:
+      openshift:
+        adaptSecurityContext: force  # Use OpenShift-allocated UIDs
+
+elasticsearch:
+  sysctlImage:
+    enabled: false  # Privileged; vm.max_map_count often set at node level on OpenShift
+  volumePermissions:
+    enabled: false
+  global:
+    compatibility:
+      openshift:
+        adaptSecurityContext: force  # Use OpenShift-allocated UIDs

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -268,6 +268,45 @@ mcp-servers:
     oracle-sqlcl:
       enabled: false
 
+    # Zammad MCP server for ticketing integration
+    zammad-mcp:
+      enabled: false
+      replicas: 1
+      deploymentMode: deployment
+      image:
+        repository: ghcr.io/basher83/zammad-mcp
+        tag: "1.1.0"
+      port: 8000
+      targetPort: 8000
+      transport: http
+      imagePullPolicy: IfNotPresent
+      env:
+        MCP_TRANSPORT: "http"
+        MCP_PORT: "8000"
+        # ZAMMAD_URL and ZAMMAD_HTTP_TOKEN from Secret (zammad.url, zammad.mcp.token)
+
+# Zammad ticketing channel (optional)
+zammad:
+  enabled: false
+  url: "https://zammad.example.com"
+  webhookSecret: ""
+  allowedGroups: []
+  aiAgentUserId: null
+  mcp:
+    enabled: false
+    uri: "http://mcp-zammad:8000/mcp"
+  # OpenShift Route for external access to Zammad Web UI (when Zammad is deployed via deploy-zammad)
+  # Requires zammad-nginx service in namespace (created by Zammad chart)
+  externalRoute:
+    enabled: false  # Set to true to create OpenShift Route for Zammad (e.g. when using helm-install-ticketing)
+    serviceName: zammad-nginx  # Override if Zammad chart uses different service name (e.g. zammad-zammad-nginx)
+  # Embed page: nginx serves Zammad chat widget embed snippet + live preview
+  # publicUrl: Zammad base URL for script src (e.g. https://ssa-zammad-<ns>.<cluster>). Set via Makefile when using helm-install-ticketing.
+  embedPage:
+    enabled: false
+    publicUrl: ""  # Required when enabled; e.g. https://ssa-zammad-mynamespace.apps.example.com
+    chatId: 1  # Zammad chat channel ID (Admin → Channels → Chat)
+
 # Enable/disable the llm-service dependency
 llm-service:
   enabled: true


### PR DESCRIPTION
Adds Helm + Makefile support for the **ticketing channel prerequisite**: Zammad deployment, optional Routes (Zammad UI + embed helper), MCP wiring, and automation (autowizard trigger, in-cluster API token → secret, MCP restart).

**Primary:** one-shot install — `make helm-install-ticketing NAMESPACE=<ns>` (main chart with ticketing values + Zammad + bootstrap).

**Also available:** `make deploy-zammad` / `make undeploy-zammad` for Zammad only; other targets (`zammad-bootstrap-token`, `zammad-set-token`, `zammad-update-embed-url`, etc.) — see `make help`.