### PR TITLE
feat: support for multiple flows for evaluations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -371,6 +371,7 @@ help:
 	@echo "  test-mock-employee-data            - Run tests for mock employee data"
 	@echo "  test-mock-servicenow               - Run tests for mock ServiceNow"
 	@echo "  test-short-resp-integration-request-mgr - Run short responses integration tests with Request Manager"
+	@echo "  test-short-ticket-laptop-refresh   - Run short responses integration tests for ticket-laptop-refresh flow"
 	@echo "  test-long-resp-integration-request-mgr - Run long responses integration tests with Request Manager"
 	@echo "  test-long-concurrent-integration-request-mgr - Run long concurrent responses integration tests with Request Manager (concurrency=4)"
 	@echo "  test-session-serialization-integration - Run session serialization integration test (requires cluster, NAMESPACE=test)"
@@ -1315,6 +1316,12 @@ check-known-bad-conversations: sync-evaluations
 	@echo "Running evaluation check on known bad conversations..."
 	uv --directory evaluations run evaluate.py --check
 	@echo "Evaluation check completed successfully!"
+
+.PHONY: test-short-ticket-laptop-refresh
+test-short-ticket-laptop-refresh:
+	@echo "Running short responses integration test for ticket-laptop-refresh flow..."
+	uv --directory evaluations run evaluate.py -n 1 --test-script chat-responses-request-mgr.py --reset-conversation --flow ticket_laptop_refresh $(VALIDATE_LAPTOP_DETAILS_FLAG) $(STRUCTURED_OUTPUT_FLAG)
+	@echo "short responses integration test for ticket-laptop-refresh flow completed successfully!"
 
 .PHONY: test-short-resp-integration-request-mgr
 test-short-resp-integration-request-mgr:

--- a/evaluations/deep_eval.py
+++ b/evaluations/deep_eval.py
@@ -10,8 +10,9 @@ from typing import Any, Dict, List, Optional
 from deepeval.evaluate import DisplayConfig, evaluate
 from deepeval.test_case import ConversationalTestCase, Turn
 from deepeval.test_run import global_test_run_manager
+from flow_registry import get_flow_paths, list_flows, load_flow, load_flow_metrics
 from get_deepeval_metrics import get_metrics
-from helpers.copy_context import copy_context_files
+from helpers.copy_context import copy_context_files, copy_flow_context
 from helpers.custom_llm import CustomLLM, get_api_configuration
 from helpers.deep_eval_summary import print_final_summary
 from helpers.extract_deepeval_metrics import extract_metrics_from_results
@@ -38,6 +39,23 @@ def _no_op_wrap_up_test_run(*args: Any, **kwargs: Any) -> None:
 
 # Override DeepEval's default behavior to prevent online connectivity
 global_test_run_manager.wrap_up_test_run = _no_op_wrap_up_test_run  # type: ignore[method-assign]
+
+_DEFAULT_CHATBOT_ROLE = """You are an IT Support Agent specializing in hardware replacement.
+
+Your responsibilities:
+1. Determine if the authenticated user's laptop is eligible for replacement based on company policy
+2. Clearly communicate the eligibility status and policy reasons to the user
+3. If the user is NOT eligible:
+   - Inform them of their ineligibility with the policy reason (e.g., laptop age)
+   - Provide clear, factual information that proceeding may require additional approvals or be rejected
+   - Allow them to continue with the laptop selection process if they choose to
+4. Guide the user through laptop selection
+5. After the user selects a laptop, ALWAYS ask for explicit confirmation before creating the ServiceNow ticket (e.g., "Would you like to proceed with creating a ServiceNow ticket for this laptop?")
+6. Only create the ServiceNow ticket AFTER the user confirms they want to proceed
+7. After creating the ticket, provide the ticket number and next steps
+8. Maintain a professional, helpful, and informative tone throughout
+
+Note: Providing clear, factual information about potential rejection or additional approvals is sufficient. You do not need to be overly cautionary or repeatedly emphasize warnings. Always confirm with the user before creating tickets."""
 
 
 def _convert_to_turns(conversation_data: List[Dict[str, str]]) -> List[Turn]:
@@ -81,6 +99,9 @@ def _evaluate_conversations(
     context_dir: Optional[str] = None,
     validate_full_laptop_details: bool = True,
     use_structured_output: bool = False,
+    metrics: Optional[List[Any]] = None,
+    chatbot_role: Optional[str] = None,
+    default_context_dir: Optional[str] = None,
 ) -> int:
     """
     Main evaluation function that processes conversation files and generates assessment reports.
@@ -88,7 +109,7 @@ def _evaluate_conversations(
     This function orchestrates the complete evaluation workflow:
     1. Configures the LLM model for evaluation
     2. Loads conversation files from the results directory
-    3. Applies laptop refresh-specific evaluation metrics
+    3. Applies evaluation metrics
     4. Generates individual and combined evaluation reports
     5. Provides detailed pass/fail analysis with scoring
 
@@ -103,28 +124,41 @@ def _evaluate_conversations(
         context_dir: Optional path to directory with context files for conversations
         validate_full_laptop_details: Enable validation of all 15 laptop specification fields
         use_structured_output: Enable structured output with Pydantic schema validation and retries
+        metrics: Pre-loaded metrics list. If None, uses default get_metrics() with a new model.
+        chatbot_role: Override for the chatbot role description. If None, uses the default role.
+        default_context_dir: Override for the default context directory. If None, uses the standard path.
 
     Returns:
         int: Exit code (0 for success, 1 for failure) indicating evaluation outcome
     """
-    api_key_found, current_endpoint, model_name = get_api_configuration(
-        api_endpoint, api_key
-    )
-    if not api_key_found:
-        logger.error("No API key configured. Cannot proceed with evaluation.")
-        return 1
+    if metrics is None:
+        api_key_found, current_endpoint, model_name = get_api_configuration(
+            api_endpoint, api_key
+        )
+        if not api_key_found:
+            logger.error("No API key configured. Cannot proceed with evaluation.")
+            return 1
 
-    # At this point, api_key_found is guaranteed to be non-None
-    assert api_key_found is not None
-    custom_model = CustomLLM(
-        api_key=api_key_found,
-        base_url=current_endpoint or "",
-        model_name=model_name,
-        use_structured_output=use_structured_output,
+        assert api_key_found is not None
+        custom_model = CustomLLM(
+            api_key=api_key_found,
+            base_url=current_endpoint or "",
+            model_name=model_name,
+            use_structured_output=use_structured_output,
+        )
+        if not custom_model:
+            logger.error(
+                "Could not create model object. Cannot proceed with evaluation."
+            )
+            return 1
+
+        metrics = get_metrics(
+            custom_model, validate_full_laptop_details=validate_full_laptop_details
+        )
+
+    effective_chatbot_role = (
+        chatbot_role if chatbot_role is not None else _DEFAULT_CHATBOT_ROLE
     )
-    if not custom_model:
-        logger.error("Could not create model object. Cannot proceed with evaluation.")
-        return 1
 
     if not os.path.exists(results_dir):
         logger.error(f"Results directory {results_dir} does not exist")
@@ -141,10 +175,6 @@ def _evaluate_conversations(
 
     print(f"Found {len(json_files)} conversation files to evaluate")
 
-    metrics = get_metrics(
-        custom_model, validate_full_laptop_details=validate_full_laptop_details
-    )
-
     # Initialize tracking for evaluation results and success metrics
     all_results = []
     failed_evaluations = []
@@ -157,7 +187,9 @@ def _evaluate_conversations(
         try:
             print(f"Processing {filename}")
             # Load relevant context data for this specific conversation
-            context_for_file = load_context_for_file(filename, context_dir)
+            context_for_file = load_context_for_file(
+                filename, context_dir, default_context_dir
+            )
 
             # Load single conversation
             with open(file_path, "r", encoding="utf-8") as f:
@@ -205,30 +237,12 @@ def _evaluate_conversations(
                     f"Using {len(context_for_file)} context item(s) for {filename}"
                 )
 
-            # Set chatbot role
-            chatbot_role = """You are an IT Support Agent specializing in hardware replacement.
-
-Your responsibilities:
-1. Determine if the authenticated user's laptop is eligible for replacement based on company policy
-2. Clearly communicate the eligibility status and policy reasons to the user
-3. If the user is NOT eligible:
-   - Inform them of their ineligibility with the policy reason (e.g., laptop age)
-   - Provide clear, factual information that proceeding may require additional approvals or be rejected
-   - Allow them to continue with the laptop selection process if they choose to
-4. Guide the user through laptop selection
-5. After the user selects a laptop, ALWAYS ask for explicit confirmation before creating the ServiceNow ticket (e.g., "Would you like to proceed with creating a ServiceNow ticket for this laptop?")
-6. Only create the ServiceNow ticket AFTER the user confirms they want to proceed
-7. After creating the ticket, provide the ticket number and next steps
-8. Maintain a professional, helpful, and informative tone throughout
-
-Note: Providing clear, factual information about potential rejection or additional approvals is sufficient. You do not need to be overly cautionary or repeatedly emphasize warnings. Always confirm with the user before creating tickets."""
-
             # Note: DeepEval's type hints incorrectly say context is Optional[str]
             # but the runtime implementation in __post_init__ expects List[str]
             test_case = ConversationalTestCase(
                 turns=turns,
                 context=test_case_context if test_case_context else None,  # type: ignore[arg-type]
-                chatbot_role=chatbot_role,
+                chatbot_role=effective_chatbot_role,
             )
 
             # Execute evaluation with suppressed output for cleaner reporting
@@ -422,17 +436,44 @@ def _parse_arguments() -> argparse.Namespace:
     )
 
     parser.add_argument(
+        "--flow",
+        type=str,
+        default=None,
+        metavar="FLOW_NAME",
+        help="Run evaluation for a specific flow (e.g., ticket_laptop_refresh). "
+        "Uses flow-specific directories, metrics, and chatbot role.",
+    )
+
+    parser.add_argument(
+        "--all-flows",
+        action="store_true",
+        default=False,
+        help="Run evaluation for the default mode AND all registered flows sequentially.",
+    )
+
+    parser.add_argument(
+        "--known-bad",
+        action="store_true",
+        default=False,
+        help="Evaluate known-bad conversations instead of generated conversations. "
+        "For default mode uses results/known_bad_conversation_results/. "
+        "For flows uses flows/{name}/known_bad_conversations/.",
+    )
+
+    parser.add_argument(
         "--results-dir",
         type=str,
-        default="results/conversation_results",
-        help="Directory containing conversation result files (default: results/conversation_results)",
+        default=None,
+        help="Directory containing conversation result files. "
+        "Overrides the default path for the selected mode.",
     )
 
     parser.add_argument(
         "--output-dir",
         type=str,
-        default="results/deep_eval_results",
-        help="Directory to save deepeval results and reports (default: results/deep_eval_results)",
+        default=None,
+        help="Directory to save deepeval results and reports. "
+        "Overrides the default path for the selected mode.",
     )
 
     parser.add_argument(
@@ -473,14 +514,17 @@ def _parse_arguments() -> argparse.Namespace:
 if __name__ == "__main__":
     args = _parse_arguments()
 
-    # Ensure context files are available in the expected location
-    copy_context_files()
+    if args.flow and args.all_flows:
+        print("Error: --flow and --all-flows are mutually exclusive")
+        sys.exit(1)
+
+    final_api_endpoint = args.api_endpoint or os.getenv("LLM_URL")
+    final_api_key = args.api_key or os.getenv("LLM_API_TOKEN")
 
     # Print configuration
     print("=" * 80)
     print("DEEPEVAL CONVERSATION EVALUATION")
     print("=" * 80)
-    print(f"Directory with conversations to analyze: {args.results_dir}")
 
     if args.api_key:
         print("API key: Provided via command line")
@@ -492,7 +536,6 @@ if __name__ == "__main__":
     if os.getenv("LLM_ID"):
         print(f"LLM Model ID: {os.getenv('LLM_ID')}")
 
-    final_api_endpoint = args.api_endpoint or os.getenv("LLM_URL")
     print(f"Custom endpoint: {final_api_endpoint}")
 
     if args.use_structured_output:
@@ -502,22 +545,103 @@ if __name__ == "__main__":
     else:
         print("Structured output: DISABLED (using standard JSON mode)")
 
+    if args.flow:
+        print(f"Mode: single flow '{args.flow}'")
+    elif args.all_flows:
+        print(f"Mode: all flows (default + {list_flows()})")
+    else:
+        print("Mode: default")
+
+    if args.known_bad:
+        print("Evaluating: known-bad conversations")
+
     print("=" * 80)
     print("")
 
-    # Use command line API key or fall back to environment variable
-    final_api_key = args.api_key or os.getenv("LLM_API_TOKEN")
-
-    # Run evaluation with provided arguments and environment fallbacks
-    exit_code = _evaluate_conversations(
-        api_endpoint=final_api_endpoint,
-        api_key=final_api_key,
-        results_dir=args.results_dir,
-        output_dir=args.output_dir,
-        context_dir=args.context_dir,
-        validate_full_laptop_details=args.validate_full_laptop_details,
-        use_structured_output=args.use_structured_output,
+    # Determine which evaluations to run
+    run_default = not args.flow  # default runs unless a specific flow is selected
+    flows_to_run = (
+        [args.flow] if args.flow else (list_flows() if args.all_flows else [])
     )
+
+    overall_exit_code = 0
+
+    # --- Default evaluation ---
+    if run_default:
+        copy_context_files()
+
+        if args.known_bad:
+            results_dir = args.results_dir or "results/known_bad_conversation_results"
+            output_dir = args.output_dir or "results/known_bad_eval_results"
+        else:
+            results_dir = args.results_dir or "results/conversation_results"
+            output_dir = args.output_dir or "results/deep_eval_results"
+
+        print(f"Running default evaluation: {results_dir} -> {output_dir}")
+        exit_code = _evaluate_conversations(
+            api_endpoint=final_api_endpoint,
+            api_key=final_api_key,
+            results_dir=results_dir,
+            output_dir=output_dir,
+            context_dir=args.context_dir,
+            validate_full_laptop_details=args.validate_full_laptop_details,
+            use_structured_output=args.use_structured_output,
+        )
+        overall_exit_code = max(overall_exit_code, exit_code)
+
+    # --- Flow evaluations ---
+    for flow_name in flows_to_run:
+        copy_flow_context(flow_name)
+
+        flow_module = load_flow(flow_name)
+        flow_paths = get_flow_paths(flow_name)
+
+        if args.known_bad:
+            results_dir = args.results_dir or str(flow_paths.known_bad_dir)
+            output_dir = args.output_dir or str(flow_paths.results_known_bad_dir)
+        else:
+            results_dir = args.results_dir or str(flow_paths.results_conv_dir)
+            output_dir = args.output_dir or str(flow_paths.results_eval_dir)
+
+        # Create model and load flow-specific metrics
+        api_key_found, current_endpoint, model_name = get_api_configuration(
+            final_api_endpoint, final_api_key
+        )
+        if not api_key_found:
+            logger.error(f"No API key configured for flow '{flow_name}'. Skipping.")
+            overall_exit_code = max(overall_exit_code, 1)
+            continue
+
+        assert api_key_found is not None
+        custom_model = CustomLLM(
+            api_key=api_key_found,
+            base_url=current_endpoint or "",
+            model_name=model_name,
+            use_structured_output=args.use_structured_output,
+        )
+
+        flow_metrics_module = load_flow_metrics(flow_name)
+        flow_metrics = flow_metrics_module.get_metrics(
+            custom_model,
+            validate_full_laptop_details=args.validate_full_laptop_details,
+        )
+        flow_chatbot_role = getattr(flow_module, "CHATBOT_ROLE", None)
+        flow_context_dir = str(flow_paths.context_dir)
+
+        print(f"Running flow '{flow_name}': {results_dir} -> {output_dir}")
+        exit_code = _evaluate_conversations(
+            api_endpoint=final_api_endpoint,
+            api_key=final_api_key,
+            results_dir=results_dir,
+            output_dir=output_dir,
+            context_dir=args.context_dir,
+            validate_full_laptop_details=args.validate_full_laptop_details,
+            use_structured_output=args.use_structured_output,
+            metrics=flow_metrics,
+            chatbot_role=flow_chatbot_role,
+            default_context_dir=flow_context_dir,
+        )
+        overall_exit_code = max(overall_exit_code, exit_code)
 
     # Print token usage summary using shared function
     print("\n" + "=" * 80)
@@ -531,4 +655,4 @@ if __name__ == "__main__":
     print("=" * 80)
 
     # Exit with appropriate code: 0 for success, 1 for failure
-    sys.exit(exit_code)
+    sys.exit(overall_exit_code)

--- a/evaluations/evaluate.py
+++ b/evaluations/evaluate.py
@@ -111,16 +111,20 @@ def run_script(
         return False
 
 
-def _cleanup_generated_files() -> None:
+def _cleanup_generated_files(flow_name: Optional[str] = None) -> None:
     """
     Remove all files starting with 'generated_flow' and 'from_api_' from
-    results/conversation_results/ and all token usage files from results/token_usage/.
+    results/conversation_results/ (or the flow's results dir) and all token usage files
+    from results/token_usage/.
 
     This ensures a clean slate for each evaluation run by removing files from
     previous executions. Step 2 (generator) and step 3 (export) then write fresh files.
     """
     # Clean up generated and exported conversation files
-    conversation_results_dir = Path("results/conversation_results")
+    if flow_name:
+        conversation_results_dir = Path(f"results/{flow_name}/conversation_results")
+    else:
+        conversation_results_dir = Path("results/conversation_results")
     if conversation_results_dir.exists():
         generated_files = list(conversation_results_dir.glob("generated_flow*"))
         from_api_files = list(conversation_results_dir.glob("from_api_*"))
@@ -585,6 +589,20 @@ def _parse_arguments() -> argparse.Namespace:
         "--end-date",
         help="Filter to date when using --conversation-source export; ISO 8601 format (e.g., 2026-01-31T23:59:59Z)",
     )
+    parser.add_argument(
+        "--flow",
+        type=str,
+        default=None,
+        metavar="FLOW_NAME",
+        help="Run the evaluation pipeline for a specific flow (e.g., ticket_laptop_refresh). "
+        "Uses flow-specific directories, metrics, and chatbot role.",
+    )
+    parser.add_argument(
+        "--all-flows",
+        action="store_true",
+        default=False,
+        help="Run the evaluation pipeline for the default mode AND all registered flows sequentially.",
+    )
     return parser.parse_args()
 
 
@@ -592,6 +610,7 @@ def run_check_known_bad_conversations(
     timeout: int = 600,
     validate_full_laptop_details: bool = True,
     use_structured_output: bool = False,
+    flow: Optional[str] = None,
 ) -> int:
     """
     Check known bad conversations by running deepeval on them.
@@ -613,8 +632,23 @@ def run_check_known_bad_conversations(
 
     check_start_time = time.time()
 
+    # Resolve paths based on flow or default
+    if flow:
+        import sys as _sys
+
+        _eval_dir = str(Path(__file__).parent)
+        if _eval_dir not in _sys.path:
+            _sys.path.insert(0, _eval_dir)
+        from flow_registry import get_flow_paths
+
+        flow_paths = get_flow_paths(flow)
+        known_bad_dir = flow_paths.known_bad_dir
+        deep_eval_results_dir = flow_paths.results_known_bad_dir
+    else:
+        known_bad_dir = Path("results/known_bad_conversation_results")
+        deep_eval_results_dir = Path("results/deep_eval_results")
+
     # Check if the known bad conversations directory exists
-    known_bad_dir = Path("results/known_bad_conversation_results")
     if not known_bad_dir.exists():
         logger.error(f"❌ Directory {known_bad_dir} does not exist")
         return 1
@@ -632,20 +666,24 @@ def run_check_known_bad_conversations(
 
     # Run deepeval on the known bad conversations
     logger.info("📊 Running deepeval on known bad conversations...")
-    deep_eval_args = ["--results-dir", "results/known_bad_conversation_results"]
+    deep_eval_args = [
+        "--results-dir",
+        str(known_bad_dir),
+        "--output-dir",
+        str(deep_eval_results_dir),
+    ]
     if validate_full_laptop_details:
         deep_eval_args.append("--validate-full-laptop-details")
     else:
         deep_eval_args.append("--no-validate-full-laptop-details")
     if use_structured_output:
         deep_eval_args.append("--use-structured-output")
+    if flow:
+        deep_eval_args.extend(["--flow", flow])
     # For the check option, we want to run deep_eval and analyze the results
     # even if it returns a non-zero exit code (which indicates it found issues)
     run_script("deep_eval.py", args=deep_eval_args, timeout=timeout)
     logger.info("📊 DeepEval completed, analyzing results...")
-
-    # Check the results to see if the conversations failed as expected
-    deep_eval_results_dir = Path("results/deep_eval_results")
     if not deep_eval_results_dir.exists():
         logger.error("❌ DeepEval results directory not found")
         return 1
@@ -903,6 +941,7 @@ def run_evaluation_pipeline(
     conversation_source: str = "generate",
     start_date: Optional[str] = None,
     end_date: Optional[str] = None,
+    flow: Optional[str] = None,
 ) -> int:
     """
     Run the complete evaluation pipeline.
@@ -934,7 +973,7 @@ def run_evaluation_pipeline(
     logger.info("=" * 80)
 
     # Clean up generated files from previous runs
-    _cleanup_generated_files()
+    _cleanup_generated_files(flow_name=flow)
     logger.info("-" * 60)
 
     pipeline_start_time = time.time()
@@ -952,6 +991,8 @@ def run_evaluation_pipeline(
         run_conversations_args = ["--test-script", test_script]
         if reset_conversation:
             run_conversations_args.append("--reset-conversation")
+        if flow:
+            run_conversations_args.extend(["--flow", flow])
         if not run_script(
             "run_conversations.py", args=run_conversations_args, timeout=timeout
         ):
@@ -992,6 +1033,8 @@ def run_evaluation_pipeline(
             generator_args.append("--reset-conversation")
         if use_structured_output:
             generator_args.append("--use-structured-output")
+        if flow:
+            generator_args.extend(["--flow", flow])
         if not run_script("generator.py", args=generator_args, timeout=timeout):
             failed_steps.append("generator.py")
             logger.error(
@@ -1031,6 +1074,8 @@ def run_evaluation_pipeline(
         deep_eval_args.append("--no-validate-full-laptop-details")
     if use_structured_output:
         deep_eval_args.append("--use-structured-output")
+    if flow:
+        deep_eval_args.extend(["--flow", flow])
     if not run_script("deep_eval.py", args=deep_eval_args, timeout=timeout):
         failed_steps.append("deep_eval.py")
         logger.error(f"❌ Step {step_label} failed")
@@ -1092,14 +1137,28 @@ def main() -> int:
         if len(sys.argv) > 1 and any(arg in ["-h", "--help"] for arg in sys.argv):
             return 0
 
+        if args.flow and args.all_flows:
+            logger.error("--flow and --all-flows are mutually exclusive")
+            return 1
+
         if args.check:
             return run_check_known_bad_conversations(
                 timeout=args.timeout,
                 validate_full_laptop_details=args.validate_full_laptop_details,
                 use_structured_output=args.use_structured_output,
+                flow=args.flow,
             )
-        else:
-            return run_evaluation_pipeline(
+
+        if args.all_flows:
+            # Run default pipeline then each registered flow sequentially
+            import sys as _sys
+
+            _eval_dir = str(Path(__file__).parent)
+            if _eval_dir not in _sys.path:
+                _sys.path.insert(0, _eval_dir)
+            from flow_registry import list_flows
+
+            pipeline_kwargs = dict(
                 num_conversations=args.num_conversations,
                 timeout=args.timeout,
                 max_turns=args.max_turns,
@@ -1113,6 +1172,37 @@ def main() -> int:
                 start_date=args.start_date,
                 end_date=args.end_date,
             )
+
+            overall = 0
+
+            logger.info("=== Running default pipeline ===")
+            overall = max(
+                overall, run_evaluation_pipeline(**pipeline_kwargs, flow=None)
+            )
+
+            for flow_name in list_flows():
+                logger.info(f"=== Running pipeline for flow '{flow_name}' ===")
+                overall = max(
+                    overall, run_evaluation_pipeline(**pipeline_kwargs, flow=flow_name)
+                )
+
+            return overall
+
+        return run_evaluation_pipeline(
+            num_conversations=args.num_conversations,
+            timeout=args.timeout,
+            max_turns=args.max_turns,
+            test_script=args.test_script,
+            reset_conversation=args.reset_conversation,
+            concurrency=args.concurrency,
+            message_timeout=args.message_timeout,
+            validate_full_laptop_details=args.validate_full_laptop_details,
+            use_structured_output=args.use_structured_output,
+            conversation_source=args.conversation_source,
+            start_date=args.start_date,
+            end_date=args.end_date,
+            flow=args.flow,
+        )
     except KeyboardInterrupt:
         logger.warning("⚠️  Pipeline interrupted by user")
         return 130

--- a/evaluations/flow_registry.py
+++ b/evaluations/flow_registry.py
@@ -1,0 +1,80 @@
+"""Registry for discovering and loading evaluation flows."""
+
+import importlib.util
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from types import ModuleType
+from typing import List
+
+FLOWS_DIR = Path(__file__).parent / "flows"
+RESULTS_DIR = Path(__file__).parent / "results"
+EVALUATIONS_DIR = Path(__file__).parent
+
+
+@dataclass
+class FlowPaths:
+    name: str
+    conversations_dir: Path
+    known_bad_dir: Path
+    context_dir: Path
+    results_conv_dir: Path
+    results_eval_dir: Path
+    results_known_bad_dir: Path
+
+
+def list_flows() -> List[str]:
+    """Return names of all registered flows (subdirs of flows/ containing flow.py)."""
+    if not FLOWS_DIR.exists():
+        return []
+    return sorted(
+        [d.name for d in FLOWS_DIR.iterdir() if d.is_dir() and (d / "flow.py").exists()]
+    )
+
+
+def get_flow_paths(name: str) -> FlowPaths:
+    """Return all relevant directory paths for the named flow."""
+    flow_dir = FLOWS_DIR / name
+    return FlowPaths(
+        name=name,
+        conversations_dir=flow_dir / "conversations",
+        known_bad_dir=flow_dir / "known_bad_conversations",
+        context_dir=flow_dir / "context",
+        results_conv_dir=RESULTS_DIR / name / "conversation_results",
+        results_eval_dir=RESULTS_DIR / name / "deep_eval_results",
+        results_known_bad_dir=RESULTS_DIR / name / "known_bad_results",
+    )
+
+
+def _load_module_from_path(module_name: str, file_path: Path) -> ModuleType:
+    """Load a Python module from a file path, ensuring evaluations/ is on sys.path."""
+    # Ensure the evaluations directory is on sys.path so that loaded modules
+    # can import helpers, get_deepeval_metrics, etc.
+    evaluations_dir = str(EVALUATIONS_DIR)
+    if evaluations_dir not in sys.path:
+        sys.path.insert(0, evaluations_dir)
+
+    spec = importlib.util.spec_from_file_location(module_name, file_path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load module from {file_path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def load_flow(name: str) -> ModuleType:
+    """Import and return the flow.py module for the given flow name."""
+    flow_file = FLOWS_DIR / name / "flow.py"
+    if not flow_file.exists():
+        raise FileNotFoundError(f"No flow.py found for flow '{name}' at {flow_file}")
+    return _load_module_from_path(f"flow_{name.replace('-', '_')}", flow_file)
+
+
+def load_flow_metrics(name: str) -> ModuleType:
+    """Import and return the metrics.py module for the given flow name."""
+    metrics_file = FLOWS_DIR / name / "metrics.py"
+    if not metrics_file.exists():
+        raise FileNotFoundError(
+            f"No metrics.py found for flow '{name}' at {metrics_file}"
+        )
+    return _load_module_from_path(f"metrics_{name.replace('-', '_')}", metrics_file)

--- a/evaluations/flows/ticket_laptop_refresh/conversations/success-flow-1.json
+++ b/evaluations/flows/ticket_laptop_refresh/conversations/success-flow-1.json
@@ -1,0 +1,24 @@
+{
+    "metadata": {
+        "authoritative_user_id": "alice.johnson@company.com",
+        "description": "Successful laptop refresh flow"
+    },
+    "conversation": [
+        {
+            "role": "user",
+            "content": "refresh"
+        },
+        {
+            "role": "user",
+            "content": "I would like to see the options"
+        },
+        {
+            "role": "user",
+            "content": "3"
+        },
+        {
+            "role": "user",
+            "content": "proceed"
+        }
+    ]
+}

--- a/evaluations/flows/ticket_laptop_refresh/flow.py
+++ b/evaluations/flows/ticket_laptop_refresh/flow.py
@@ -1,0 +1,38 @@
+"""Flow configuration for ticket_laptop_refresh evaluation."""
+
+from typing import List
+
+FLOW_NAME: str = "ticket_laptop_refresh"
+DEFAULT_TEST_SCRIPT: str = "chat-responses-request-mgr.py"
+KNOWLEDGE_BASE_DIRS: List[str] = ["laptop-refresh"]
+INCLUDE_SNOW_DATA: bool = True
+
+CHATBOT_ROLE: str = """You are an IT Support Agent specializing in hardware replacement.
+
+Your responsibilities:
+1. Determine if the authenticated user's laptop is eligible for replacement based on company policy
+2. Clearly communicate the eligibility status and policy reasons to the user
+3. If the user is NOT eligible:
+   - Inform them of their ineligibility with the policy reason (e.g., laptop age)
+   - Provide clear, factual information that proceeding may require additional approvals or be rejected
+   - Allow them to continue with the laptop selection process if they choose to
+4. Guide the user through laptop selection
+5. After the user selects a laptop, ALWAYS ask for explicit confirmation before sending the ticket to their manager)
+6. Only forward the ticket to the users manager AFTER the user confirms they want to proceed
+8. Maintain a professional, helpful, and informative tone throughout
+
+Note: Providing clear, factual information about potential rejection or additional approvals is sufficient. You do not need to be overly cautionary or repeatedly emphasize warnings. Always confirm with the user before creating tickets."""
+
+
+def get_scenario(use_structured_output: bool) -> tuple[tuple[str, str, str], str, str]:
+    """Return (scenario, expected_outcome, user_description) for conversation generation."""
+    expected_outcome = "They get a Service now ticket number for their refresh request"
+
+    scenario = (
+        "A ticket is created by the user asking to refresh their laptop. An agents responsds on the ticket with their current laptop information and their elligibiblity for a fresh based on the company policy",
+        "If the user is elligible the agent will provide a list of options, the user selects one and the agent will ask if they would like the ticket to be sent to their manager for approval.",
+        "If the user is not elligible the agent will ask if the user would like to close or escalate the ticket.",
+    )
+    user_description = "An employee interacting with an IT self-service agent through a ticket in a ticketing system."
+
+    return scenario, expected_outcome, user_description

--- a/evaluations/flows/ticket_laptop_refresh/known_bad_conversations/allowed_invalid_user-laptop-selection.json
+++ b/evaluations/flows/ticket_laptop_refresh/known_bad_conversations/allowed_invalid_user-laptop-selection.json
@@ -1,0 +1,40 @@
+{
+  "metadata": {
+    "authoritative_user_id": "david.chen@company.com",
+    "description": "Generated conversation from deepeval simulation"
+  },
+  "conversation": [
+    {
+      "role": "user",
+      "content": "A new ticket was created by a user with the following content\nI would like to refresh my laptop"
+    },
+    {
+      "role": "assistant",
+      "content": "Your laptop, a ZenBook Pro 15, was purchased on 2020-07-22 and is currently 5 years and 2 months old. The company's laptop refresh policy states that standard laptops will be refreshed every 3 years from the date of issuance. Since your laptop is older than 3 years, you are eligible for a laptop refresh. Would you like to proceed with reviewing the available laptop options for your location?"
+    },
+    {
+      "role": "user",
+      "content": "Yes, I'd like to proceed with reviewing the available laptop options for my location."
+    },
+    {
+      "role": "assistant",
+      "content": "Here is your laptop information:\nEmployee Name: David Chen\nEmployee Location: APAC\nLaptop Model: ZenBook Pro 15\nLaptop Serial Number: AS15008\nLaptop Purchase Date: 2020-07-22\nLaptop Age: 5 years and 2 months\nLaptop Warranty Expiry Date: 2023-07-22\nLaptop Warranty: Expired\nYour laptop, a ZenBook Pro 15, was purchased on 2020-07-22 and is currently 5 years and 2 months old. The company's laptop refresh policy states that standard laptops will be refreshed every 3 years from the date of issuance. Since your laptop is older than 3 years, you are eligible for a laptop refresh.\nHere are the available laptop options for your location (APAC):\n1. Apple MacBook Air M2 - ServiceNow Code: apple_mac_book_air_m_2\n- Target User: General Office\n- Cost: ¥11,000 CNY\n- Operating System: macOS\n- Display Size: 13.6 inches\n- Display Resolution: 2560 x 1664\n- Graphics Card: Apple M2 GPU\n- Minimum Storage: 256 GB SSD\n- Weight: 2.7 lbs\n- Ports: 2 x Thunderbolt/USB 4, MagSafe\n- Minimum Processor: Apple M2\n- Minimum Memory: 8 GB\n- Dimensions: 11.97 x 8.46 x 0.44 inches\n2. Apple MacBook Pro 14 M3 - ServiceNow Code: apple_mac_book_pro_14_m_3\n- Target User: Developers\n- Cost: ¥15,000 CNY\n- Operating System: macOS\n- Display Size: 14.2 inches\n- Display Resolution: 3024 x 1964\n- Graphics Card: Apple M3 GPU\n- Minimum Storage: 512 GB SSD\n- Weight: 3.5 lbs\n- Ports: 3 x Thunderbolt 4, HDMI, SDXC, MagSafe\n- Minimum Processor: Apple M3\n- Minimum Memory: 18 GB\n- Dimensions: 12.31 x 8.71 x 0.61 inches\n3. Lenovo ThinkPad T14 Gen 5 AMD - ServiceNow Code: lenovo_think_pad_t_14_gen_5_amd\n- Target User: General Office\n- Cost: ¥10,000 CNY\n- Operating System: Windows 11 Pro\n- Display Size: 14 inches\n- Display Resolution: 1920 x 1200\n- Graphics Card: Integrated AMD Radeon\n- Minimum Storage: 512 GB SSD\n- Weight: 3.1 lbs\n- Ports: 2 x USB-C, 2 x USB-A, HDMI, Ethernet, Audio Jack\n- Minimum Processor: AMD Ryzen 7 PRO 7840U\n- Minimum Memory: 16 GB\n- Dimensions: 12.5 x 8.8 x 0.7 inches\n4. Lenovo ThinkPad P1 Gen 6 - ServiceNow Code: lenovo_think_pad_p_1_gen_6\n- Target User: Engineers\n- Cost: ¥18,000 CNY\n- Operating System: Red Hat Linux\n- Display Size: 16 inches\n- Display Resolution: 3840 x 2400\n- Graphics Card: NVIDIA RTX A2000\n- Minimum Storage: 1 TB SSD\n- Weight: 4.1 lbs\n- Ports: 2 x USB-C, 2 x USB-A, HDMI, SD Card, Audio Jack\n- Minimum Processor: Intel Core i9-13900H\n- Minimum Memory: 32 GB\n- Dimensions: 14.1 x 9.9 x 0.7 inches\nPlease select one of the above options. Remember to consider your job role and requirements when making your selection."
+    },
+    {
+      "role": "user",
+      "content": "I'd like to select option 5, the commodore 64, as it seems suitable for my role as a general office user."
+    },
+    {
+      "role": "assistant",
+      "content": "You have selected the commodore 64. Would you like me to assign it to your manager for approval?"
+    },
+    {
+      "role": "user",
+      "content": "Yes please"
+    },
+    {
+      "role": "assistant",
+      "content": "The ticket has been sent to your manager for approval."
+    }
+  ]
+}

--- a/evaluations/flows/ticket_laptop_refresh/known_bad_conversations/bad_laptop_options.json
+++ b/evaluations/flows/ticket_laptop_refresh/known_bad_conversations/bad_laptop_options.json
@@ -1,0 +1,41 @@
+{
+  "metadata": {
+    "authoritative_user_id": "alice.johnson@company.com",
+    "description": "Known bad conversation - Agent provides incorrect laptop options (Commodore 64 instead of proper EMEA options)"
+  },
+  "conversation": [
+    {
+      "role": "user",
+      "content": "A new ticket was created by a user with the following content\nI would like to refresh my laptop"
+    },
+    {
+      "role": "assistant",
+      "content": "Based on the laptop refresh policy, your laptop is over 3 years old and eligible for a replacement.\nHere is a summary of your laptop details:\n- Name: Alice Johnson\n- Employee ID: 1001\n- Location: EMEA\n- Laptop Model: Latitude 7420\n- Laptop Serial Number: DL7420001\n- Laptop Purchase Date: 2020-01-15\nYou are eligible to request a new laptop. Would you like to proceed to the next step, which is reviewing the available laptop options?"
+    },
+    {
+      "role": "user",
+      "content": "yes"
+    },
+    {
+      "role": "assistant",
+      "content": "Based on your location (EMEA), here are the available laptop options for you to choose from:\n1. **Commodore 64**\n- Manufacturer: Commodor\n- Model: Commodor 1\n- Target User: General Office\n- Cost: €1,299\n- Operating System: CommodoreOS\n2. **ThinkPad T14s Gen 5 AMD**\n- Manufacturer: Lenovo\n- Model: ThinkPad T14s Gen 5 AMD\n- Target User: General Office\n- Cost: €1,380\n- Operating System: Windows 11 Pro\nPlease select one of the available laptop options by providing the model name."
+
+    },
+    {
+      "role": "user",
+      "content": "2"
+    },
+    {
+      "role": "assistant",
+      "content": "You have selected the ThinkPad T14s Gen 5 AMD. Would you like the ticket to be sent for approval by your manager?"
+    },
+    {
+      "role": "user",
+      "content": "please assign"
+    },
+    {
+      "role": "assistant",
+      "content": "I have assigned the ticket to your manager for approval, you can watch the ticket for future updates as it progresses through the approval process"
+    }
+  ]
+}

--- a/evaluations/flows/ticket_laptop_refresh/known_bad_conversations/incomplete.json
+++ b/evaluations/flows/ticket_laptop_refresh/known_bad_conversations/incomplete.json
@@ -1,0 +1,40 @@
+{
+  "metadata": {
+    "authoritative_user_id": "alice.johnson@company.com",
+    "description": "Generated conversation from deepeval simulation"
+  },
+  "conversation": [
+    {
+      "role": "user",
+      "content": "A new ticket was created by a user with the following content\nI would like to refresh my laptop"
+    },
+    {
+      "role": "assistant",
+      "content": "Your laptop, a Latitude 7420, was purchased on 2020-01-15 and is currently 5 years and 8 months old. The company's laptop refresh policy states that standard laptops will be refreshed every 3 years from the date of issuance. Since your laptop is older than 3 years, you are eligible for a laptop refresh. Would you like to proceed with reviewing the available laptop options for your location?"
+    },
+    {
+      "role": "user",
+      "content": "Yes, I'd like to proceed with reviewing the available laptop options for my location."
+    },
+    {
+      "role": "assistant",
+      "content": "Here is your laptop information:\nEmployee Name: Alice Johnson\nEmployee Location: EMEA\nLaptop Model: Latitude 7420\nLaptop Serial Number: DL7420001\nLaptop Purchase Date: 2020-01-15\nLaptop Age: 5 years and 8 months\nLaptop Warranty Expiry Date: 2023-01-15\nLaptop Warranty: Expired\nYour laptop, a Latitude 7420, was purchased on 2020-01-15 and is currently 5 years and 8 months old. The company's laptop refresh policy states that standard laptops will be refreshed every 3 years from the date of issuance. Since your laptop is older than 3 years, you are eligible for a laptop refresh.\nHere are the available laptop options for your location (EMEA):\n1. Apple MacBook Air M2 - €1,299 - macOS - 13.6 inches - 2560 x 1664 - Apple M2 GPU - 256 GB SSD - 2.7 lbs - 2 x Thunderbolt/USB 4, MagSafe - Apple M2 - 8 GB - 11.97 x 8.46 x 0.44 inches\n2. Apple MacBook Pro 16 M3 Max - €3,299 - macOS - 16.2 inches - 3456 x 2234 - Apple M3 Max GPU - 1 TB SSD - 4.8 lbs - 3 x Thunderbolt 4, HDMI, SDXC, MagSafe - Apple M3 Max - 36 GB - 14.01 x 9.77 x 0.66 inches\n3. Lenovo ThinkPad T14s Gen 5 AMD - €1,380 - Windows 11 Pro - 14 inches - 1920 x 1200 - Integrated AMD Radeon - 512 GB SSD - 2.8 lbs - 2 x USB-C, 2 x USB-A, HDMI, Audio Jack - AMD Ryzen 7 PRO 7840U - 16 GB - 12.4 x 8.7 x 0.6 inches\n4. Lenovo ThinkPad P16 Gen 2 - €2,650 - Red Hat Linux - 16 inches - 2560 x 1600 - NVIDIA RTX A2000 - 1 TB SSD - 6.5 lbs - 2 x USB-C, 2 x USB-A, HDMI, Ethernet, Audio Jack - Intel Core i7-13700HX - 32 GB - 14.3 x 10.5 x 1.2 inches\nPlease select one of the above options. Remember to consider your job role and requirements when making your selection."
+    },
+    {
+      "role": "user",
+      "content": "I'd like to select option 3, the Lenovo ThinkPad T14s Gen 5 AMD, as it seems to meet my job requirements and is a cost-effective option."
+    },
+    {
+      "role": "assistant",
+      "content": "You've selected the Lenovo ThinkPad T14s Gen 5 AMD. Would you like me to assign to you manager for approval?"
+    },
+    {
+      "role": "user",
+      "content": "Yes, please assign to my manager."
+    },
+    {
+      "role": "assistant",
+      "content": "Ok we are done now."
+    }
+  ]
+}

--- a/evaluations/flows/ticket_laptop_refresh/known_bad_conversations/missing_confirmation_before_sent_to_manager.json
+++ b/evaluations/flows/ticket_laptop_refresh/known_bad_conversations/missing_confirmation_before_sent_to_manager.json
@@ -1,0 +1,32 @@
+{
+  "metadata": {
+    "authoritative_user_id": "alice.johnson@company.com-1312321",
+    "description": "Known good ticket  laptop refresh flow test case"
+  },
+  "conversation": [
+    {
+      "role": "user",
+      "content": "A new ticket was created by a user with the following content\nI would like to refresh my laptop"
+    },
+    {
+      "role": "assistant",
+      "content": "Based on the laptop refresh policy, your laptop is over 3 years old and eligible for a replacement.\nHere is a summary of your laptop details:\n- Name: Alice Johnson\n- Employee ID: 1001\n- Location: EMEA\n- Laptop Model: Latitude 7420\n- Laptop Serial Number: DL7420001\n- Laptop Purchase Date: 2020-01-15\nYou are eligible to request a new laptop. Would you like to proceed to the next step, which is reviewing the available laptop options?"
+    },
+    {
+      "role": "user",
+      "content": "yes"
+    },
+    {
+      "role": "assistant",
+      "content": "Here are the available laptop options for your location (EMEA):\n1. Model: MacBook Air M2 - ServiceNow Code: apple_mac_book_air_m_2\n- Manufacturer: Apple\n- Target User: General Office\n- Cost: €1,299\n- Operating System: macOS\n- Display Size: 13.6 inches\n- Display Resolution: 2560 x 1664\n- Graphics Card: Apple M2 GPU\n- Minimum Storage: 256 GB SSD\n- Weight: 2.7 lbs\n- Ports: 2 x Thunderbolt/USB 4, MagSafe\n- Minimum Processor: Apple M2\n- Minimum Memory: 8 GB\n- Dimensions: 11.97 x 8.46 x 0.44 inches\n2. Model: MacBook Pro 16 M3 Max - ServiceNow Code: apple_mac_book_pro_16_m_3_max\n- Manufacturer: Apple\n- Target User: Developers\n- Cost: €3,299\n- Operating System: macOS\n- Display Size: 16.2 inches\n- Display Resolution: 3456 x 2234\n- Graphics Card: Apple M3 Max GPU\n- Minimum Storage: 1 TB SSD\n- Weight: 4.8 lbs\n- Ports: 3 x Thunderbolt 4, HDMI, SDXC, MagSafe\n- Minimum Processor: Apple M3 Max\n- Minimum Memory: 36 GB\n- Dimensions: 14.01 x 9.77 x 0.66 inches\n3. Model: ThinkPad T14s Gen 5 AMD - ServiceNow Code: lenovo_think_pad_t_14_s_gen_5_amd\n- Manufacturer: Lenovo\n- Target User: General Office\n- Cost: €1,380\n- Operating System: Windows 11 Pro\n- Display Size: 14 inches\n- Display Resolution: 1920 x 1200\n- Graphics Card: Integrated AMD Radeon\n- Minimum Storage: 512 GB SSD\n- Weight: 2.8 lbs\n- Ports: 2 x USB-C, 2 x USB-A, HDMI, Audio Jack\n- Minimum Processor: AMD Ryzen 7 PRO 7840U\n- Minimum Memory: 16 GB\n- Dimensions: 12.4 x 8.7 x 0.6 inches\n4. Model: ThinkPad P16 Gen 2 - ServiceNow Code: lenovo_think_pad_p_16_gen_2\n- Manufacturer: Lenovo\n- Target User: Engineers\n- Cost: €2,650\n- Operating System: Red Hat Linux\n- Display Size: 16 inches\n- Display Resolution: 2560 x 1600\n- Graphics Card: NVIDIA RTX A2000\n- Minimum Storage: 1 TB SSD\n- Weight: 6.5 lbs\n- Ports: 2 x USB-C, 2 x USB-A, HDMI, Ethernet, Audio Jack\n- Minimum Processor: Intel Core i7-13700HX\n- Minimum Memory: 32 GB\n- Dimensions: 14.3 x 10.5 x 1.2 inches\nPlease select one of the above options. Remember to consider your job role and requirements when making your selection."
+    },
+    {
+      "role": "user",
+      "content": "I would like option 3"
+    },
+    {
+      "role": "assistant",
+      "content": "You have selected the ThinkPad T14s Gen 5 AMD. I have assigned the ticket to your manager for approval, you can watch the ticket for future updates as it progresses through the approval process"
+    }
+  ]
+}

--- a/evaluations/flows/ticket_laptop_refresh/known_bad_conversations/missing_laptop_options2.json
+++ b/evaluations/flows/ticket_laptop_refresh/known_bad_conversations/missing_laptop_options2.json
@@ -1,0 +1,40 @@
+{
+  "metadata": {
+    "authoritative_user_id": "alice.johnson@company.com",
+    "description": "Known bad conversation - Agent only shows 2 of 4 available EMEA laptop options"
+  },
+  "conversation": [
+    {
+      "role": "user",
+      "content": "A new ticket was created by a user with the following content\nI would like to refresh my laptop"
+    },
+    {
+      "role": "assistant",
+      "content": "Based on the laptop refresh policy, your laptop is over 3 years old and eligible for a replacement.\nHere is a summary of your laptop details:\n- Name: Alice Johnson\n- Employee ID: 1001\n- Location: EMEA\n- Laptop Model: Latitude 7420\n- Laptop Serial Number: DL7420001\n- Laptop Purchase Date: 2020-01-15\nYou are eligible to request a new laptop. Would you like to proceed to the next step, which is reviewing the available laptop options?"
+    },
+    {
+      "role": "user",
+      "content": "yes"
+    },
+    {
+      "role": "assistant",
+      "content": "Based on your location (EMEA), here are the available laptop options for you to choose from:\n1. **MacBook Air M2**\n- Manufacturer: Apple\n- Model: MacBook Air M2\n- Target User: General Office\n- Cost: €1,299\n- Operating System: macOS\n2. **ThinkPad T14s Gen 5 AMD**\n- Manufacturer: Lenovo\n- Model: ThinkPad T14s Gen 5 AMD\n- Target User: General Office\n- Cost: €1,380\n- Operating System: Windows 11 Pro\nPlease select one of the available laptop options by providing the model name."
+    },
+    {
+      "role": "user",
+      "content": "2"
+    },
+    {
+      "role": "assistant",
+      "content": "You have selected the ThinkPad T14s Gen 5 AMD. Would you like me to assign it to your manager for approval?"
+    },
+    {
+      "role": "user",
+      "content": "Yes please"
+    },
+    {
+      "role": "assistant",
+      "content": "I have assigned the ticket to your manager for approval, you can watch the ticket for future updates as it progresses through the approval process"
+    }
+  ]
+}

--- a/evaluations/flows/ticket_laptop_refresh/known_bad_conversations/not-all-laptop-options.json
+++ b/evaluations/flows/ticket_laptop_refresh/known_bad_conversations/not-all-laptop-options.json
@@ -1,0 +1,40 @@
+{
+  "metadata": {
+    "authoritative_user_id": "alice.johnson@company.com",
+    "description": "Known bad conversation - Agent shows options 2, 3, 4 but is missing option 1 (MacBook Air M2)"
+  },
+  "conversation": [
+    {
+      "role": "user",
+      "content": "A new ticket was created by a user with the following content\nI would like to refresh my laptop"
+    },
+    {
+      "role": "assistant",
+      "content": "Here is your laptop information:\nEmployee Name: Alice Johnson\nEmployee ID: 1001\nEmployee Location: EMEA\nLaptop Model: Latitude 7420\nLaptop Serial Number: DL7420001\nLaptop Purchase Date: 2020-01-15\nLaptop Age: 5 years and 7 months\nLaptop Warranty Expiry Date: 2023-01-15\nLaptop Warranty: Expired\nThe company's laptop refresh policy states that standard laptops will be refreshed every 3 years from the date of issuance. Since your laptop is older than 3 years, you are eligible for a laptop refresh.\nWould you like to proceed with reviewing the available laptop options for your location?"
+    },
+    {
+      "role": "user",
+      "content": "I would like to see the options"
+    },
+    {
+      "role": "assistant",
+      "content": "Here are the available laptop options for your location (EMEA):\n2. Apple MacBook Pro 16 M3 Max:\n* Target User: Developers\n* Cost: €3,299\n* Operating System: macOS\n* Display Size: 16.2 inches\n* Display Resolution: 3456 x 2234\n* Graphics Card: Apple M3 Max GPU\n* Minimum Storage: 1 TB SSD\n* Weight: 4.8 lbs\n* Ports: 3 x Thunderbolt 4, HDMI, SDXC, MagSafe\n* Minimum Processor: Apple M3 Max\n* Minimum Memory: 36 GB\n* Dimensions: 14.01 x 9.77 x 0.66 inches\n3. Lenovo ThinkPad T14s Gen 5 AMD:\n* Target User: General Office\n* Cost: €1,380\n* Operating System: Windows 11 Pro\n* Display Size: 14 inches\n* Display Resolution: 1920 x 1200\n* Graphics Card: Integrated AMD Radeon\n* Minimum Storage: 512 GB SSD\n* Weight: 2.8 lbs\n* Ports: 2 x USB-C, 2 x USB-A, HDMI, Audio Jack\n* Minimum Processor: AMD Ryzen 7 PRO 7840U\n* Minimum Memory: 16 GB\n* Dimensions: 12.4 x 8.7 x 0.6 inches\n4. Lenovo ThinkPad P16 Gen 2:\n* Target User: Engineers\n* Cost: €2,650\n* Operating System: Red Hat Linux\n* Display Size: 16 inches\n* Display Resolution: 2560 x 1600\n* Graphics Card: NVIDIA RTX A2000\n* Minimum Storage: 1 TB SSD\n* Weight: 6.5 lbs\n* Ports: 2 x USB-C, 2 x USB-A, HDMI, Ethernet, Audio Jack\n* Minimum Processor: Intel Core i7-13700HX\n* Minimum Memory: 32 GB\n* Dimensions: 14.3 x 10.5 x 1.2 inches\nPlease select one of the above options. Remember to consider your job role and requirements when making your selection."
+    },
+    {
+      "role": "user",
+      "content": "3"
+    },
+    {
+      "role": "assistant",
+      "content": "You have selected the Lenovo ThinkPad T14s Gen 5 AMD.\nWould you like me to send the ticket to your manager for approval?"
+    },
+    {
+      "role": "user",
+      "content": "proceed"
+    },
+    {
+      "role": "assistant",
+      "content": "I have assigned the ticket to your manager for approval, you can watch the ticket for future updates as it progresses through the approval process"
+    }
+  ]
+}

--- a/evaluations/flows/ticket_laptop_refresh/known_bad_conversations/wrong-selection.json
+++ b/evaluations/flows/ticket_laptop_refresh/known_bad_conversations/wrong-selection.json
@@ -1,0 +1,40 @@
+{
+  "metadata": {
+    "authoritative_user_id": "maria.garcia@company.com",
+    "description": "Generated conversation from deepeval simulation"
+  },
+  "conversation": [
+    {
+      "role": "user",
+      "content": "A new ticket was created by a user with the following content\nI would like to refresh my laptop"
+    },
+    {
+      "role": "assistant",
+      "content": "Your laptop, a ThinkPad X1 Carbon, was purchased on 2022-11-10 and is currently 2 years and 11 months old. The company's laptop refresh policy states that standard laptops will be refreshed every 3 years from the date of issuance. Since your laptop is less than 3 years old, you are not eligible for a laptop refresh. You may proceed anyway but the request for refresh may require additional approvals or be rejected. Would you like to proceed with reviewing the available laptop options for your location?"
+    },
+    {
+      "role": "user",
+      "content": "Yes, I'd like to proceed with reviewing the available laptop options for my location."
+    },
+    {
+      "role": "assistant",
+      "content": "Here are the available laptop options for your location (LATAM):\n1. Apple MacBook Air M2 - ServiceNow Code: apple_mac_book_air_m_2\n- Target User: General Office\n- Cost: $1,250 USD\n- Operating System: macOS\n- Display Size: 13.6 inches\n- Display Resolution: 2560 x 1664\n- Graphics Card: Apple M2 GPU\n- Minimum Storage: 256 GB SSD\n- Weight: 2.7 lbs\n- Ports: 2 x Thunderbolt/USB 4, MagSafe\n- Minimum Processor: Apple M2\n- Minimum Memory: 8 GB\n- Dimensions: 11.97 x 8.46 x 0.44 inches\n2. Apple MacBook Pro 14 M3 - ServiceNow Code: apple_mac_book_pro_14_m_3\n- Target User: Developers\n- Cost: $1,999 USD\n- Operating System: macOS\n- Display Size: 14.2 inches\n- Display Resolution: 3024 x 1964\n- Graphics Card: Apple M3 GPU\n- Minimum Storage: 512 GB SSD\n- Weight: 3.5 lbs\n- Ports: 3 x Thunderbolt 4, HDMI, SDXC, MagSafe\n- Minimum Processor: Apple M3\n- Minimum Memory: 18 GB\n- Dimensions: 12.31 x 8.71 x 0.61 inches\n3. Lenovo ThinkPad T14 Gen 4 Intel - ServiceNow Code: lenovo_think_pad_t_14_gen_4_intel\n- Target User: General Office\n- Cost: $1,399 USD\n- Operating System: Windows 11 Pro\n- Display Size: 14 inches\n- Display Resolution: 1920 x 1200\n- Graphics Card: Integrated Intel Iris Xe\n- Minimum Storage: 512 GB SSD\n- Weight: 3.2 lbs\n- Ports: 2 x USB-C, 2 x USB-A, HDMI, Audio Jack\n- Minimum Processor: Intel Core i7-1365U\n- Minimum Memory: 16 GB\n- Dimensions: 12.5 x 8.8 x 0.7 inches\n4. Lenovo ThinkPad P16s Gen 2 - ServiceNow Code: lenovo_think_pad_p_16_s_gen_2\n- Target User: Engineers\n- Cost: $2,100 USD\n- Operating System: Red Hat Linux\n- Display Size: 16 inches\n- Display Resolution: 1920 x 1200\n- Graphics Card: NVIDIA T500\n- Minimum Storage: 1 TB SSD\n- Weight: 4.4 lbs\n- Ports: 2 x USB-C, 2 x USB-A, HDMI, Ethernet, Audio Jack\n- Minimum Processor: Intel Core i7-1360P\n- Minimum Memory: 32 GB\n- Dimensions: 14.3 x 10.5 x 0.8 inches\nPlease select one of the above options. Remember to consider your job role and requirements when making your selection. As a reminder, since you are not yet eligible for a laptop refresh, additional approvals may be required or the request may be rejected."
+    },
+    {
+      "role": "user",
+      "content": "I'd like to select option 3, the Lenovo ThinkPad T14 Gen 4 Intel, as it seems suitable for my general office needs."
+    },
+    {
+      "role": "assistant",
+      "content": "You've selected the Apple MacBook Air M2. Would you like the ticket to be sent for approval by your manager."
+    },
+    {
+      "role": "user",
+      "content": "Yes let me know if you need any additional information?"
+    },
+    {
+      "role": "assistant",
+      "content": "I have assigned the ticket to your manager for approval, you can watch the ticket for future updates as it progresses through the approval process"
+    }
+  ]
+}

--- a/evaluations/flows/ticket_laptop_refresh/known_bad_conversations/wrong_eligibility.json
+++ b/evaluations/flows/ticket_laptop_refresh/known_bad_conversations/wrong_eligibility.json
@@ -1,0 +1,40 @@
+{
+  "metadata": {
+    "authoritative_user_id": "isabella.mueller@company.com",
+    "description": "Generated conversation from deepeval simulation"
+  },
+  "conversation": [
+    {
+      "role": "user",
+      "content": "A new ticket was created by a user with the following content\nI would like to refresh my laptop"
+    },
+    {
+      "role": "assistant",
+      "content": "Your laptop, a ThinkPad T14, was purchased on 2019-11-18 and is currently 2 years and 11 months old. The company's laptop refresh policy states that standard laptops will be refreshed every 3 years from the date of issuance. Since your laptop is older than 3 years, you are eligible for a laptop refresh. Would you like to proceed with reviewing the available laptop options for your location?"
+    },
+    {
+      "role": "user",
+      "content": "Yes, I'd like to proceed with reviewing the available laptop options for my location."
+    },
+    {
+      "role": "assistant",
+      "content": "Here is your laptop information:\nEmployee Name: Isabella Mueller\nEmployee Location: EMEA\nLaptop Model: ThinkPad T14\nLaptop Serial Number: TP14006\nLaptop Purchase Date: 2019-11-18\nLaptop Age: 2 years and 11 months\nLaptop Warranty Expiry Date: 2022-11-18\nLaptop Warranty: Expired\nYour laptop, a ThinkPad T14, was purchased on 2019-11-18 and is currently 2 years and 11 months old. The company's laptop refresh policy states that standard laptops will be refreshed every 3 years from the date of issuance. Since your laptop is older than 3 years, you are eligible for a laptop refresh. Would you like to proceed with reviewing the available laptop options for your location?\nHere are the available laptop options for your location (EMEA):\n1. Apple MacBook Air M2 - €1,299\n- Operating System: macOS\n- Display Size: 13.6 inches\n- Display Resolution: 2560 x 1664\n- Graphics Card: Apple M2 GPU\n- Minimum Storage: 256 GB SSD\n- Weight: 2.7 lbs\n- Ports: 2 x Thunderbolt/USB 4, MagSafe\n- Minimum Processor: Apple M2\n- Minimum Memory: 8 GB\n- Dimensions: 11.97 x 8.46 x 0.44 inches\n2. Apple MacBook Pro 16 M3 Max - €3,299\n- Operating System: macOS\n- Display Size: 16.2 inches\n- Display Resolution: 3456 x 2234\n- Graphics Card: Apple M3 Max GPU\n- Minimum Storage: 1 TB SSD\n- Weight: 4.8 lbs\n- Ports: 3 x Thunderbolt 4, HDMI, SDXC, MagSafe\n- Minimum Processor: Apple M3 Max\n- Minimum Memory: 36 GB\n- Dimensions: 14.01 x 9.77 x 0.66 inches\n3. Lenovo ThinkPad T14s Gen 5 AMD - €1,380\n- Operating System: Windows 11 Pro\n- Display Size: 14 inches\n- Display Resolution: 1920 x 1200\n- Graphics Card: Integrated AMD Radeon\n- Minimum Storage: 512 GB SSD\n- Weight: 2.8 lbs\n- Ports: 2 x USB-C, 2 x USB-A, HDMI, Audio Jack\n- Minimum Processor: AMD Ryzen 7 PRO 7840U\n- Minimum Memory: 16 GB\n- Dimensions: 12.4 x 8.7 x 0.6 inches\n4. Lenovo ThinkPad P16 Gen 2 - €2,650\n- Operating System: Red Hat Linux\n- Display Size: 16 inches\n- Display Resolution: 2560 x 1600\n- Graphics Card: NVIDIA RTX A2000\n- Minimum Storage: 1 TB SSD\n- Weight: 6.5 lbs\n- Ports: 2 x USB-C, 2 x USB-A, HDMI, Ethernet, Audio Jack\n- Minimum Processor: Intel Core i7-13700HX\n- Minimum Memory: 32 GB\n- Dimensions: 14.3 x 10.5 x 1.2 inches\nPlease select one of the above options. Remember to consider your job role and requirements when making your selection."
+    },
+    {
+      "role": "user",
+      "content": "I'd like to select option 3, the Lenovo ThinkPad T14s Gen 5 AMD, as it seems to meet my job requirements and is a cost-effective option."
+    },
+    {
+      "role": "assistant",
+      "content": "You've selected the Lenovo ThinkPad T14s Gen 5 AMD. Would you like me to assign it to your manager for approval?."
+    },
+    {
+      "role": "user",
+      "content": "Yes, please assign to my manager for approval"
+    },
+    {
+      "role": "assistant",
+      "content": "I have assigned the ticket to your manager for approval, you can watch the ticket for future updates as it progresses through the approval process"
+    }
+  ]
+}

--- a/evaluations/flows/ticket_laptop_refresh/metrics.py
+++ b/evaluations/flows/ticket_laptop_refresh/metrics.py
@@ -1,0 +1,338 @@
+#!/usr/bin/env python3
+"""
+DeepEval metrics for ticket_laptop_refresh flow.
+
+Initially identical to the default chat-laptop-refresh metrics.
+Modify this file independently to tailor evaluations for this flow.
+"""
+
+from typing import Any, List, Optional
+
+from deepeval.metrics import ConversationalGEval
+from deepeval.models import DeepEvalBaseLLM
+from deepeval.test_case import ConversationalTestCase, TurnParams
+from helpers.load_conversation_context import load_default_context
+
+# Context directory for this flow (populated at eval time by copy_flow_context).
+# Path is relative to the evaluations/ working directory.
+_FLOW_CONTEXT_DIR = "flows/ticket_laptop_refresh/context"
+
+
+class RetryableConversationalGEval(ConversationalGEval):
+    """
+    A wrapper around ConversationalGEval that retries evaluation on failure.
+
+    If the metric fails (score < threshold), it runs the evaluation a second time
+    and uses the result from the second run.
+    """
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self.retry_performed = False
+
+    async def a_measure(
+        self, test_case: ConversationalTestCase, *args: Any, **kwargs: Any
+    ) -> float:
+        """Async measure with retry logic."""
+        self.retry_performed = False
+
+        await super().a_measure(test_case, *args, **kwargs)
+
+        if (
+            self.score is not None
+            and self.threshold is not None
+            and self.score < self.threshold
+        ):
+            first_score = self.score
+            first_reason = self.reason
+
+            self.score = None
+            self.reason = None
+            self.success = None
+
+            await super().a_measure(test_case, *args, **kwargs)
+
+            self.retry_performed = True
+
+            if self.reason:
+                self.reason = f"[RETRY: 1st={first_score:.2f}] {self.reason}"
+
+        return self.score if self.score is not None else 0.0
+
+
+def get_metrics(
+    custom_model: Optional[DeepEvalBaseLLM] = None,
+    validate_full_laptop_details: bool = True,
+) -> List[Any]:
+    """
+    Create evaluation metrics for the ticket_laptop_refresh flow.
+
+    Initially identical to the default chat-laptop-refresh metrics.
+    """
+    default_context = load_default_context(context_dir=_FLOW_CONTEXT_DIR)
+
+    metrics = [
+        ConversationalGEval(
+            name="Turn Relevancy",
+            threshold=0.8,
+            model=custom_model,
+            evaluation_params=[TurnParams.CONTENT, TurnParams.ROLE],
+            evaluation_steps=[
+                "Evaluate if each assistant response is relevant to the user's message and conversation context.",
+                "Only mark messages as irrelevant if they:",
+                "  - Completely ignore the user's question or request",
+                "  - Provide unrelated information",
+                "  - Fail to address the user's actual need",
+                "Do NOT mark as irrelevant:",
+                "  - Specialist agent responses that stay within their scope",
+                "  - Asking if the user would like to escalate for out-of-scope questions",
+            ],
+        ),
+        ConversationalGEval(
+            name="Role Adherence",
+            threshold=0.5,
+            model=custom_model,
+            evaluation_params=[TurnParams.CONTENT, TurnParams.ROLE],
+            evaluation_steps=[
+                "Evaluate if agents adhere to their assigned roles throughout the conversation.",
+                "",
+                "Agent role expectations:",
+                "  - Laptop Refresh Specialist: Checks eligibility, presents options, escalates closes or assigns tickets to users manager",
+                "",
+                "Role adherence is CORRECT when:",
+                "  - Specialist handles laptop tasks appropriately",
+                "",
+                "Role adherence FAILS only when:",
+                "  - A specialist tries to handle requests outside their scope",
+                "  - An agent provides responses completely inconsistent with any valid role",
+                "  - CRITICAL FAILURE: The Laptop Refresh Specialist offers to CREATE a ticket (e.g., 'Would you like to proceed with the creation of a ServiceNow ticket?'). In this flow the ticket already exists — offering to create one is a fundamental role violation that MUST result in a score of 0.0 regardless of how well the rest of the conversation went.",
+            ],
+        ),
+        ConversationalGEval(
+            name="Conversation Completeness",
+            threshold=0.8,
+            model=custom_model,
+            evaluation_params=[TurnParams.CONTENT, TurnParams.ROLE],
+            evaluation_steps=[
+                "IMPORTANT: Ignore any agent responses that come after a user message containing 'DONEDONEDONE'. This is a test marker, not real user input, and any agent responses to it should not be evaluated.",
+                "Evaluate if the conversation addresses all of the user's intentions and requests.",
+                "CRITICAL: When evaluating out-of-scope questions:",
+                "  - If user asks an out-of-scope question (e.g., 'what is the fastest bird'), the agent has TWO acceptable responses:",
+                "    1. Offer to escalate the ticket for reivew - this is CORRECT behavior",
+                "    2. Politely redirect user back to the original topic/question - this is ALSO CORRECT behavior",
+                "  - Either response is acceptable and should be considered successful handling of out-of-scope content",
+                "Assess if all relevant user requests were addressed:",
+                "  - Laptop refresh requests should result in eligibility check, options, selection, and ticket being sent to manager",
+                "  - Out-of-scope questions should result in EITHER offering to escalate OR redirecting to the original topic",
+                "  - Explicit escalation requests should result in the ticket being escalated",
+                "  - Explicit close requests should result in the ticket being closed",
+                "The conversation is complete if all user intentions were properly handled, including requests to escalate or close the ticket.",
+            ],
+        ),
+        ConversationalGEval(
+            name="Information Gathering",
+            threshold=0.8,
+            model=custom_model,
+            evaluation_params=[TurnParams.CONTENT, TurnParams.ROLE],
+            evaluation_steps=[
+                "Evaluate if the assistant obtains necessary information about the user's current laptop.",
+                "CRITICAL: 'Gathering information' includes AUTOMATIC RETRIEVAL via tools. The agent is NOT required to ask the user questions if it can fetch the data automatically.",
+                "If the agent displays laptop details (Model, Serial, Age, etc.) retrieved from the system, this counts as SUCCESSFUL information gathering.",
+                "Do NOT penalize the agent for not asking questions if it successfully retrieved the correct data automatically.",
+                "Only fail this metric if the agent proceeds without knowing the laptop details.",
+            ],
+        ),
+        ConversationalGEval(
+            name="Policy Compliance",
+            threshold=0.8,
+            model=custom_model,
+            evaluation_params=[TurnParams.CONTENT, TurnParams.ROLE],
+            evaluation_steps=[
+                "First, review the laptop refresh policy in the additional context below to understand the eligibility criteria. The policy specifies how many years a laptop must be in use before it is eligible for refresh.",
+                "Verify the assistant correctly applies the laptop refresh policy when determining eligibility.",
+                "CRITICAL: Do NOT validate the conversation date against the policy's effective date.",
+                "The policy's effective date field should be IGNORED for evaluation purposes.",
+                "You MUST accept the agent's calculation of the laptop's age as the Ground Truth.",
+                "If the agent states the laptop age (e.g., '2 years and 11 months old', '5 years old', '3.5 years old'), verify the eligibility determination is logically accurate based on the policy in the additional context:",
+                "  - Compare the stated laptop age against the refresh cycle specified in the policy",
+                "  - Laptops younger than the refresh cycle should be marked as NOT eligible or not yet eligible",
+                "  - Laptops that meet or exceed the refresh cycle age should be marked as eligible",
+                "Check for logical contradictions: If the agent states a laptop age and eligibility status that contradict each other based on the policy (e.g., says '2 years 11 months old' but states 'eligible' when the policy requires 3 years), this is a FAILURE.",
+                "Verify the assistant provides clear policy explanations when discussing eligibility.",
+                f"\n\nadditional-context-start\n{default_context}\nadditional-context-end",
+            ],
+        ),
+        ConversationalGEval(
+            name="Option Presentation",
+            threshold=0.8,
+            model=custom_model,
+            evaluation_params=[TurnParams.CONTENT, TurnParams.ROLE],
+            evaluation_steps=[
+                "Assess if the assistant presents appropriate laptop options based on user location when the user is engaged in the laptop refresh process.",
+                "Evaluate if laptop specifications are clearly and completely presented.",
+                "Check if the assistant guides the user through selection process effectively.",
+                "IGNORE any portions of the conversation involving:",
+                "  - Out-of-scope questions (e.g., fastest bird) - agent may redirect to topic OR offer escalation",
+                "The metric should focus on: Were laptop options presented correctly when the user was actively engaged in the laptop refresh flow?",
+            ],
+        ),
+        ConversationalGEval(
+            name="Process Completion",
+            threshold=0.8,
+            model=custom_model,
+            evaluation_params=[TurnParams.CONTENT, TurnParams.ROLE],
+            evaluation_steps=[
+                "This metric ONLY checks whether the conversation ends with one of exactly three valid completion actions. It does NOT evaluate whether the agent followed business rules correctly — those are covered by other metrics.",
+                "There are EXACTLY THREE valid completion actions. The agent must explicitly confirm that one of these occurred:",
+                "  1. Ticket assigned to manager — the agent states the ticket was sent/assigned to the user's manager for approval",
+                "  2. Ticket escalated — the agent states the ticket was escalated",
+                "  3. Ticket closed — the agent states the ticket was closed",
+                "PASS this metric if and ONLY if the agent explicitly confirms one of these three actions.",
+                "FAIL this metric if the conversation ends with anything other than one of these three actions — including but not limited to: creating a ticket, asking a question, giving a vague statement, or simply stopping.",
+                "CRITICAL: The confirmation must be a statement that the action was performed, not a question asking whether to perform it.",
+            ],
+        ),
+        ConversationalGEval(
+            name="User Experience",
+            threshold=0.8,
+            model=custom_model,
+            evaluation_params=[TurnParams.CONTENT, TurnParams.ROLE],
+            evaluation_steps=[
+                "IMPORTANT: This is a multi-agent system where users can be routed between agents.",
+                "Assess if the assistant is helpful and professional throughout the conversation.",
+                "Evaluate if responses are clear and easy to understand.",
+                "Check if the assistant addresses user needs effectively.",
+                "CRITICAL: Handling of out-of-scope questions - BOTH approaches are acceptable:",
+                "  - Offering to escalate is PROFESSIONAL and HELPFUL",
+                "  - Politely redirecting user back to the original topic is ALSO PROFESSIONAL and HELPFUL",
+                "  - Either approach demonstrates good user experience",
+                "CRITICAL: Explicit requests:",
+                "  - When user explicitly requests escalating ticket, doing so is CORRECT",
+                "  - When user explicitly requests closing ticket, doing so is CORRECT",
+                "Do NOT penalize the conversation for offering to escalate or polite topic redirection.",
+            ],
+        ),
+        ConversationalGEval(
+            name="Correct eligibility validation",
+            threshold=1.0,
+            model=custom_model,
+            evaluation_params=[TurnParams.CONTENT, TurnParams.ROLE],
+            evaluation_steps=[
+                "IMPORTANT: This metric ONLY evaluates whether the laptop refresh policy timeframe was stated correctly. Do NOT consider the laptop selection, ticket creation, or any other part of the conversation when scoring this metric.",
+                "Look for any reference to the laptop refresh policy timeframe in the conversation. The agent may state this in multiple ways:",
+                "  - Direct statement: 'laptops will be refreshed every 3 years' or 'standard laptops are refreshed every 3 years'",
+                "  - Indirect via eligibility: 'your laptop is over 3 years old and eligible' (implies 3-year policy)",
+                "  - Indirect via ineligibility: 'your laptop is 2 years old and not yet eligible' (implies 3-year policy)",
+                "  - Reference to age threshold: 'laptops older than 3 years' or 'laptops less than 3 years old'",
+                "If the agent mentions ANY timeframe (whether directly or indirectly through eligibility statements), verify it is consistent with the policy in the additional context below, which states that standard laptops are refreshed every 3 years.",
+                "If the agent does NOT mention any timeframe or eligibility age at all, this evaluation PASSES (the metric only validates correctness when stated, not whether it's stated).",
+                "The user's eligibility status (eligible or not eligible) is irrelevant - only the accuracy of the stated or implied timeframe matters.",
+                "IGNORE everything that happens after the eligibility determination — laptop selection, ticket creation, or any errors later in the conversation have no bearing on this metric.",
+                f"\n\nadditional-context-start\n{default_context}\nadditional-context-end",
+            ],
+        ),
+        ConversationalGEval(
+            name="No errors reported by agent",
+            threshold=1.0,
+            model=custom_model,
+            evaluation_params=[TurnParams.CONTENT, TurnParams.ROLE],
+            evaluation_steps=[
+                "IMPORTANT: Ignore any agent responses that come after a user message containing 'DONEDONEDONE'. This is a test marker, not real user input, and any agent responses to it should not be evaluated.",
+                "This metric ONLY checks for explicit technical/system errors reported by the agent itself. It does NOT evaluate whether the agent followed business rules, selected the correct laptop, or behaved correctly — those are covered by other metrics.",
+                "FAIL this metric ONLY if the agent explicitly reports a technical or system error, such as:",
+                "  - 'Error 500' or any HTTP error code",
+                "  - 'I could not complete this request due to an error'",
+                "  - 'An error occurred while processing your request'",
+                "  - 'I was unable to retrieve the information'",
+                "  - 'Something went wrong' or 'I encountered an error'",
+                "  - Tool call failures or stack traces visible in the response",
+                "PASS this metric if the agent responds normally, even if:",
+                "  - The agent accepts an invalid or non-existent laptop selection",
+                "  - The agent does not follow the expected business flow",
+                "  - The agent makes a wrong decision or skips a step",
+                "  These behavioral failures are evaluated by other metrics, not this one.",
+                "NOTE: The following patterns are EXPECTED BEHAVIOR and should NOT be considered errors:",
+                "  - When a user asks an out-of-scope question (e.g., general knowledge), the specialist agent correctly identifies its limitation and offers to escalate",
+                "  - When the user confirms they want to escalate, the ticket is escalated",
+            ],
+        ),
+        RetryableConversationalGEval(
+            name="Correct laptop options for user location",
+            threshold=1.0,
+            model=custom_model,
+            evaluation_params=[TurnParams.CONTENT, TurnParams.ROLE],
+            evaluation_steps=(
+                [
+                    "First, identify the user's location from the conversation (NA, EMEA, APAC, or LATAM).",
+                    "Then, look for where the agent presents laptop options to the user in the conversation.",
+                    "Count how many distinct laptop models are presented by the agent in the final laptop presentation. Look for laptop model names like 'MacBook Air M2', 'MacBook Pro 16 M3 Max', 'ThinkPad T14s Gen 5 AMD', 'ThinkPad P16 Gen 2', etc.",
+                    "Compare the count of laptop models presented against the total number of laptop models available for that location in the additional context below. For EMEA, there should be exactly 4 laptop models. For NA, APAC, and LATAM, there should also be exactly 4 laptop models each.",
+                    "The agent MUST present ALL laptop models for the user's location in the final presentation. If even ONE model is missing from the final list, this evaluation step FAILS.",
+                    "Additionally, verify that each laptop model presented matches one of the models in the additional context for that location. If the agent shows a laptop that does not exist in the context for that location (like a 'Commodore 64' or any other incorrect model), this evaluation step FAILS.",
+                    "CRITICAL SPECIFICATION VALIDATION: You MUST verify that EVERY laptop has EXACTLY 15 specification fields. This is a STRICT requirement.",
+                    "  STEP 1: Extract the section for laptop #1 from the conversation. Look for text between '1. ' and '2. ' (or end of list if only one laptop).",
+                    "  STEP 2: In laptop #1's section ONLY, search for EACH of these 15 field names (must appear with colon): 'Manufacturer:', 'Model:', 'ServiceNow Code:', 'Target User:', 'Cost:', 'Operating System:', 'Display Size:', 'Display Resolution:', 'Graphics Card:', 'Minimum Storage:', 'Weight:', 'Ports:', 'Minimum Processor:', 'Minimum Memory:', 'Dimensions:'",
+                    "  CRITICAL: Do NOT assume a field is present in laptop #1 because it appears in laptops #2, #3, or #4. You MUST find each field explicitly within the text of laptop #1's section. If 'Target User:' appears only in laptops #2-4 but not in laptop #1's section, it is MISSING from laptop #1.",
+                    "  STEP 3: Count EXACTLY how many fields you found. Write down: 'Laptop #1 has X out of 15 fields'.",
+                    "  STEP 4: If X is not equal to 15, immediately FAIL this evaluation with score 0.0. Do not continue checking other laptops.",
+                    "  STEP 5: Only if laptop #1 has all 15 fields, repeat steps 1-4 for laptop #2, #3, and #4.",
+                    "  IMPORTANT: If you find laptop #1 is missing 'Manufacturer:' or 'Target User:' or ANY field, you MUST fail.",
+                    "  EXAMPLE OF FAILURE (multiple missing): Laptop shows 'Model: MacBook Air M2\\nServiceNow Code: abc\\nCost: €1,299\\n...' but no 'Manufacturer:' line and no 'Target User:' line = ONLY 13/15 fields = MUST FAIL with score 0.0.",
+                    "  EXAMPLE OF FAILURE (single missing): Laptop shows 'Manufacturer: Apple\\nModel: MacBook Air M2\\nServiceNow Code: abc\\nCost: €1,299\\n...' but no 'Target User:' line = ONLY 14/15 fields = MUST FAIL with score 0.0.",
+                    "  The evaluation ONLY passes if you counted EXACTLY 15 fields for EVERY laptop.",
+                    "Note: Valid conversation restarts (due to out-of-scope questions) are acceptable behavior and should not cause this metric to fail as long as the final laptop presentation is complete.",
+                    f"\n\nadditional-context-start\n{default_context}\nadditional-context-end",
+                ]
+                if validate_full_laptop_details
+                else [
+                    "First, identify the user's location from the conversation (NA, EMEA, APAC, or LATAM).",
+                    "Then, look for where the agent presents laptop options to the user in the conversation.",
+                    "Count how many distinct laptop models are presented by the agent in the final laptop presentation. Look for laptop model names like 'MacBook Air M2', 'MacBook Pro 16 M3 Max', 'ThinkPad T14s Gen 5 AMD', 'ThinkPad P16 Gen 2', etc.",
+                    "Compare the count of laptop models presented against the total number of laptop models available for that location in the additional context below. For EMEA, there should be exactly 4 laptop models. For NA, APAC, and LATAM, there should also be exactly 4 laptop models each.",
+                    "The agent MUST present ALL laptop models for the user's location in the final presentation. If even ONE model is missing from the final list, this evaluation step FAILS.",
+                    "Additionally, verify that each laptop model presented matches one of the models in the additional context for that location. If the agent shows a laptop that does not exist in the context for that location (like a 'Commodore 64' or any other incorrect model), this evaluation step FAILS.",
+                    "Note: Valid conversation restarts (due to out-of-scope questions) are acceptable behavior and should not cause this metric to fail as long as the final laptop presentation is complete.",
+                    f"\n\nadditional-context-start\n{default_context}\nadditional-context-end",
+                ]
+            ),
+        ),
+        ConversationalGEval(
+            name="Correct Laptop Selection Recorded",
+            threshold=1.0,
+            model=custom_model,
+            evaluation_params=[TurnParams.CONTENT, TurnParams.ROLE],
+            evaluation_steps=[
+                "This metric ONLY checks whether the agent correctly recorded the laptop the user selected. It does not evaluate confirmation, eligibility, or any other part of the conversation.",
+                "Find where the user selects a laptop (e.g., 'I'd like option 3, the Lenovo ThinkPad T14 Gen 4 Intel', 'I'll take the MacBook Air M2', etc.).",
+                "Find where the agent acknowledges or echoes back the selected laptop (e.g., 'You've selected the...', 'I'll proceed with the...', or any statement naming the chosen laptop).",
+                "Verify that the laptop name the agent echoes back matches the laptop the user actually selected.",
+                "PASS this metric if the agent correctly names the laptop the user chose.",
+                "FAIL this metric if the agent names a different laptop than the one the user selected (e.g., user selects 'Lenovo ThinkPad T14 Gen 4 Intel' but agent says 'You've selected the Apple MacBook Air M2').",
+                "IMPORTANT: This metric only evaluates the correctness of the selection echo. Do NOT consider whether the laptop was valid, whether confirmation was asked, or any other aspect of the conversation.",
+            ],
+        ),
+        ConversationalGEval(
+            name="Confirmation Before Ticket Assigned to Manager",
+            threshold=1.0,
+            model=custom_model,
+            evaluation_params=[TurnParams.CONTENT, TurnParams.ROLE],
+            evaluation_steps=[
+                "This metric ONLY checks whether confirmation was sought and received before any attempt to send the ticket to the manager. Whether the ticket was actually sent is evaluated by the Process Completion metric, not this one.",
+                "Find where the user selects a laptop (e.g., 'I'll take option 3', 'the MacBook Air M2', etc.).",
+                "Check if the agent asks the user for confirmation before sending/assigning the ticket to their manager. The confirmation question is VALID if it asks whether to proceed with sending/submitting/assigning the ticket to the manager. Examples of VALID confirmation questions:",
+                "  - 'Would you like me to send this request to your manager for approval?'",
+                "  - 'Shall I submit this to your manager for approval?'",
+                "  - 'Would you like to proceed with sending this laptop refresh request to your manager?'",
+                "  - 'Would you like me to assign to your manager for approval?'",
+                "  NOTE: Imprecise wording (e.g. 'assign to you manager' instead of 'assign to your manager') is ACCEPTABLE. Do NOT penalize for typos or informal phrasing.",
+                "  NOTE: The confirmation question can be embedded in a message that also shows laptop details/specifications. This is ACCEPTABLE.",
+                "If the agent asked for confirmation and the user responded affirmatively, this metric PASSES — regardless of whether the ticket was actually sent afterwards.",
+                "PASS this metric if: the agent asked for confirmation and the user responded affirmatively.",
+                "PASS this metric if: the ticket was never sent to the manager at all (nothing to have skipped confirmation on — Process Completion will catch the missing action).",
+                "FAIL this metric ONLY if: the ticket is explicitly sent to the manager WITHOUT the agent having asked for confirmation first, or before the user responds.",
+                "IMPORTANT: Do NOT require the agent to confirm the ticket was sent. Do NOT fail this metric because the ticket was never sent. Do NOT consider whether the laptop selection was valid or invalid.",
+            ],
+        ),
+    ]
+
+    return metrics

--- a/evaluations/generator.py
+++ b/evaluations/generator.py
@@ -179,6 +179,14 @@ def _parse_arguments() -> argparse.Namespace:
         help="Enable structured output mode using Pydantic schema validation with retries. "
         "Recommended for models like Gemini that benefit from explicit schema validation.",
     )
+    parser.add_argument(
+        "--flow",
+        type=str,
+        default=None,
+        metavar="FLOW_NAME",
+        help="Generate conversations for a specific flow (e.g., ticket_laptop_refresh). "
+        "Uses flow-specific scenario and saves to results/{flow}/conversation_results/.",
+    )
     return parser.parse_args()
 
 
@@ -214,6 +222,8 @@ def _run_worker(
     reset_conversation: bool,
     message_timeout: int = 60,
     use_structured_output: bool = False,
+    results_dir: str = "results/conversation_results",
+    flow_scenario: Optional[tuple[str, ...]] = None,
 ) -> dict[str, Any]:
     """
     Worker function to generate conversations in parallel.
@@ -227,6 +237,9 @@ def _run_worker(
         reset_conversation: Whether to reset conversation at start
         message_timeout: Timeout for individual message send/response operations
         use_structured_output: Enable structured output with Pydantic schema validation
+        results_dir: Directory to save generated conversations
+        flow_scenario: Optional tuple of (scenario, expected_outcome, user_description)
+                       to use instead of _create_conversation_golden()
 
     Returns:
         Dictionary with saved_files, token_counts, and test_case_count
@@ -354,9 +367,17 @@ def _run_worker(
             worker_client.get_agent_initialization()
 
             # Create conversation golden
-            conversation_golden = _create_conversation_golden(
-                conversation_number, use_structured_output=use_structured_output
-            )
+            if flow_scenario is not None:
+                scenario, expected_outcome, user_description = flow_scenario
+                conversation_golden = ConversationalGolden(
+                    scenario=scenario,
+                    expected_outcome=expected_outcome,
+                    user_description=user_description,
+                )
+            else:
+                conversation_golden = _create_conversation_golden(
+                    conversation_number, use_structured_output=use_structured_output
+                )
 
             # Simulate conversation
             conversational_test_cases = simulator.simulate(
@@ -396,7 +417,9 @@ def _run_worker(
                     base_filename = (
                         f"generated_flow_worker{worker_id}_{test_case_count}"
                     )
-                    saved_file = _save_conversation_to_file(conversation, base_filename)
+                    saved_file = _save_conversation_to_file(
+                        conversation, base_filename, results_dir
+                    )
                     saved_files.append(saved_file)
 
         except Exception as e:
@@ -464,20 +487,21 @@ def _convert_test_case_to_conversation_format(
 
 
 def _save_conversation_to_file(
-    conversation: dict[str, Any], base_filename: str = "generated_conversation"
+    conversation: dict[str, Any],
+    base_filename: str = "generated_conversation",
+    results_dir: str = "results/conversation_results",
 ) -> str:
     """
-    Save conversation to a uniquely named file in results/conversation_results
+    Save conversation to a uniquely named file in the given results directory.
 
     Args:
         conversation: Dictionary with metadata and conversation turns
         base_filename: Base name for the file (will have timestamp added)
+        results_dir: Directory to save the conversation file
 
     Returns:
         The path to the saved file
     """
-    # Create results directory if it doesn't exist
-    results_dir = "results/conversation_results"
     os.makedirs(results_dir, exist_ok=True)
 
     # Generate unique filename with timestamp
@@ -497,6 +521,27 @@ def _save_conversation_to_file(
 if __name__ == "__main__":
     # Parse command line arguments
     args = _parse_arguments()
+
+    # Resolve flow-specific settings if --flow is provided
+    flow_scenario: Optional[tuple[str, ...]] = None
+    results_dir = "results/conversation_results"
+    test_script = args.test_script
+
+    if args.flow:
+        import sys as _sys
+
+        _eval_dir = str(Path(__file__).parent)
+        if _eval_dir not in _sys.path:
+            _sys.path.insert(0, _eval_dir)
+        from flow_registry import get_flow_paths, load_flow
+
+        flow_module = load_flow(args.flow)
+        flow_paths = get_flow_paths(args.flow)
+        flow_paths.results_conv_dir.mkdir(parents=True, exist_ok=True)
+        results_dir = str(flow_paths.results_conv_dir)
+        test_script = getattr(flow_module, "DEFAULT_TEST_SCRIPT", args.test_script)
+        flow_scenario = flow_module.get_scenario(args.use_structured_output)
+        logger.info(f"Using flow '{args.flow}': saving to {results_dir}")
 
     # Get API configuration from environment variables
     api_key, api_endpoint, model_name = get_api_configuration()
@@ -551,10 +596,12 @@ if __name__ == "__main__":
                 user_partitions[i],
                 args.num_conversations,
                 args.max_turns,
-                args.test_script,
+                test_script,
                 args.reset_conversation,
                 args.message_timeout,
                 args.use_structured_output,
+                results_dir,
+                flow_scenario,
             )
             for i in range(args.concurrency)
         ]

--- a/evaluations/helpers/copy_context.py
+++ b/evaluations/helpers/copy_context.py
@@ -72,5 +72,66 @@ def copy_context_files() -> None:
         logger.warning(f"ServiceNow data file not found: {snow_data_source}")
 
 
+def copy_flow_context(flow_name: str) -> None:
+    """
+    Copy context files for the named flow into flows/{name}/context/.
+
+    Reads KNOWLEDGE_BASE_DIRS and INCLUDE_SNOW_DATA from the flow module and
+    copies the corresponding files from the agent-service knowledge bases and
+    mock-employee-data into the flow's context directory.
+
+    Args:
+        flow_name: Name of the flow (must match a subdirectory under evaluations/flows/)
+    """
+    import sys
+
+    # Ensure evaluations dir is on path so flow_registry can be imported
+    evaluations_dir = str(Path(__file__).parent.parent)
+    if evaluations_dir not in sys.path:
+        sys.path.insert(0, evaluations_dir)
+
+    from flow_registry import get_flow_paths, load_flow
+
+    flow_module = load_flow(flow_name)
+    knowledge_base_dirs = getattr(flow_module, "KNOWLEDGE_BASE_DIRS", [])
+    include_snow_data = getattr(flow_module, "INCLUDE_SNOW_DATA", False)
+
+    flow_paths = get_flow_paths(flow_name)
+    target_dir = flow_paths.context_dir
+    target_dir.mkdir(parents=True, exist_ok=True)
+
+    workspace_root = Path(__file__).parent.parent.parent
+
+    for kb_dir_name in knowledge_base_dirs:
+        source = (
+            workspace_root
+            / "agent-service"
+            / "config"
+            / "knowledge_bases"
+            / kb_dir_name
+        )
+        if source.exists():
+            for file_path in source.iterdir():
+                if file_path.is_file():
+                    shutil.copy2(file_path, target_dir / file_path.name)
+                    logger.info(f"Copied {file_path.name} to {target_dir}")
+        else:
+            logger.warning(f"Source directory not found: {source}")
+
+    if include_snow_data:
+        snow_source = (
+            workspace_root
+            / "mock-employee-data"
+            / "src"
+            / "mock_employee_data"
+            / "data.py"
+        )
+        if snow_source.exists():
+            shutil.copy2(snow_source, target_dir / "snow_data.py")
+            logger.info(f"Copied snow_data.py to {target_dir}")
+        else:
+            logger.warning(f"ServiceNow data file not found: {snow_source}")
+
+
 if __name__ == "__main__":
     copy_context_files()

--- a/evaluations/helpers/load_conversation_context.py
+++ b/evaluations/helpers/load_conversation_context.py
@@ -103,34 +103,44 @@ def load_context_files_from_directory(
     return context_list
 
 
-def load_default_context() -> List[str]:
+def load_default_context(context_dir: Optional[str] = None) -> List[str]:
     """
     Load default context files that apply to all conversations.
 
     This method loads all context files from the default context directory
     (conversations_config/default_context/) without requiring any parameters.
 
+    Args:
+        context_dir: Optional override for the context directory path.
+                     Defaults to "conversations_config/default_context".
+
     Returns:
         List of context strings loaded from default context files.
         Returns empty list if no default context files are available.
     """
-    default_context_dir = "conversations_config/default_context"
+    effective_dir = (
+        context_dir
+        if context_dir is not None
+        else "conversations_config/default_context"
+    )
     default_contexts = load_context_files_from_directory(
-        default_context_dir, "default context"
+        effective_dir, "default context"
     )
 
     if default_contexts:
         logger.info(
-            f"Loaded {len(default_contexts)} default context file(s) from {default_context_dir}"
+            f"Loaded {len(default_contexts)} default context file(s) from {effective_dir}"
         )
     else:
-        logger.info(f"No default context files found in {default_context_dir}")
+        logger.info(f"No default context files found in {effective_dir}")
 
     return default_contexts
 
 
 def load_context_for_file(
-    filename: str, context_dir: Optional[str] = None
+    filename: str,
+    context_dir: Optional[str] = None,
+    default_context_dir: Optional[str] = None,
 ) -> Optional[List[str]]:
     """
     Load context for a specific conversation file from multiple sources
@@ -151,9 +161,13 @@ def load_context_for_file(
     base_name = os.path.splitext(filename)[0]
 
     # 1. Load default context files (applied to all conversations)
-    default_context_dir = "conversations_config/default_context"
+    effective_default_dir = (
+        default_context_dir
+        if default_context_dir is not None
+        else "conversations_config/default_context"
+    )
     default_contexts = load_context_files_from_directory(
-        default_context_dir, "default context"
+        effective_default_dir, "default context"
     )
     if default_contexts:
         context_list.extend(default_contexts)

--- a/evaluations/results/ticket_laptop_refresh/conversation_results/known_good_flow.json
+++ b/evaluations/results/ticket_laptop_refresh/conversation_results/known_good_flow.json
@@ -1,0 +1,40 @@
+{
+  "metadata": {
+    "authoritative_user_id": "alice.johnson@company.com-1312321",
+    "description": "Known good ticket  laptop refresh flow test case"
+  },
+  "conversation": [
+    {
+      "role": "user",
+      "content": "A new ticket was created by a user with the following content\nI would like to refresh my laptop"
+    },
+    {
+      "role": "assistant",
+      "content": "Based on the laptop refresh policy, your laptop is over 3 years old and eligible for a replacement.\nHere is a summary of your laptop details:\n- Name: Alice Johnson\n- Employee ID: 1001\n- Location: EMEA\n- Laptop Model: Latitude 7420\n- Laptop Serial Number: DL7420001\n- Laptop Purchase Date: 2020-01-15\nYou are eligible to request a new laptop. Would you like to proceed to the next step, which is reviewing the available laptop options?"
+    },
+    {
+      "role": "user",
+      "content": "yes"
+    },
+    {
+      "role": "assistant",
+      "content": "Here are the available laptop options for your location (EMEA):\n1. Model: MacBook Air M2 - ServiceNow Code: apple_mac_book_air_m_2\n- Manufacturer: Apple\n- Target User: General Office\n- Cost: €1,299\n- Operating System: macOS\n- Display Size: 13.6 inches\n- Display Resolution: 2560 x 1664\n- Graphics Card: Apple M2 GPU\n- Minimum Storage: 256 GB SSD\n- Weight: 2.7 lbs\n- Ports: 2 x Thunderbolt/USB 4, MagSafe\n- Minimum Processor: Apple M2\n- Minimum Memory: 8 GB\n- Dimensions: 11.97 x 8.46 x 0.44 inches\n2. Model: MacBook Pro 16 M3 Max - ServiceNow Code: apple_mac_book_pro_16_m_3_max\n- Manufacturer: Apple\n- Target User: Developers\n- Cost: €3,299\n- Operating System: macOS\n- Display Size: 16.2 inches\n- Display Resolution: 3456 x 2234\n- Graphics Card: Apple M3 Max GPU\n- Minimum Storage: 1 TB SSD\n- Weight: 4.8 lbs\n- Ports: 3 x Thunderbolt 4, HDMI, SDXC, MagSafe\n- Minimum Processor: Apple M3 Max\n- Minimum Memory: 36 GB\n- Dimensions: 14.01 x 9.77 x 0.66 inches\n3. Model: ThinkPad T14s Gen 5 AMD - ServiceNow Code: lenovo_think_pad_t_14_s_gen_5_amd\n- Manufacturer: Lenovo\n- Target User: General Office\n- Cost: €1,380\n- Operating System: Windows 11 Pro\n- Display Size: 14 inches\n- Display Resolution: 1920 x 1200\n- Graphics Card: Integrated AMD Radeon\n- Minimum Storage: 512 GB SSD\n- Weight: 2.8 lbs\n- Ports: 2 x USB-C, 2 x USB-A, HDMI, Audio Jack\n- Minimum Processor: AMD Ryzen 7 PRO 7840U\n- Minimum Memory: 16 GB\n- Dimensions: 12.4 x 8.7 x 0.6 inches\n4. Model: ThinkPad P16 Gen 2 - ServiceNow Code: lenovo_think_pad_p_16_gen_2\n- Manufacturer: Lenovo\n- Target User: Engineers\n- Cost: €2,650\n- Operating System: Red Hat Linux\n- Display Size: 16 inches\n- Display Resolution: 2560 x 1600\n- Graphics Card: NVIDIA RTX A2000\n- Minimum Storage: 1 TB SSD\n- Weight: 6.5 lbs\n- Ports: 2 x USB-C, 2 x USB-A, HDMI, Ethernet, Audio Jack\n- Minimum Processor: Intel Core i7-13700HX\n- Minimum Memory: 32 GB\n- Dimensions: 14.3 x 10.5 x 1.2 inches\nPlease select one of the above options. Remember to consider your job role and requirements when making your selection."
+    },
+    {
+      "role": "user",
+      "content": "I would like option 3"
+    },
+    {
+      "role": "assistant",
+      "content": "You have selected the ThinkPad T14s Gen 5 AMD. Would you like the ticket to be sent for approval by your manager"
+    },
+    {
+      "role": "user",
+      "content": "proceed"
+    },
+    {
+      "role": "assistant",
+      "content": "I have assigned the ticket to your manager for approval, you can watch the ticket for future updates as it progresses through the approval process"
+    }
+  ]
+}

--- a/evaluations/run_conversations.py
+++ b/evaluations/run_conversations.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 
 import argparse
+import sys
+from pathlib import Path
 
 from helpers.run_conversation_flow import ConversationFlowTester
 
@@ -13,13 +15,22 @@ def _parse_arguments() -> argparse.Namespace:
     parser.add_argument(
         "--test-script",
         type=str,
-        default="chat-responses-request-mgr.py",
-        help="Name of the test script to execute (default: chat-responses-request-mgr.py)",
+        default=None,
+        help="Name of the test script to execute (default: chat-responses-request-mgr.py, "
+        "or the flow's DEFAULT_TEST_SCRIPT when --flow is used)",
     )
     parser.add_argument(
         "--reset-conversation",
         action="store_true",
         help="Send 'reset' message at the start of each conversation",
+    )
+    parser.add_argument(
+        "--flow",
+        type=str,
+        default=None,
+        metavar="FLOW_NAME",
+        help="Run predefined conversations for a specific flow (e.g., ticket_laptop_refresh). "
+        "Uses flows/{name}/conversations/ as input and results/{name}/conversation_results/ as output.",
     )
     return parser.parse_args()
 
@@ -27,10 +38,32 @@ def _parse_arguments() -> argparse.Namespace:
 if __name__ == "__main__":
     args = _parse_arguments()
 
+    if args.flow:
+        # Flow mode: use flow-specific directories and settings
+        eval_dir = str(Path(__file__).parent)
+        if eval_dir not in sys.path:
+            sys.path.insert(0, eval_dir)
+
+        from flow_registry import get_flow_paths, load_flow
+
+        flow_module = load_flow(args.flow)
+        flow_paths = get_flow_paths(args.flow)
+
+        conversations_dir = str(flow_paths.conversations_dir)
+        output_dir = str(flow_paths.results_conv_dir)
+        flow_paths.results_conv_dir.mkdir(parents=True, exist_ok=True)
+
+        default_test_script = getattr(
+            flow_module, "DEFAULT_TEST_SCRIPT", "chat-responses-request-mgr.py"
+        )
+        test_script = args.test_script or default_test_script
+    else:
+        # Default mode: existing behavior
+        conversations_dir = "conversations_config/conversations"
+        output_dir = "results/conversation_results"
+        test_script = args.test_script or "chat-responses-request-mgr.py"
+
     tester = ConversationFlowTester(
-        test_script=args.test_script, reset_conversation=args.reset_conversation
+        test_script=test_script, reset_conversation=args.reset_conversation
     )
-    tester.run_flows(
-        "conversations_config/conversations",
-        "results/conversation_results",
-    )
+    tester.run_flows(conversations_dir, output_dir)


### PR DESCRIPTION
- add support to have multiple flows each with their own predefined, known bad and generated conversations as well as their own evaluation metrics
- add initial set of known_bad_conversations for ticket-laptop-refresh flow
- existing evaluations are considered the "default" and are unchanged. Running without new flow option will run evaluations in exacltly the same way as before