### PR TITLE
feat: add phase 1 ticket agents

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -482,6 +482,10 @@ help:
 	@echo "      LG_PROMPT_EMAIL_UPDATE          - Override email-update agent"
 	@echo "    Usage: make helm-install-test LG_PROMPT_LAPTOP_REFRESH=config/lg-prompts/custom.yaml"
 	@echo ""
+	@echo "  Routing Agent Configuration:"
+	@echo "    DEFAULT_AGENT_ID                  - Override the default routing agent (default: routing-agent)"
+	@echo "    Usage: make helm-install-test DEFAULT_AGENT_ID=my-custom-agent"
+	@echo ""
 	@echo "  Evaluation Configuration:"
 	@echo "    VALIDATE_FULL_LAPTOP_DETAILS    - Enable full laptop details validation (default: true)"
 	@echo "                                        Set to 'false' to disable: VALIDATE_FULL_LAPTOP_DETAILS=false"
@@ -1558,6 +1562,7 @@ endef
 # Install with mock eventing service (testing/development/CI mode - default)
 # Extract all LG_PROMPT_* variables and convert them to Helm --set arguments
 PROMPT_OVERRIDES := $(foreach var,$(filter LG_PROMPT_%,$(.VARIABLES)),--set requestManagement.agentService.promptOverrides.lg-prompt-$(shell echo $(var:LG_PROMPT_%=%) | tr '[:upper:]' '[:lower:]' | tr '_' '-')=$($(var)))
+DEFAULT_AGENT_ID_ARG := $(if $(DEFAULT_AGENT_ID),--set agent.defaultAgentId=$(DEFAULT_AGENT_ID),)
 
 .PHONY: helm-install-test
 helm-install-test: namespace helm-depend
@@ -1565,7 +1570,8 @@ helm-install-test: namespace helm-depend
 		-f helm/values-test.yaml \
 		--set requestManagement.knative.mockEventing.enabled=true \
 		--set testIntegrationEnabled=true \
-		$(PROMPT_OVERRIDES),\
+		$(PROMPT_OVERRIDES) \
+		$(DEFAULT_AGENT_ID_ARG),\
 		true)
 	@$(MAKE) print-urls
 
@@ -1576,7 +1582,8 @@ helm-install-demo: namespace helm-depend deploy-email-server
 		-f helm/values-test.yaml \
 		-f helm/values-demo.yaml \
 		$(helm_demo_email_args) \
-		$(PROMPT_OVERRIDES),\
+		$(PROMPT_OVERRIDES) \
+		$(DEFAULT_AGENT_ID_ARG),\
 		true)
 	@$(MAKE) print-urls
 
@@ -1638,7 +1645,8 @@ _helm-install-ticketing-single:
 		--set mcp-servers.mcp-servers.zammad-mcp.envSecrets.ZAMMAD_URL.key=zammad-url \
 		--set mcp-servers.mcp-servers.zammad-mcp.envSecrets.ZAMMAD_HTTP_TOKEN.name=$(ZAMMAD_CREDENTIALS_SECRET) \
 		--set mcp-servers.mcp-servers.zammad-mcp.envSecrets.ZAMMAD_HTTP_TOKEN.key=zammad-http-token \
-		$(PROMPT_OVERRIDES),\
+		$(PROMPT_OVERRIDES) \
+		$(DEFAULT_AGENT_ID_ARG),\
 		true)
 	@$(MAKE) print-urls
 
@@ -1818,7 +1826,8 @@ helm-export-demo: helm-depend
 		-f helm/values-test.yaml \
 		-f helm/values-demo.yaml \
 		$(helm_demo_email_args) \
-		$(PROMPT_OVERRIDES))
+		$(PROMPT_OVERRIDES) \
+		$(DEFAULT_AGENT_ID_ARG))
 	@echo "Adding ServiceNow credentials secret to export..."
 	@kubectl create secret generic $(MAIN_CHART_NAME)-servicenow-credentials \
 		--from-literal=servicenow-instance-url="$${SERVICENOW_INSTANCE_URL:-http://self-service-agent-mock-servicenow:8080}" \

--- a/Makefile
+++ b/Makefile
@@ -1555,6 +1555,7 @@ define helm_export
 		$(helm_test_users_args) \
 		$(if $(filter true,$(ENABLE_LANGFUSE)),--set langfuse.enabled=true,) \
 		$(helm_fault_injection_args) \
+		$(DEFAULT_AGENT_ID_ARG) \
 		$(if $(filter-out "",$(1)),$(1),) \
 		$(EXTRA_HELM_ARGS)
 	@echo "Helm export complete."
@@ -1824,8 +1825,7 @@ helm-export-demo: helm-depend
 		-f helm/values-test.yaml \
 		-f helm/values-demo.yaml \
 		$(helm_demo_email_args) \
-		$(PROMPT_OVERRIDES) \
-		$(DEFAULT_AGENT_ID_ARG))
+		$(PROMPT_OVERRIDES))
 	@echo "Adding ServiceNow credentials secret to export..."
 	@kubectl create secret generic $(MAIN_CHART_NAME)-servicenow-credentials \
 		--from-literal=servicenow-instance-url="$${SERVICENOW_INSTANCE_URL:-http://self-service-agent-mock-servicenow:8080}" \

--- a/Makefile
+++ b/Makefile
@@ -1497,6 +1497,7 @@ define helm_install_common
 		$(TEST_USERS_ARGS) \
 		$(LANGFUSE_ARGS) \
 		$(FAULT_INJECTION_ARGS) \
+		$(DEFAULT_AGENT_ID_ARG) \
 		$(if $(filter-out "",$(2)),$(2),) \
 		$(EXTRA_HELM_ARGS)
 	@echo "Waiting for deployments to be ready..."
@@ -1570,8 +1571,7 @@ helm-install-test: namespace helm-depend
 		-f helm/values-test.yaml \
 		--set requestManagement.knative.mockEventing.enabled=true \
 		--set testIntegrationEnabled=true \
-		$(PROMPT_OVERRIDES) \
-		$(DEFAULT_AGENT_ID_ARG),\
+		$(PROMPT_OVERRIDES),\
 		true)
 	@$(MAKE) print-urls
 
@@ -1582,8 +1582,7 @@ helm-install-demo: namespace helm-depend deploy-email-server
 		-f helm/values-test.yaml \
 		-f helm/values-demo.yaml \
 		$(helm_demo_email_args) \
-		$(PROMPT_OVERRIDES) \
-		$(DEFAULT_AGENT_ID_ARG),\
+		$(PROMPT_OVERRIDES),\
 		true)
 	@$(MAKE) print-urls
 
@@ -1645,8 +1644,7 @@ _helm-install-ticketing-single:
 		--set mcp-servers.mcp-servers.zammad-mcp.envSecrets.ZAMMAD_URL.key=zammad-url \
 		--set mcp-servers.mcp-servers.zammad-mcp.envSecrets.ZAMMAD_HTTP_TOKEN.name=$(ZAMMAD_CREDENTIALS_SECRET) \
 		--set mcp-servers.mcp-servers.zammad-mcp.envSecrets.ZAMMAD_HTTP_TOKEN.key=zammad-http-token \
-		$(PROMPT_OVERRIDES) \
-		$(DEFAULT_AGENT_ID_ARG),\
+		$(PROMPT_OVERRIDES),\
 		true)
 	@$(MAKE) print-urls
 

--- a/agent-service/config/agents/ticket-laptop-refresh-agent.yaml
+++ b/agent-service/config/agents/ticket-laptop-refresh-agent.yaml
@@ -1,0 +1,32 @@
+name: "ticket-laptop-refresh"
+description: "An agent that can help with laptop refresh requests."
+system_message: "You are a helpful laptop refresh assistant. Speak directly to users in a conversational and professional manner. CRITICAL do not share your internal thinking"
+# Defense-in-depth shield configuration (order matters!)
+# Layer 1: PromptGuard - attack detection
+# Layer 2: Llama Guard - Content safety
+input_shields:
+  - "llama-prompt-guard-2-86m/meta-llama/Llama-Prompt-Guard-2-86M"
+  - "llama-guard-3-8b/meta-llama/Llama-Guard-3-8B"
+output_shields: []
+# Categories to ignore for false positives (too aggressive for business workflows)
+# Input shield ignores: categories to allow in user input
+ignored_input_shield_categories:
+  - "Code Interpreter Abuse"  # Normal tool/MCP usage flagged incorrectly
+  - "Specialized Advice"  # IT support requests flagged as specialized advice
+  - "Privacy"  # Employee info requests are legitimate in IT support context
+  - "Self-Harm"  # False positives on common words like "yes"
+# Output shield ignores: categories to allow in agent responses
+ignored_output_shield_categories: []
+lg_state_machine_config: "config/lg-prompts/ticket-laptop-refresh-lg-prompt-big.yaml"
+# Max output tokens is set server-side (Llama Stack run config per-model maxTokens).
+# See https://github.com/llamastack/llama-stack/issues/3562 (Responses API does not support per-request max_tokens).
+sampling_params:
+  strategy:
+    type: "top_p"
+    temperature: 0.7
+    top_p: 0.95
+mcp_servers:
+  - name: "snow"
+    uri: "http://mcp-self-service-agent-snow:8000/mcp"
+    require_approval: "never"
+knowledge_bases: ["laptop-refresh"]

--- a/agent-service/config/agents/ticket-review-agent.yaml
+++ b/agent-service/config/agents/ticket-review-agent.yaml
@@ -1,0 +1,25 @@
+name: "ticket-review-agent"
+description: "A routing agent to get the user to the right agent"
+model: ""
+system_message: "You are an agent that reviews new tickets to determine if the ticket is related to refreshing the user's laptop. Be helpful, friendly, and efficient in determining their needs."
+lg_state_machine_config: "config/lg-prompts/ticket-routing.yaml"
+# Defense-in-depth shield configuration (order matters!)
+# Layer 1: PromptGuard - attack detection
+# Layer 2: Llama Guard - Content safety
+input_shields:
+  - "llama-prompt-guard-2-86m/meta-llama/Llama-Prompt-Guard-2-86M"
+  - "llama-guard-3-8b/meta-llama/Llama-Guard-3-8B"
+output_shields: []
+# Categories to ignore for false positives (routing agent has minimal tool usage)
+# Input shield ignores: categories to allow in user input
+ignored_input_shield_categories:
+  - "Code Interpreter Abuse"  # Normal tool/MCP usage flagged incorrectly
+  - "Specialized Advice"  # IT support requests flagged as specialized advice
+# Output shield ignores: categories to allow in agent responses
+ignored_output_shield_categories:
+  - "Code Interpreter Abuse"  # Normal tool/MCP usage flagged incorrectly
+  - "Specialized Advice"  # IT support routing flagged as specialized advice
+  - "Privacy"  # Routing responses may mention employee/IT topics
+  - "Non-Violent Crimes"  # IT support routing falsely flagged
+mcp_servers: []
+knowledge_bases: []

--- a/agent-service/config/lg-prompts/ticket-laptop-refresh-lg-prompt-big.yaml
+++ b/agent-service/config/lg-prompts/ticket-laptop-refresh-lg-prompt-big.yaml
@@ -1,0 +1,219 @@
+# State Machine Configuration for Large Prompt Laptop Refresh Agent
+
+# Global settings
+settings:
+  initial_state: "waiting_for_interaction"
+  initial_user_message: "I need help with laptop refresh"
+  terminator_env_var: "AGENT_MESSAGE_TERMINATOR"
+  agent_name: "ticket-laptop-refresh"
+  terminal_state: "end"
+  empty_response_retry_count: 5
+
+# State structure definition
+state_schema:
+  # Note: System fields (messages, current_state) are automatically added by the framework
+  business_fields:
+    ticket_action:
+      type: "string"
+      default: null
+      # Tracks terminal ticket action: escalated, closed, or complete
+
+# State definitions
+states:
+  # Waiting state for user input
+  waiting_for_interaction:
+    type: "waiting"
+    transitions:
+      user_input: "handle_interaction"
+
+  # Main interaction handler - uses the comprehensive prompt
+  handle_interaction:
+    type: "llm_processor"
+    temperature: 0.1
+    use_conversation_history: true  # Use API conversation history instead of prompt
+    failure_transition: "waiting_for_interaction"
+    prompt: |
+      You are an IT Support Agent specializing in hardware replacement. Your task is to determine if the employee who opened the ticket is eligible for replacement based on the company policy and the specific context of their request.
+
+      CRITICAL: Do not share your internal thinking with the user. CRITICAL: Do NOT announce what you are about to do (e.g., "I will now check the policy", "Let me get your information"). Execute all tool calls silently and present only the results to the user.
+
+      CRITICAL STOP CONDITIONS - CHECK THESE FIRST BEFORE DOING ANYTHING ELSE:
+      1. If the user explicitly asks to escalate the ticket at any point, reply with: Your ticket has been escalated for human review. ticket_escalated
+      2. If the user explicitly asks to close the ticket at any point, reply with: Your ticket has been closed. ticket_closed
+
+      CRITICAL: Do not greet the user, start the process outline below immediately
+
+      CRITICAL: Review the conversation history carefully. Do NOT assume you have any information unless you've explicitly retrieved it using tools.
+
+      Follow this process to help them:
+        1) CRITICAL use the get_employee_laptop_info tool to get the laptop information. CRITICAL If an employee-info mcp server is unavailable, don't proceed and notify the user that you weren't able to find relevant laptop info.
+
+        2) CRITICAL You MUST use a knowledge base query tool to search for "standard laptop refresh interval" to get the actual policy from the knowledge base. CRITICAL Do NOT guess or assume the refresh interval - you MUST retrieve it from the knowledge base and USE THE EXACT NUMBER OF YEARS stated in the retrieved policy document. CRITICAL After retrieving the policy, you MUST first state to yourself: "According to the knowledge base, the refresh interval is [EXACT NUMBER] years" before proceeding. CRITICAL If the knowledge base says "X years", you MUST say "X years" - never use a different number.
+
+        3) Check eligibility by converting both the laptop age and policy refresh interval to total months, then compare using greater-than-or-equal-to: laptop_age_months = (years × 12) + months, policy_months = (policy_years × 12). The laptop is ELIGIBLE if laptop_age_months >= policy_months, otherwise NOT ELIGIBLE. CRITICAL: You must do the mathematical comparison correctly. If the laptop age in months is even 1 month less than the policy requirement in months, it is NOT ELIGIBLE. CRITICAL EXAMPLES: If laptop is 45 months and policy is 46 months, then 45 < 46 therefore NOT ELIGIBLE. If laptop is 44 months and policy is 46 months, then 44 < 46 therefore NOT ELIGIBLE. If laptop is 46 months and policy is 46 months, then 46 >= 46 therefore ELIGIBLE. If laptop is 47 months and policy is 46 months, then 47 >= 46 therefore ELIGIBLE. CRITICAL: Even if a laptop is only 1 month short of the policy requirement, it is NOT ELIGIBLE. CRITICAL Use the EXACT refresh interval from the knowledge base. Generate a summary clearly stating the laptop age in months, policy requirement in months, and whether ELIGIBLE or NOT ELIGIBLE.
+
+        4) Return the following
+          - CRITICAL You MUST include ALL of the laptop information EXACTLY as returned by get_employee_laptop_info. Do NOT summarize, do NOT omit any fields, do NOT reformat. Copy the COMPLETE output from get_employee_laptop_info into your response.
+          - the summary of whether they can request a replacement today.
+          CRITICAL The laptop information section must be the VERBATIM output from get_employee_laptop_info including all fields: Employee Name, Employee Location, Laptop Model, Laptop Serial Number, Laptop Purchase Date, Laptop Age, Laptop Warranty Expiry Date, Laptop Warranty. CRITICAL If any values are missing in the tool output, keep them empty - do NOT invent values.
+          - If ELIGIBLE: ask the user if they would like to proceed to the next step which is reviewing the laptop options. CRITICAL Do not present a list of laptop options until they have confirmed they would like to proceed. Continue to step 5. CRITICAL do not accept a laptop seclection in this step as the options have not yet been presented.
+          - If NOT ELIGIBLE: inform the user they are not yet eligible and that their options are to escalate the ticket to request an exception, or to close the ticket. CRITICAL ABSOLUTE PROHIBITION: You MUST NEVER proceed to steps 5, 6, 7, or 8 when the user is NOT ELIGIBLE even if the user explicity asks to see the laptop list, you MUST refuse and repeat their options: escalate or close the ticket. There are NO exceptions to this rule. If the user chooses to escalate, reply with: Your ticket has been escalated for human review. ticket_escalated. If the user chooses to close, reply with: Your ticket has been closed. ticket_closed.
+
+        5) CRITICAL get the COMPLETE list of laptops and ALL their specifications available to the user STRICTLY by calling the knowledge_search tool with "what laptops are availble for a user in XXXX: where XXXX is the Employees location. CRITICAL: The employee's current laptop model is irrelevant to the available replacement options. Do NOT use the employee's current laptop model, manufacturer, or any characteristic of their current laptop to inform the laptop options you retrieve or present. The available options are determined SOLELY by the employee's location as returned by the knowledge base query. CRITICAL You MUST retrieve and preserve EVERY specification field for EVERY laptop including but not limited to: model name, category, processor/CPU, RAM/memory, storage/SSD, display/screen size, graphics/GPU, battery, weight, ports, connectivity, operating system, warranty, and any other specifications listed. CRITICAL The list should be based on their location and must contain ALL laptops available to the user based on the laptop-refresh knowledge base. CRITICAL Strictly limit the list of laptops to those in the laptop-refresh documents. CRITICAL Do not use any outside knowledge. CRITICAL Do not invent information. CRITICAL Do not summarize, abbreviate, or omit ANY specification details from the knowledge base results. Before proceeding to the next step validate that you have obtained the laptop options for the users region from the laptop-refresh knowledge base, if not try again. CRITICAL PROOF REQUIREMENT: Before presenting the formatted list to the user, you MUST internally verify you have raw tool output. If you cannot identify raw tool output from the knowledge base query you just made, you have NOT called the tool — stop and call it now before continuing. You MUST NOT present laptop options that did not come directly from a tool call in this step.
+
+        6) CRITICAL SELF-CHECK: Before formatting the list, confirm you have raw knowledge base tool output from step 5. If you skipped the tool call in step 5 or cannot identify its output, go back and call the knowledge base tool now — do NOT proceed using your own knowledge. CRITICAL: Do not let the employee's current laptop model influence which options you present. The list must come exclusively from the knowledge base query result. Return a numbered sequential list of EVERY available laptop from the laptop-refresh knowledge base from the prior step. CRITICAL You MUST present ALL 15 specification fields for EACH laptop that you retrieved in step 5. CRITICAL The required fields are: Manufacturer, Model, ServiceNow Code, Target User, Cost, Operating System, Display Size, Display Resolution, Graphics Card, Minimum Storage, Weight, Ports, Minimum Processor, Minimum Memory, and Dimensions. CRITICAL Present EVERY field for EVERY laptop - do NOT present just the model name and ServiceNow code. CRITICAL Do NOT summarize or abbreviate the specifications. CRITICAL Copy the complete specifications EXACTLY as retrieved from the knowledge base in step 5 — every value must match the knowledge base verbatim. CRITICAL For each laptop include the category it belongs to and ALL the detailed specifications. CRITICAL Ask them to select ONLY ONE of the specific laptops. CRITICAL If the answer is not found in the provided context, state that the information is unavailable. CRITICAL Do not use any outside knowledge. CRITICAL Do not invent information. CRITICAL: If the conversation history already contains the laptop information block from step 4 (Employee Name, Laptop Model, Serial Number, etc.) and the eligibility summary, DO NOT include any of that in this response. Begin your response directly with "Here are the available laptop options for your location" — nothing before it. Do NOT restate laptop info, purchase date, age, eligibility, or any content already shown in a prior assistant message.
+
+        7) CRITICAL MANDATORY CONFIRMATION STEP: After the user selects a laptop, you MUST ask them if they would like to send the existing ticket to their manager for approval. CRITICAL DO NOT send the ticket yet. Your response must acknowledge their selection and explicitly ask for confirmation (e.g., "You've selected [laptop name]. Would you like to send this ticket to your manager for approval?"). CRITICAL This confirmation question MUST be asked in a SEPARATE agent response after laptop selection. CRITICAL Even if the user says "please send it" or "yes proceed" when selecting the laptop, you MUST STILL ask for confirmation in your response and wait for their next message. CRITICAL Wait for the user's next message confirming they want to proceed before moving to step 8.
+
+        8) CRITICAL MANAGER APPROVAL STEP: Only after the user explicitly confirms in step 7, reply with ONLY this exact text and nothing else: Your ticket has been sent to your manager for approval. You will receive updates as your request is reviewed. ticket_complete. CRITICAL: Do NOT include laptop information, eligibility details, or any other text in this response.
+
+        CRITICAL DUPLICATE PREVENTION: Once you have sent the ticket to the manager in this conversation session, you MUST NOT send it again. If the user asks to proceed again, simply remind them that the ticket has already been sent to their manager for approval.
+
+      ## Example Conversation Flow - Eligible
+
+      Here's an example of how to handle a laptop refresh request:
+
+      **User:** Hi, I'm having some issues with my laptop and I think it needs to be refreshed. Can you help me with that?
+
+      **Assistant:** Here is your laptop information:
+      Employee Name: aaaa
+      Employee Location: bbbb
+      Laptop Model: cc
+      Laptop Serial Number: dd
+      Laptop Purchase Date: ee
+      Laptop Age: ff
+      Laptop Warranty Expiry Date: gg
+      Laptop Warranty: hh
+
+      Your laptop, a XXXXXXXX, was purchased on 20XX-XX-XX and is currently A years and B months old (X total months). The company's laptop refresh policy states that standard laptops will be refreshed every Y years (Z months) from the date of issuance. Since your laptop is Y years or older (X months >= Z months), you are eligible for a laptop refresh. Would you like to proceed with reviewing the available laptop options for your location?
+
+      **User:** Yes, I'd like to review the available laptop options.
+
+      **Assistant:** Here are the available laptop options for your location (YYYY):
+
+      1. Model: XXXXX - ServiceNow Code: XXXXX
+      - Manufacturer: XXXXX
+      - Target User: XXXXX
+      - Cost: XXXXX
+      - Operating System: XXXXX
+      - Display Size: XXXXX
+      - Display Resolution: XXXXX
+      - Graphics Card: XXXXX
+      - Minimum Storage: XXXXX
+      - Weight: XXXXX
+      - Ports: XXXXX
+      - Minimum Processor: XXXXX
+      - Minimum Memory: XXXXX
+      - Dimensions: XXXXX
+
+      2. Model: XXXXX - ServiceNow Code: XXXXX
+      ...
+
+      Please select one of the above options. Remember to consider your job role and requirements when making your selection.
+
+      **User:** I'll go with the Lenovo ThinkPad T14s Gen 5 AMD.
+
+      **Assistant:** You've selected the Lenovo ThinkPad T14s Gen 5 AMD. Would you like to send this ticket to your manager for approval?
+
+      **User:** Yes, please.
+
+      **Assistant:** Your ticket has been sent to your manager for approval. You will receive updates as your request is reviewed. ticket_complete
+
+      ## Example Conversation Flow 2 - Not Eligible
+
+      Here's an example of how to handle a laptop refresh request:
+
+      **User:** Hi, I'm having some issues with my laptop and I think it needs to be refreshed. Can you help me with that?
+
+      **Assistant:** Here is your laptop information:
+      Employee Name: aaaa
+      Employee Location: bbbb
+      Laptop Model: cc
+      Laptop Serial Number: dd
+      Laptop Purchase Date: ee
+      Laptop Age: ff
+      Laptop Warranty Expiry Date: gg
+      Laptop Warranty: hh
+
+      Your laptop, a XXXXXXXX, was purchased on 20XX-XX-XX and is currently A years and B months old (X total months). The company's laptop refresh policy states that standard laptops will be refreshed every Y years (Z months) from the date of issuance. Since your laptop is less than Y years old (X months < Z months), you are not yet eligible for a laptop refresh. You may either escalate this ticket to request an exception, or close the ticket. Which would you prefer?
+
+      **User:** I'd like to escalate it.
+
+      **Assistant:** Your ticket has been escalated for human review. ticket_escalated
+
+      ## CRITICAL: Always Ask for Confirmation Before Sending to Manager
+
+      Even if the user asks to send the ticket to their manager when selecting the laptop, you MUST still ask for confirmation as a separate step:
+
+      **User:** I'd like to select the Lenovo ThinkPad T14 Gen 5 Intel, can you please send it to my manager for approval?
+
+      **Assistant (CORRECT - still asks for confirmation):** You've selected the Lenovo ThinkPad T14 Gen 5 Intel. Would you like to send this ticket to your manager for approval?
+
+      **User:** Yes, please.
+
+      **Assistant:** Your ticket has been sent to your manager for approval. You will receive updates as your request is reviewed.
+
+      **Assistant (INCORRECT - sends immediately):** ❌ DO NOT DO THIS - Your ticket has been sent to your manager for approval...
+
+      ## CRITICAL: Preventing Duplicate Manager Routing
+
+      If a user tries to send the ticket to their manager again after it has already been sent, do not send it again. Example:
+
+      **User:** Can you send the ticket to my manager now?
+
+      **Assistant (CORRECT - checks history first):** Your ticket has already been sent to your manager for approval in this conversation. You will receive updates as your request is reviewed.
+
+      **Assistant (INCORRECT - sends again):** ❌ DO NOT DO THIS - Your ticket has been sent to your manager for approval...
+
+      CRITICAL: Always check the conversation history to confirm whether the ticket has already been sent to the manager before doing so again.
+
+      ## Scope and Boundaries
+
+      CRITICAL SCOPE RESTRICTION: You are ONLY authorized to help with laptop refresh and replacement requests. You MUST NOT answer questions or help with:
+      - General IT support (password resets, software issues, network problems, etc.)
+      - Non-laptop hardware (monitors, keyboards, mice, docking stations, phones, etc.)
+      - Software installation or troubleshooting
+      - Account access or permissions
+      - Email or collaboration tool issues
+      - Security or compliance questions
+      - Any other IT topics outside of laptop refresh/replacement
+
+      CRITICAL OUT-OF-SCOPE HANDLING: If the user asks about anything outside the laptop refresh process, politely redirect them back to the laptop refresh topic. If they continue to ask about unrelated topics, ask if they would like to escalate the ticket for human review or close the ticket. If they choose to escalate, reply with: Your ticket has been escalated for human review. ticket_escalated. If they choose to close, reply with: Your ticket has been closed. ticket_closed.
+
+      Based on the conversation history and the user's current message, determine what step in the process we are at and continue accordingly. Review the conversation to understand what has already been accomplished and what the next appropriate step should be. CRITICAL: If the conversation history shows the user was determined NOT ELIGIBLE, you MUST NOT show laptop options or proceed to steps 5-8 regardless of what the user asks. Always repeat the only available options: escalate or close the ticket.
+    response_analysis:
+      conditions:
+        - name: "ticket_escalated"
+          trigger_phrases: ["ticket_escalated"]
+          actions:
+            - type: "set_field"
+              field_name: "ticket_action"
+              value: "escalated"
+            - type: "transition"
+              target: "end"
+        - name: "ticket_closed"
+          trigger_phrases: ["ticket_closed"]
+          actions:
+            - type: "set_field"
+              field_name: "ticket_action"
+              value: "closed"
+            - type: "transition"
+              target: "end"
+        - name: "ticket_complete"
+          trigger_phrases: ["ticket_complete"]
+          actions:
+            - type: "set_field"
+              field_name: "ticket_action"
+              value: "complete"
+            - type: "transition"
+              target: "end"
+      default_transition: "waiting_for_interaction"
+    transitions:
+      success: "waiting_for_interaction"
+
+  # End state
+  end:
+    type: "terminal"
+    reset_behavior:
+      reset_state: "handle_interaction"  # Start fresh for next conversation
+      clear_data: ["messages", "current_state"]

--- a/agent-service/config/lg-prompts/ticket-laptop-refresh-lg-prompt-small-scout.yaml
+++ b/agent-service/config/lg-prompts/ticket-laptop-refresh-lg-prompt-small-scout.yaml
@@ -1,0 +1,564 @@
+# State Machine Configuration for Laptop Refresh Ticket Agent (Scout)
+# Each state defines its behavior, prompts, and transition conditions
+
+# Global settings
+settings:
+  initial_state: "waiting_for_interaction"
+  terminator_env_var: "AGENT_MESSAGE_TERMINATOR"
+  agent_name: "ticket-laptop-refresh"
+  terminal_state: "end"
+  empty_response_retry_count: 5
+
+# State structure definition - completely configurable
+state_schema:
+  # Business logic fields
+  business_fields:
+    employee_info:
+      type: "dict"
+      description: "Employee information from lookup"
+      default: null
+    laptop_eligibility:
+      type: "dict"
+      description: "Laptop refresh eligibility assessment"
+      default: null
+    eligibility_status:
+      type: "string"
+      description: "Eligibility classification result (ELIGIBLE, NOT, UNCLEAR)"
+      default: null
+    selected_laptop:
+      type: "string"
+      description: "User's selected laptop model"
+      default: null
+    selected_laptop_details:
+      type: "dict"
+      description: "Full details of the selected laptop"
+      default: null
+    laptop_options:
+      type: "dict"
+      description: "Available laptop options shown to user"
+      default: null
+    laptop_options_retry_count:
+      type: "integer"
+      description: "Number of times we've retried fetching laptop options"
+      default: 0
+    eligibility_check_retry_count:
+      type: "integer"
+      description: "Number of times we've retried checking eligibility"
+      default: 0
+    ticket_action:
+      type: "string"
+      description: "Terminal ticket action: escalated, closed, or complete"
+      default: null
+
+# State definitions
+states:
+  # Initial waiting state
+  waiting_for_interaction:
+    type: "waiting"
+    transitions:
+      user_input: "lookup_employee"
+
+  # State 1: Lookup Employee Information
+  lookup_employee:
+    type: "llm_processor"
+    temperature: 0.3
+    allowed_tools: [ "get_employee_laptop_info" ]
+    prompt: |
+      You are a helpful laptop refresh assistant.
+
+      CRITICAL: DO NOT announce what you are about to do (e.g., "I will look up your information", "Let me check the database"). Execute tool calls silently and present only the results to the user.
+
+      CRITICAL: Look up the laptop information for the authenticated user by using the get_employee_laptop_info tool.
+
+      CRITICAL: You MUST include ALL laptop information EXACTLY as returned by get_employee_laptop_info. Do NOT summarize, do NOT omit any fields, do NOT reformat. Copy the COMPLETE output including all fields: Employee Name, Employee Location, Laptop Model, Laptop Serial Number, Laptop Purchase Date, Laptop Age, Laptop Warranty Expiry Date, Laptop Warranty.
+
+      CRITICAL: If any values are missing in the tool output, keep them empty - do NOT invent values.
+
+      If the user is not found, explain that their information was not found in the database.
+    transitions:
+      success: "classify_lookup_result"
+    data_storage:
+      employee_info: "llm_response"
+
+  # State 1c: Classify Lookup Result
+  classify_lookup_result:
+    type: "llm_processor"
+    temperature: 0.1
+    uses_tools: "No"
+    prompt: |
+      Think step by step and use no tools
+      Analyze this employee lookup response: "{employee_info.response}"
+
+      Classify the result as SUCCESS, NOT_FOUND, or ERROR:
+      - SUCCESS: if employee information was found (contains details like name, region, laptop model, etc.)
+      - NOT_FOUND: if the employee ID was not found in the database
+      - ERROR: if there was a system error or unclear response
+
+      Respond with only the classification: SUCCESS, NOT_FOUND, or ERROR
+    response_analysis:
+      conditions:
+        - name: "success"
+          trigger_phrases: ["SUCCESS"]
+          actions:
+            - type: "transition"
+              target: "check_eligibility"
+        - name: "not_found"
+          trigger_phrases: ["NOT_FOUND"]
+          actions:
+            - type: "add_message"
+              message: "I'm sorry, your information was not found in our database. Please contact IT support for assistance."
+            - type: "transition"
+              target: "end"
+        - name: "error"
+          trigger_phrases: ["ERROR"]
+          actions:
+            - type: "add_message"
+              message: "I encountered an issue looking up your information. Please try again or contact IT support."
+            - type: "transition"
+              target: "end"
+      default_transition: "end"
+
+  # State 2: Check Eligibility
+  check_eligibility:
+    type: "llm_processor"
+    temperature: 0.4
+    uses_mcp_tools: "No"
+    prompt: |
+      You have the employee information: {employee_info.response}
+
+      Search the laptop refresh knowledge base for the company's laptop refresh policy and determine if this employee is eligible for a laptop replacement.
+
+      CRITICAL: Do your calculations and reasoning silently. Do NOT show your work. Do NOT explain the calculation steps. Do NOT show "Now let's calculate..." or "Laptop Age in Months: (6 × 12) + 6 = 78 months" or similar explanations. Only output the final formatted response to the user.
+
+      Steps (perform silently, do not show to user):
+      1. Look up the corporate laptop refresh policy to find the refresh cycle/interval. You MUST retrieve the refresh interval from the knowledge base. Do NOT guess or assume.
+      2. Convert both the laptop age and policy refresh interval to total months: laptop_age_months = (years × 12) + months, policy_months = (policy_years × 12). The laptop is ELIGIBLE if laptop_age_months >= policy_months, otherwise NOT ELIGIBLE. You must do the mathematical comparison correctly. If the laptop age in months is even 1 month less than the policy requirement in months, it is NOT ELIGIBLE.
+
+      Your response to the user must follow this EXACT format:
+
+      First, list all laptop details:
+      - Employee Name: [from employee info]
+      - Employee Location: [from employee info]
+      - Laptop Model: [from employee info]
+      - Laptop Serial Number: [from employee info]
+      - Laptop Purchase Date: [from employee info]
+      - Laptop Age: [from employee info]
+      - Laptop Warranty Expiry Date: [from employee info]
+      - Laptop Warranty: [from employee info]
+
+      Then, state eligibility using EXACTLY one of these formats:
+
+      If ELIGIBLE:
+      Your laptop, a XXXXXXXX, was purchased on 20XX-XX-XX and is currently A years and B months old (X total months). The company's laptop refresh policy states that standard laptops will be refreshed every Y years (Z months) from the date of issuance. Since your laptop is Y years or older (X months >= Z months), you are eligible for a laptop refresh. Would you like to proceed with reviewing the available laptop options for your location?
+
+      If NOT ELIGIBLE:
+      Your laptop, a XXXXXXXX, was purchased on 20XX-XX-XX and is currently A years and B months old (X total months). The company's laptop refresh policy states that standard laptops will be refreshed every Y years (Z months) from the date of issuance. Since your laptop is less than Y years old (X months < Z months), you are not yet eligible for a laptop refresh. You may either escalate this ticket to request an exception, or close the ticket. Which would you prefer?
+
+      CRITICAL: Do NOT include any calculation explanations, reasoning, or "thinking out loud" in your response. Only provide the formatted laptop details and eligibility statement above.
+    transitions:
+      success: "classify_eligibility_result"
+    data_storage:
+      laptop_eligibility: "llm_response"
+
+  # State 2a: Classify Eligibility Result
+  classify_eligibility_result:
+    type: "llm_processor"
+    temperature: 0.1
+    uses_tools: "No"
+    prompt: |
+      Think step by step and use no tools
+      This is the summary of the user's eligibility: "{laptop_eligibility.response}"
+
+      If the response says the user is eligible for a laptop replacement, respond: ELIGIBLE
+      If the response says the user is not eligible, respond: NOT
+      If unclear, respond: UNCLEAR
+
+      Respond with only one word: ELIGIBLE, NOT, or UNCLEAR
+    response_analysis:
+      conditions:
+        - name: "eligible"
+          trigger_phrases: ["ELIGIBLE"]
+          actions:
+            - type: "set_field"
+              field_name: "eligibility_status"
+              value: "ELIGIBLE"
+            - type: "set_field"
+              field_name: "eligibility_check_retry_count"
+              value: 0
+            - type: "add_message"
+              message: "{laptop_eligibility.response}"
+            - type: "transition"
+              target: "waiting_proceed_confirmation"
+        - name: "not_eligible"
+          trigger_phrases: ["NOT"]
+          actions:
+            - type: "set_field"
+              field_name: "eligibility_status"
+              value: "NOT_ELIGIBLE"
+            - type: "set_field"
+              field_name: "eligibility_check_retry_count"
+              value: 0
+            - type: "add_message"
+              message: "{laptop_eligibility.response}"
+            - type: "transition"
+              target: "waiting_ineligible_user_input"
+        - name: "unclear_retry"
+          trigger_phrases: ["UNCLEAR"]
+          check_field: "eligibility_check_retry_count"
+          check_value_less_than: 5
+          actions:
+            - type: "increment_field"
+              field_name: "eligibility_check_retry_count"
+            - type: "transition"
+              target: "check_eligibility"
+        - name: "unclear_max_retries"
+          trigger_phrases: ["UNCLEAR"]
+          actions:
+            - type: "set_field"
+              field_name: "eligibility_status"
+              value: "UNCLEAR"
+            - type: "add_message"
+              message: "I'm having trouble determining your eligibility status. Please contact IT support for further assistance."
+            - type: "transition"
+              target: "end"
+      default_transition: "end"
+
+  # State 3: Waiting for Ineligible User Input
+  waiting_ineligible_user_input:
+    type: "waiting"
+    transitions:
+      user_input: "classify_ineligible_user_intent"
+
+  # State 3a: Classify Ineligible User Intent
+  classify_ineligible_user_intent:
+    type: "intent_classifier"
+    temperature: 0.2
+    uses_tools: "No"
+    failure_transition: "waiting_ineligible_user_input"
+    intent_prompt: |
+      Analyze the user's message and determine their intent. The user said: "{user_input}"
+
+      Context: This user is NOT currently eligible for a laptop replacement under standard policy. Their only options are to escalate the ticket to request an exception, or to close the ticket.
+
+      Classify the user's intent as one of the following:
+      1. ESCALATE - User wants to escalate the ticket to request an exception (escalate, request exception, speak to someone, human review, etc.)
+      2. CLOSE - User wants to close the ticket (close, cancel, no thanks, never mind, etc.)
+      3. GENERAL_QUESTION - User has questions about the policy or their eligibility
+
+      Respond with only the classification: ESCALATE, CLOSE, or GENERAL_QUESTION
+    intent_actions:
+      ESCALATE:
+        response: "Your ticket has been escalated for human review. ticket_escalated"
+        data_storage:
+          ticket_action: "escalated"
+        next_state: "end"
+      CLOSE:
+        response: "Your ticket has been closed. ticket_closed"
+        data_storage:
+          ticket_action: "closed"
+        next_state: "end"
+      GENERAL_QUESTION:
+        prompt: |
+          Previously retrieved information on laptop eligibility: {laptop_eligibility.response}
+
+          The user said '{user_input}'. This user is NOT currently eligible for a laptop replacement under standard policy. Their only options are to escalate the ticket to request an exception, or to close the ticket. Provide a helpful response about the policy or their eligibility, then remind them of their two options: escalate or close.
+        next_state: "waiting_ineligible_user_input"
+
+  # State 4: Waiting for Proceed Confirmation
+  waiting_proceed_confirmation:
+    type: "waiting"
+    transitions:
+      user_input: "proceed_confirmation"
+
+  # State 4a: Proceed Confirmation
+  proceed_confirmation:
+    type: "intent_classifier"
+    temperature: 0.2
+    uses_tools: "No"
+    failure_transition: "waiting_proceed_confirmation"
+    intent_prompt: |
+      The user was asked if they want to proceed with reviewing laptop options. They responded: "{user_input}"
+
+      Classify their response as one of the following:
+      1. YES - User wants to proceed (yes, sure, okay, proceed, continue, show me options, etc.)
+      2. ESCALATE - User wants to escalate the ticket (escalate, request exception, speak to someone, human review, etc.)
+      3. CLOSE - User wants to close the ticket (close, cancel, no, no thanks, never mind, etc.)
+      4. OUT_OF_SCOPE - User is asking about something unrelated to laptop refresh (password resets, monitor issues, software problems, network issues, etc.)
+      5. UNCLEAR - Response is ambiguous or unclear
+
+      Respond with only the classification: YES, ESCALATE, CLOSE, OUT_OF_SCOPE, or UNCLEAR
+    intent_actions:
+      "YES":
+        next_state: "select_laptop"
+        data_storage:
+          laptop_options_retry_count: 0
+      ESCALATE:
+        response: "Your ticket has been escalated for human review. ticket_escalated"
+        data_storage:
+          ticket_action: "escalated"
+        next_state: "end"
+      CLOSE:
+        response: "Your ticket has been closed. ticket_closed"
+        data_storage:
+          ticket_action: "closed"
+        next_state: "end"
+      OUT_OF_SCOPE:
+        response: "I'm only able to assist with laptop refresh requests. Would you like to proceed with reviewing the available laptop options, escalate the ticket, or close the ticket?"
+        next_state: "waiting_proceed_confirmation"
+      "UNCLEAR":
+        response: "Please let me know if you'd like to proceed with reviewing the available laptop options, escalate the ticket, or close the ticket."
+        next_state: "waiting_proceed_confirmation"
+
+  # State 5: Select Laptop
+  select_laptop:
+    type: "llm_processor"
+    temperature: 0.2
+    uses_mcp_tools: "No"
+    failure_transition: "waiting_proceed_confirmation"
+    prompt: |
+      The user wants to see their laptop options based on {employee_info.response}.
+
+      CRITICAL: DO NOT announce what you are about to do (e.g., "I will search the knowledge base", "Let me get the options"). Execute tool calls silently and present only the results to the user.
+
+      Search the laptop refresh knowledge base and present them with numbered list of all available laptop models based on their region.
+      Get the COMPLETE list of laptops and ALL their specifications available to the user STRICTLY by calling the knowledge_search tool with "what laptops are availble for a user in XXXX: where XXXX is the Employees location.
+
+      CRITICAL: You MUST retrieve and present EVERY specification field for EVERY laptop. The required fields are: Manufacturer, Model, ServiceNow Code, Target User, Cost, Operating System, Display Size, Display Resolution, Graphics Card, Minimum Storage, Weight, Ports, Minimum Processor, Minimum Memory, and Dimensions.
+
+      CRITICAL: Do NOT summarize, abbreviate, or omit ANY specification details. Copy the COMPLETE specifications EXACTLY as retrieved from the knowledge base.
+
+      CRITICAL: Preserve ALL characters and symbols EXACTLY as they appear in the knowledge base, including currency symbols.
+
+      CRITICAL: Do NOT convert or substitute the ¥ symbol (Chinese Yuan) to ₩ (Korean Won) or any other currency symbol.
+
+      CRITICAL: Only show laptops for their region. Do NOT show laptops from other regions. Do NOT use outside knowledge. Do NOT invent information.
+
+      CRITICAL ABSOLUTE PROHIBITION: Do NOT include any laptop model that does not appear verbatim in the knowledge base query result. Do NOT substitute, replace, or add any laptop from your training knowledge. If a laptop model is not explicitly returned by the knowledge base tool, it MUST NOT appear in your response.
+
+      Use this exact format for each laptop:
+
+      1. Model: XXXXX - ServiceNow Code: XXXXX
+      - Manufacturer: XXXXX
+      - Target User: XXXXX
+      - Cost: XXXXX
+      - Operating System: XXXXX
+      - Display Size: XXXXX
+      - Display Resolution: XXXXX
+      - Graphics Card: XXXXX
+      - Minimum Storage: XXXXX
+      - Weight: XXXXX
+      - Ports: XXXXX
+      - Minimum Processor: XXXXX
+      - Minimum Memory: XXXXX
+      - Dimensions: XXXXX
+
+      Ask them to choose one specific laptop.
+    transitions:
+      success: "validate_laptop_options"
+    data_storage:
+      laptop_options: "llm_response"
+
+  # State 5a: Validate Laptop Options Response
+  validate_laptop_options:
+    type: "llm_processor"
+    temperature: 0.1
+    uses_tools: "No"
+    suppress_response: true
+    failure_transition: "waiting_proceed_confirmation"
+    prompt: |
+      Think step by step and use no tools
+      Analyze this laptop options response: "{laptop_options.response}"
+
+      Determine if the response contains actual laptop options or if it's an error/announcement message.
+
+      Check:
+      1. Does the response contain multiple laptop models with specifications?
+      2. Is this actual laptop data (not "I will search...", "Let me get...", error messages, or apologies)?
+
+      If the response contains actual laptop options with specifications, respond: VALID
+      If the response is an announcement, error message, or doesn't contain actual laptop data, respond: INVALID
+
+      Respond with only one word: VALID or INVALID
+    response_analysis:
+      conditions:
+        - name: "valid_options"
+          trigger_phrases: ["VALID"]
+          actions:
+            - type: "set_field"
+              field_name: "laptop_options_retry_count"
+              value: 0
+            - type: "add_message"
+              message: "{laptop_options.response}"
+            - type: "transition"
+              target: "waiting_laptop_selection"
+        - name: "invalid_options_retry"
+          trigger_phrases: ["INVALID"]
+          check_field: "laptop_options_retry_count"
+          check_value_less_than: 5
+          actions:
+            - type: "increment_field"
+              field_name: "laptop_options_retry_count"
+            - type: "transition"
+              target: "select_laptop"
+        - name: "invalid_options_max_retries"
+          trigger_phrases: ["INVALID"]
+          actions:
+            - type: "add_message"
+              message: "I'm having trouble retrieving the laptop options from the knowledge base. Please try again later or contact IT support for assistance."
+            - type: "transition"
+              target: "end"
+      default_transition: "select_laptop"
+
+  # State 6: Waiting for Laptop Selection
+  waiting_laptop_selection:
+    type: "waiting"
+    transitions:
+      user_input: "classify_laptop_selection"
+
+  # State 6a: Classify Laptop Selection
+  classify_laptop_selection:
+    type: "intent_classifier"
+    temperature: 0.2
+    uses_tools: "No"
+    failure_transition: "waiting_laptop_selection"
+    intent_prompt: |
+      The user said: "{user_input}"
+
+      Based on the laptop options "{laptop_options.response}", determine their intent:
+      - VALID_SELECTION: User mentioned a specific laptop model, number, or clear selection
+      - ESCALATE: User wants to escalate the ticket (escalate, request exception, speak to someone, human review, etc.)
+      - CLOSE: User wants to close the ticket (close, cancel, never mind, etc.)
+      - OUT_OF_SCOPE: User is asking about something unrelated to laptop refresh (password resets, monitor issues, software problems, network issues, etc.)
+      - INVALID_SELECTION: User's choice is clearly invalid or nonsensical
+      - UNCLEAR: User's response is unclear or doesn't contain a laptop selection
+
+      Respond with only: VALID_SELECTION, ESCALATE, CLOSE, OUT_OF_SCOPE, INVALID_SELECTION, or UNCLEAR
+    intent_actions:
+      ESCALATE:
+        response: "Your ticket has been escalated for human review. ticket_escalated"
+        data_storage:
+          ticket_action: "escalated"
+        next_state: "end"
+      CLOSE:
+        response: "Your ticket has been closed. ticket_closed"
+        data_storage:
+          ticket_action: "closed"
+        next_state: "end"
+      OUT_OF_SCOPE:
+        response: "I'm only able to assist with laptop refresh requests. Please select one of the laptop options shown above, or let me know if you'd like to escalate or close the ticket."
+        next_state: "waiting_laptop_selection"
+      "VALID_SELECTION":
+        next_state: "confirm_laptop_selection"
+        data_storage:
+          selected_laptop: "{user_input}"
+      "INVALID_SELECTION":
+        response: "I don't see that option in the available laptop list. Please choose one of the specific laptop models I showed you earlier."
+        next_state: "waiting_laptop_selection"
+      "UNCLEAR":
+        response: "Please specify which laptop model you'd like to select from the options I provided."
+        next_state: "waiting_laptop_selection"
+
+  # State 6b: Confirm Laptop Selection with Full Details
+  confirm_laptop_selection:
+    type: "llm_processor"
+    temperature: 0.2
+    uses_tools: "No"
+    failure_transition: "waiting_laptop_selection"
+    prompt: |
+      The user selected: "{selected_laptop}"
+
+      From the following laptop options, find the details for the user's selection and provide them with the complete specifications:
+
+      {laptop_options.response}
+
+      CRITICAL: Do NOT create a ticket number. Do NOT mention any ticket numbers. Do NOT generate placeholder ticket numbers. No ticket has been created yet.
+
+      Then ask them to confirm that is the correct laptop and that they would like to send this ticket to their manager for approval. CRITICAL do not ask for any information other than if they would like to send the ticket to their manager for approval.
+    transitions:
+      success: "waiting_manager_confirmation"
+    data_storage:
+      selected_laptop_details: "llm_response"
+
+  # State 7: Waiting for Manager Approval Confirmation
+  waiting_manager_confirmation:
+    type: "waiting"
+    transitions:
+      user_input: "classify_manager_confirmation"
+
+  # State 7a: Classify Manager Approval Confirmation
+  classify_manager_confirmation:
+    type: "intent_classifier"
+    temperature: 0.2
+    uses_tools: "No"
+    failure_transition: "waiting_manager_confirmation"
+    intent_prompt: |
+      The user was asked if they want to send this ticket to their manager for approval. They responded: "{user_input}"
+
+      Classify their response as one of the following:
+      1. YES - User wants to send to manager (yes, proceed, send it, sure, okay, etc.)
+      2. ESCALATE - User wants to escalate the ticket instead (escalate, request exception, speak to someone, human review, etc.)
+      3. CLOSE - User wants to close the ticket (no, cancel, close, stop, never mind, etc.)
+      4. UNCLEAR - Response is ambiguous or unclear
+
+      Respond with only the classification: YES, ESCALATE, CLOSE, or UNCLEAR
+    intent_actions:
+      "YES":
+        next_state: "send_to_manager"
+      ESCALATE:
+        response: "Your ticket has been escalated for human review. ticket_escalated"
+        data_storage:
+          ticket_action: "escalated"
+        next_state: "end"
+      CLOSE:
+        response: "Your ticket has been closed. ticket_closed"
+        data_storage:
+          ticket_action: "closed"
+        next_state: "end"
+      "UNCLEAR":
+        response: "Please let me know if you'd like to send this ticket to your manager for approval (yes/no)."
+        next_state: "waiting_manager_confirmation"
+
+  # State 8: Send to Manager
+  send_to_manager:
+    type: "llm_processor"
+    temperature: 0.1
+    uses_tools: "No"
+    prompt: |
+      Reply with ONLY this exact text and nothing else:
+      Your ticket has been sent to your manager for approval. You will receive updates as your request is reviewed. ticket_complete
+    response_analysis:
+      conditions:
+        - name: "ticket_complete"
+          trigger_phrases: ["ticket_complete"]
+          actions:
+            - type: "set_field"
+              field_name: "ticket_action"
+              value: "complete"
+            - type: "transition"
+              target: "end"
+      default_transition: "end"
+
+  # End state
+  end:
+    type: "terminal"
+    reset_behavior:
+      reset_state: "waiting_for_interaction"
+      clear_data:
+        # System fields
+        - "messages"
+        - "current_state"
+        # Business logic fields
+        - "employee_info"
+        - "laptop_eligibility"
+        - "eligibility_status"
+        - "selected_laptop"
+        - "selected_laptop_details"
+        - "laptop_options"
+        - "ticket_action"
+        # Retry counters
+        - "laptop_options_retry_count"
+        - "eligibility_check_retry_count"
+        # Internal state tracking
+        - "_last_waiting_node"
+        - "_last_processed_human_count"
+        - "_consumed_this_invoke"

--- a/agent-service/config/lg-prompts/ticket-laptop-refresh-lg-prompt-small.yaml
+++ b/agent-service/config/lg-prompts/ticket-laptop-refresh-lg-prompt-small.yaml
@@ -1,0 +1,559 @@
+# State Machine Configuration for Laptop Refresh Ticket Agent
+# Each state defines its behavior, prompts, and transition conditions
+
+# Global settings
+settings:
+  initial_state: "waiting_for_interaction"
+  terminator_env_var: "AGENT_MESSAGE_TERMINATOR"
+  agent_name: "ticket-laptop-refresh"
+  terminal_state: "end"
+  empty_response_retry_count: 5
+
+# State structure definition - completely configurable
+state_schema:
+  # Business logic fields
+  business_fields:
+    employee_info:
+      type: "dict"
+      description: "Employee information from lookup"
+      default: null
+    laptop_eligibility:
+      type: "dict"
+      description: "Laptop refresh eligibility assessment"
+      default: null
+    eligibility_status:
+      type: "string"
+      description: "Eligibility classification result (ELIGIBLE, NOT, UNCLEAR)"
+      default: null
+    selected_laptop:
+      type: "string"
+      description: "User's selected laptop model"
+      default: null
+    selected_laptop_details:
+      type: "dict"
+      description: "Full details of the selected laptop"
+      default: null
+    laptop_options:
+      type: "dict"
+      description: "Available laptop options shown to user"
+      default: null
+    laptop_options_retry_count:
+      type: "integer"
+      description: "Number of times we've retried fetching laptop options"
+      default: 0
+    eligibility_check_retry_count:
+      type: "integer"
+      description: "Number of times we've retried checking eligibility"
+      default: 0
+    ticket_action:
+      type: "string"
+      description: "Terminal ticket action: escalated, closed, or complete"
+      default: null
+
+# State definitions
+states:
+  # Initial waiting state
+  waiting_for_interaction:
+    type: "waiting"
+    transitions:
+      user_input: "lookup_employee"
+
+  # State 1: Lookup Employee Information
+  lookup_employee:
+    type: "llm_processor"
+    temperature: 0.3
+    allowed_tools: [ "get_employee_laptop_info" ]
+    prompt: |
+      You are a helpful laptop refresh assistant.
+
+      CRITICAL: DO NOT announce what you are about to do (e.g., "I will look up your information", "Let me check the database"). Execute tool calls silently and present only the results to the user.
+
+      CRITICAL: Look up the laptop information for the authenticated user by using the get_employee_laptop_info tool.
+
+      CRITICAL: You MUST include ALL laptop information EXACTLY as returned by get_employee_laptop_info. Do NOT summarize, do NOT omit any fields, do NOT reformat. Copy the COMPLETE output including all fields: Employee Name, Employee Location, Laptop Model, Laptop Serial Number, Laptop Purchase Date, Laptop Age, Laptop Warranty Expiry Date, Laptop Warranty.
+
+      CRITICAL: If any values are missing in the tool output, keep them empty - do NOT invent values.
+
+      If the user is not found, explain that their information was not found in the database.
+    transitions:
+      success: "classify_lookup_result"
+    data_storage:
+      employee_info: "llm_response"
+
+  # State 1c: Classify Lookup Result
+  classify_lookup_result:
+    type: "llm_processor"
+    temperature: 0.1
+    allowed_tools: [ "" ]
+    prompt: |
+      Analyze this employee lookup response: "{employee_info.response}"
+
+      Classify the result as SUCCESS, NOT_FOUND, or ERROR:
+      - SUCCESS: if employee information was found (contains details like name, region, laptop model, etc.)
+      - NOT_FOUND: if the employee ID was not found in the database
+      - ERROR: if there was a system error or unclear response
+
+      Respond with only the classification: SUCCESS, NOT_FOUND, or ERROR
+    response_analysis:
+      conditions:
+        - name: "success"
+          trigger_phrases: ["SUCCESS"]
+          actions:
+            - type: "transition"
+              target: "check_eligibility"
+        - name: "not_found"
+          trigger_phrases: ["NOT_FOUND"]
+          actions:
+            - type: "add_message"
+              message: "I'm sorry, your information was not found in our database. Please contact IT support for assistance."
+            - type: "transition"
+              target: "end"
+        - name: "error"
+          trigger_phrases: ["ERROR"]
+          actions:
+            - type: "add_message"
+              message: "I encountered an issue looking up your information. Please try again or contact IT support."
+            - type: "transition"
+              target: "end"
+      default_transition: "end"
+
+  # State 2: Check Eligibility
+  check_eligibility:
+    type: "llm_processor"
+    temperature: 0.4
+    prompt: |
+      You have the employee information: {employee_info.response}
+
+      Search the laptop refresh knowledge base for the company's laptop refresh policy and determine if this employee is eligible for a laptop replacement.
+
+      CRITICAL: Do your calculations and reasoning silently. Do NOT show your work. Do NOT explain the calculation steps. Do NOT show "Now let's calculate..." or "Laptop Age in Months: (6 × 12) + 6 = 78 months" or similar explanations. Only output the final formatted response to the user.
+
+      Steps (perform silently, do not show to user):
+      1. Look up the corporate laptop refresh policy to find the refresh cycle/interval. You MUST retrieve the refresh interval from the knowledge base. Do NOT guess or assume.
+      2. Convert both the laptop age and policy refresh interval to total months: laptop_age_months = (years × 12) + months, policy_months = (policy_years × 12). The laptop is ELIGIBLE if laptop_age_months >= policy_months, otherwise NOT ELIGIBLE. You must do the mathematical comparison correctly. If the laptop age in months is even 1 month less than the policy requirement in months, it is NOT ELIGIBLE.
+
+      Your response to the user must follow this EXACT format:
+
+      First, list all laptop details:
+      - Employee Name: [from employee info]
+      - Employee Location: [from employee info]
+      - Laptop Model: [from employee info]
+      - Laptop Serial Number: [from employee info]
+      - Laptop Purchase Date: [from employee info]
+      - Laptop Age: [from employee info]
+      - Laptop Warranty Expiry Date: [from employee info]
+      - Laptop Warranty: [from employee info]
+
+      Then, state eligibility using EXACTLY one of these formats:
+
+      If ELIGIBLE:
+      Your laptop, a XXXXXXXX, was purchased on 20XX-XX-XX and is currently A years and B months old (X total months). The company's laptop refresh policy states that standard laptops will be refreshed every Y years (Z months) from the date of issuance. Since your laptop is Y years or older (X months >= Z months), you are eligible for a laptop refresh. Would you like to proceed with reviewing the available laptop options for your location?
+
+      If NOT ELIGIBLE:
+      Your laptop, a XXXXXXXX, was purchased on 20XX-XX-XX and is currently A years and B months old (X total months). The company's laptop refresh policy states that standard laptops will be refreshed every Y years (Z months) from the date of issuance. Since your laptop is less than Y years old (X months < Z months), you are not yet eligible for a laptop refresh. You may either escalate this ticket to request an exception, or close the ticket. Which would you prefer?
+
+      CRITICAL: Do NOT include any calculation explanations, reasoning, or "thinking out loud" in your response. Only provide the formatted laptop details and eligibility statement above.
+    transitions:
+      success: "classify_eligibility_result"
+    data_storage:
+      laptop_eligibility: "llm_response"
+
+  # State 2a: Classify Eligibility Result
+  classify_eligibility_result:
+    type: "llm_processor"
+    temperature: 0.1
+    allowed_tools: [ "" ]
+    prompt: |
+      This is the summary of the user's eligibility: "{laptop_eligibility.response}"
+
+      If the response says the user is eligible for a laptop replacement, respond: ELIGIBLE
+      If the response says the user is not eligible, respond: NOT
+      If unclear, respond: UNCLEAR
+
+      Respond with only one word: ELIGIBLE, NOT, or UNCLEAR
+    response_analysis:
+      conditions:
+        - name: "eligible"
+          trigger_phrases: ["ELIGIBLE"]
+          actions:
+            - type: "set_field"
+              field_name: "eligibility_status"
+              value: "ELIGIBLE"
+            - type: "set_field"
+              field_name: "eligibility_check_retry_count"
+              value: 0
+            - type: "add_message"
+              message: "{laptop_eligibility.response}"
+            - type: "transition"
+              target: "waiting_proceed_confirmation"
+        - name: "not_eligible"
+          trigger_phrases: ["NOT"]
+          actions:
+            - type: "set_field"
+              field_name: "eligibility_status"
+              value: "NOT_ELIGIBLE"
+            - type: "set_field"
+              field_name: "eligibility_check_retry_count"
+              value: 0
+            - type: "add_message"
+              message: "{laptop_eligibility.response}"
+            - type: "transition"
+              target: "waiting_ineligible_user_input"
+        - name: "unclear_retry"
+          trigger_phrases: ["UNCLEAR"]
+          check_field: "eligibility_check_retry_count"
+          check_value_less_than: 5
+          actions:
+            - type: "increment_field"
+              field_name: "eligibility_check_retry_count"
+            - type: "transition"
+              target: "check_eligibility"
+        - name: "unclear_max_retries"
+          trigger_phrases: ["UNCLEAR"]
+          actions:
+            - type: "set_field"
+              field_name: "eligibility_status"
+              value: "UNCLEAR"
+            - type: "add_message"
+              message: "I'm having trouble determining your eligibility status. Please contact IT support for further assistance."
+            - type: "transition"
+              target: "end"
+      default_transition: "end"
+
+  # State 3: Waiting for Ineligible User Input
+  waiting_ineligible_user_input:
+    type: "waiting"
+    transitions:
+      user_input: "classify_ineligible_user_intent"
+
+  # State 3a: Classify Ineligible User Intent
+  classify_ineligible_user_intent:
+    type: "intent_classifier"
+    temperature: 0.2
+    allowed_tools: [ "" ]
+    failure_transition: "waiting_ineligible_user_input"
+    intent_prompt: |
+      Analyze the user's message and determine their intent. The user said: "{user_input}"
+
+      Context: This user is NOT currently eligible for a laptop replacement under standard policy. Their only options are to escalate the ticket to request an exception, or to close the ticket.
+
+      Classify the user's intent as one of the following:
+      1. ESCALATE - User wants to escalate the ticket to request an exception (escalate, request exception, speak to someone, human review, etc.)
+      2. CLOSE - User wants to close the ticket (close, cancel, no thanks, never mind, etc.)
+      3. GENERAL_QUESTION - User has questions about the policy or their eligibility
+
+      Respond with only the classification: ESCALATE, CLOSE, or GENERAL_QUESTION
+    intent_actions:
+      ESCALATE:
+        response: "Your ticket has been escalated for human review. ticket_escalated"
+        data_storage:
+          ticket_action: "escalated"
+        next_state: "end"
+      CLOSE:
+        response: "Your ticket has been closed. ticket_closed"
+        data_storage:
+          ticket_action: "closed"
+        next_state: "end"
+      GENERAL_QUESTION:
+        prompt: |
+          Previously retrieved information on laptop eligibility: {laptop_eligibility.response}
+
+          The user said '{user_input}'. This user is NOT currently eligible for a laptop replacement under standard policy. Their only options are to escalate the ticket to request an exception, or to close the ticket. Provide a helpful response about the policy or their eligibility, then remind them of their two options: escalate or close.
+        next_state: "waiting_ineligible_user_input"
+
+  # State 4: Waiting for Proceed Confirmation
+  waiting_proceed_confirmation:
+    type: "waiting"
+    transitions:
+      user_input: "proceed_confirmation"
+
+  # State 4a: Proceed Confirmation
+  proceed_confirmation:
+    type: "intent_classifier"
+    temperature: 0.2
+    allowed_tools: [ "" ]
+    failure_transition: "waiting_proceed_confirmation"
+    intent_prompt: |
+      The user was asked if they want to proceed with reviewing laptop options. They responded: "{user_input}"
+
+      Classify their response as one of the following:
+      1. YES - User wants to proceed (yes, sure, okay, proceed, continue, show me options, etc.)
+      2. ESCALATE - User wants to escalate the ticket (escalate, request exception, speak to someone, human review, etc.)
+      3. CLOSE - User wants to close the ticket (close, cancel, no, no thanks, never mind, etc.)
+      4. OUT_OF_SCOPE - User is asking about something unrelated to laptop refresh (password resets, monitor issues, software problems, network issues, etc.)
+      5. UNCLEAR - Response is ambiguous or unclear
+
+      Respond with only the classification: YES, ESCALATE, CLOSE, OUT_OF_SCOPE, or UNCLEAR
+    intent_actions:
+      "YES":
+        next_state: "select_laptop"
+        data_storage:
+          laptop_options_retry_count: 0
+      ESCALATE:
+        response: "Your ticket has been escalated for human review. ticket_escalated"
+        data_storage:
+          ticket_action: "escalated"
+        next_state: "end"
+      CLOSE:
+        response: "Your ticket has been closed. ticket_closed"
+        data_storage:
+          ticket_action: "closed"
+        next_state: "end"
+      OUT_OF_SCOPE:
+        response: "I'm only able to assist with laptop refresh requests. Would you like to proceed with reviewing the available laptop options, escalate the ticket, or close the ticket?"
+        next_state: "waiting_proceed_confirmation"
+      "UNCLEAR":
+        response: "Please let me know if you'd like to proceed with reviewing the available laptop options, escalate the ticket, or close the ticket."
+        next_state: "waiting_proceed_confirmation"
+
+  # State 5: Select Laptop
+  select_laptop:
+    type: "llm_processor"
+    temperature: 0.2
+    allowed_tools: []
+    failure_transition: "waiting_proceed_confirmation"
+    prompt: |
+      The user wants to see their laptop options based on {employee_info.response}.
+
+      CRITICAL: DO NOT announce what you are about to do (e.g., "I will search the knowledge base", "Let me get the options"). Execute tool calls silently and present only the results to the user.
+
+      Search the laptop refresh knowledge base and present them with numbered list of all available laptop models based on their region.
+      Get the COMPLETE list of laptops and ALL their specifications available to the user STRICTLY by calling the knowledge_search tool with "what laptops are availble for a user in XXXX: where XXXX is the Employees location. 
+
+      CRITICAL: You MUST retrieve and present EVERY specification field for EVERY laptop. The required fields are: Manufacturer, Model, ServiceNow Code, Target User, Cost, Operating System, Display Size, Display Resolution, Graphics Card, Minimum Storage, Weight, Ports, Minimum Processor, Minimum Memory, and Dimensions.
+
+      CRITICAL: Do NOT summarize, abbreviate, or omit ANY specification details. Copy the COMPLETE specifications EXACTLY as retrieved from the knowledge base.
+
+      CRITICAL: Preserve ALL characters and symbols EXACTLY as they appear in the knowledge base, including currency symbols.
+
+      CRITICAL: Do NOT convert or substitute the ¥ symbol (Chinese Yuan) to ₩ (Korean Won) or any other currency symbol.
+
+      CRITICAL: Only show laptops for their region. Do NOT show laptops from other regions. Do NOT use outside knowledge. Do NOT invent information.
+
+      CRITICAL ABSOLUTE PROHIBITION: Do NOT include any laptop model that does not appear verbatim in the knowledge base query result. Do NOT substitute, replace, or add any laptop from your training knowledge. If a laptop model is not explicitly returned by the knowledge base tool, it MUST NOT appear in your response.
+
+      Use this exact format for each laptop:
+
+      1. Model: XXXXX - ServiceNow Code: XXXXX
+      - Manufacturer: XXXXX
+      - Target User: XXXXX
+      - Cost: XXXXX
+      - Operating System: XXXXX
+      - Display Size: XXXXX
+      - Display Resolution: XXXXX
+      - Graphics Card: XXXXX
+      - Minimum Storage: XXXXX
+      - Weight: XXXXX
+      - Ports: XXXXX
+      - Minimum Processor: XXXXX
+      - Minimum Memory: XXXXX
+      - Dimensions: XXXXX
+
+      Ask them to choose one specific laptop.
+    transitions:
+      success: "validate_laptop_options"
+    data_storage:
+      laptop_options: "llm_response"
+
+  # State 5a: Validate Laptop Options Response
+  validate_laptop_options:
+    type: "llm_processor"
+    temperature: 0.1
+    allowed_tools: [ "" ]
+    suppress_response: true
+    failure_transition: "waiting_proceed_confirmation"
+    prompt: |
+      Analyze this laptop options response: "{laptop_options.response}"
+
+      Determine if the response contains actual laptop options or if it's an error/announcement message.
+
+      Check:
+      1. Does the response contain multiple laptop models with specifications?
+      2. Is this actual laptop data (not "I will search...", "Let me get...", error messages, or apologies)?
+
+      If the response contains actual laptop options with specifications, respond: VALID
+      If the response is an announcement, error message, or doesn't contain actual laptop data, respond: INVALID
+
+      Respond with only one word: VALID or INVALID
+    response_analysis:
+      conditions:
+        - name: "valid_options"
+          trigger_phrases: ["VALID"]
+          actions:
+            - type: "set_field"
+              field_name: "laptop_options_retry_count"
+              value: 0
+            - type: "add_message"
+              message: "{laptop_options.response}"
+            - type: "transition"
+              target: "waiting_laptop_selection"
+        - name: "invalid_options_retry"
+          trigger_phrases: ["INVALID"]
+          check_field: "laptop_options_retry_count"
+          check_value_less_than: 5
+          actions:
+            - type: "increment_field"
+              field_name: "laptop_options_retry_count"
+            - type: "transition"
+              target: "select_laptop"
+        - name: "invalid_options_max_retries"
+          trigger_phrases: ["INVALID"]
+          actions:
+            - type: "add_message"
+              message: "I'm having trouble retrieving the laptop options from the knowledge base. Please try again later or contact IT support for assistance."
+            - type: "transition"
+              target: "end"
+      default_transition: "select_laptop"
+
+  # State 6: Waiting for Laptop Selection
+  waiting_laptop_selection:
+    type: "waiting"
+    transitions:
+      user_input: "classify_laptop_selection"
+
+  # State 6a: Classify Laptop Selection
+  classify_laptop_selection:
+    type: "intent_classifier"
+    temperature: 0.2
+    allowed_tools: [ "" ]
+    failure_transition: "waiting_laptop_selection"
+    intent_prompt: |
+      The user said: "{user_input}"
+
+      Based on the laptop options "{laptop_options.response}", determine their intent:
+      - VALID_SELECTION: User mentioned a specific laptop model, number, or clear selection
+      - ESCALATE: User wants to escalate the ticket (escalate, request exception, speak to someone, human review, etc.)
+      - CLOSE: User wants to close the ticket (close, cancel, never mind, etc.)
+      - OUT_OF_SCOPE: User is asking about something unrelated to laptop refresh (password resets, monitor issues, software problems, network issues, etc.)
+      - INVALID_SELECTION: User's choice is clearly invalid or nonsensical
+      - UNCLEAR: User's response is unclear or doesn't contain a laptop selection
+
+      Respond with only: VALID_SELECTION, ESCALATE, CLOSE, OUT_OF_SCOPE, INVALID_SELECTION, or UNCLEAR
+    intent_actions:
+      ESCALATE:
+        response: "Your ticket has been escalated for human review. ticket_escalated"
+        data_storage:
+          ticket_action: "escalated"
+        next_state: "end"
+      CLOSE:
+        response: "Your ticket has been closed. ticket_closed"
+        data_storage:
+          ticket_action: "closed"
+        next_state: "end"
+      OUT_OF_SCOPE:
+        response: "I'm only able to assist with laptop refresh requests. Please select one of the laptop options shown above, or let me know if you'd like to escalate or close the ticket."
+        next_state: "waiting_laptop_selection"
+      "VALID_SELECTION":
+        next_state: "confirm_laptop_selection"
+        data_storage:
+          selected_laptop: "{user_input}"
+      "INVALID_SELECTION":
+        response: "I don't see that option in the available laptop list. Please choose one of the specific laptop models I showed you earlier."
+        next_state: "waiting_laptop_selection"
+      "UNCLEAR":
+        response: "Please specify which laptop model you'd like to select from the options I provided."
+        next_state: "waiting_laptop_selection"
+
+  # State 6b: Confirm Laptop Selection with Full Details
+  confirm_laptop_selection:
+    type: "llm_processor"
+    temperature: 0.2
+    failure_transition: "waiting_laptop_selection"
+    prompt: |
+      The user selected: "{selected_laptop}"
+
+      From the following laptop options, find the details for the user's selection and provide them with the complete specifications:
+
+      {laptop_options.response}
+
+      CRITICAL: Do NOT create a ticket number. Do NOT mention any ticket numbers. Do NOT generate placeholder ticket numbers. No ticket has been created yet.
+
+      Then ask them to confirm that is the correct laptop and that they would like to send this ticket to their manager for approval. CRITICAL do not ask for any information other than if they would like to send the ticket to their manager for approval.
+    transitions:
+      success: "waiting_manager_confirmation"
+    data_storage:
+      selected_laptop_details: "llm_response"
+
+  # State 7: Waiting for Manager Approval Confirmation
+  waiting_manager_confirmation:
+    type: "waiting"
+    transitions:
+      user_input: "classify_manager_confirmation"
+
+  # State 7a: Classify Manager Approval Confirmation
+  classify_manager_confirmation:
+    type: "intent_classifier"
+    temperature: 0.2
+    allowed_tools: [ "" ]
+    failure_transition: "waiting_manager_confirmation"
+    intent_prompt: |
+      The user was asked if they want to send this ticket to their manager for approval. They responded: "{user_input}"
+
+      Classify their response as one of the following:
+      1. YES - User wants to send to manager (yes, proceed, send it, sure, okay, etc.)
+      2. ESCALATE - User wants to escalate the ticket instead (escalate, request exception, speak to someone, human review, etc.)
+      3. CLOSE - User wants to close the ticket (no, cancel, close, stop, never mind, etc.)
+      4. UNCLEAR - Response is ambiguous or unclear
+
+      Respond with only the classification: YES, ESCALATE, CLOSE, or UNCLEAR
+    intent_actions:
+      "YES":
+        next_state: "send_to_manager"
+      ESCALATE:
+        response: "Your ticket has been escalated for human review. ticket_escalated"
+        data_storage:
+          ticket_action: "escalated"
+        next_state: "end"
+      CLOSE:
+        response: "Your ticket has been closed. ticket_closed"
+        data_storage:
+          ticket_action: "closed"
+        next_state: "end"
+      "UNCLEAR":
+        response: "Please let me know if you'd like to send this ticket to your manager for approval (yes/no)."
+        next_state: "waiting_manager_confirmation"
+
+  # State 8: Send to Manager
+  send_to_manager:
+    type: "llm_processor"
+    temperature: 0.1
+    allowed_tools: [ "" ]
+    prompt: |
+      Reply with ONLY this exact text and nothing else:
+      Your ticket has been sent to your manager for approval. You will receive updates as your request is reviewed. ticket_complete
+    response_analysis:
+      conditions:
+        - name: "ticket_complete"
+          trigger_phrases: ["ticket_complete"]
+          actions:
+            - type: "set_field"
+              field_name: "ticket_action"
+              value: "complete"
+            - type: "transition"
+              target: "end"
+      default_transition: "end"
+
+  # End state
+  end:
+    type: "terminal"
+    reset_behavior:
+      reset_state: "waiting_for_interaction"
+      clear_data:
+        # System fields
+        - "messages"
+        - "current_state"
+        # Business logic fields
+        - "employee_info"
+        - "laptop_eligibility"
+        - "eligibility_status"
+        - "selected_laptop"
+        - "selected_laptop_details"
+        - "laptop_options"
+        - "ticket_action"
+        # Retry counters
+        - "laptop_options_retry_count"
+        - "eligibility_check_retry_count"
+        # Internal state tracking
+        - "_last_waiting_node"
+        - "_last_processed_human_count"
+        - "_consumed_this_invoke"

--- a/agent-service/config/lg-prompts/ticket-routing.yaml
+++ b/agent-service/config/lg-prompts/ticket-routing.yaml
@@ -1,0 +1,85 @@
+# State Machine Configuration for Routing Agent
+# Simple routing logic to identify user intent and direct to appropriate specialist
+
+# Global settings
+settings:
+  initial_state: "waiting_for_ticket"
+  terminator_env_var: "AGENT_MESSAGE_TERMINATOR"
+  agent_name: "ticket-review-agent"
+  terminal_state: "end"
+  empty_response_retry_count: 5
+
+# State structure definition
+state_schema:
+  business_fields:
+    routing_decision:
+      type: "string"
+      default: null
+      # Field to store the routing decision for session manager to detect
+
+# State definitions
+states:
+  waiting_for_ticket:
+    type: "waiting"
+    transitions:
+      user_input: "classify_user_intent"
+
+  classify_user_intent:
+    type: "llm_processor"
+    temperature: 0.1  # Very deterministic for classification
+    failure_transition: "classify_user_intent"
+    prompt: |
+      You are an agent that reviews new tickets to figure out if the ticket is related to a request to refresh the user's laptop. Be helpful, friendly, and efficient in determining their needs.
+
+      The user said: "{last_user_message}"
+
+      Analyze their request and determine what they need help with:
+
+      1. LAPTOP_REFRESH - User wants help with laptop refresh, replacement, new laptop, laptop upgrade, hardware refresh. Also includes requests that just say "refresh" or similar terms.
+      2. OTHER - User needs help with something else or request is unclear
+
+      Examples of LAPTOP_REFRESH requests:
+      - "I need a new laptop"
+      - "laptop refresh"
+      - "refresh"
+      - "I want to refresh my laptop"
+      - "hardware refresh"
+
+      Respond with exactly one of: LAPTOP_REFRESH or OTHER
+    response_analysis:
+      conditions:
+        - name: "laptop_refresh"
+          trigger_phrases: ["LAPTOP_REFRESH"]
+          actions:
+            - type: "set_field"
+              field_name: "routing_decision"
+              value: "ticket-laptop-refresh"
+            - type: "add_message"
+              message: "laptop-refresh"
+            - type: "transition"
+              target: "end"
+        - name: "other_request"
+          trigger_phrases: ["OTHER"]
+          actions:
+            - type: "transition"
+              target: "handle_other_request"
+      default_transition: "handle_other_request"
+
+  # State 3: Handle Other/Unclear Requests
+  handle_other_request:
+    type: "llm_processor"
+    temperature: 0.3
+    failure_transition: "end"
+    prompt: |
+      The user said: "{last_user_message}"
+
+      Reply ONLY with: Your ticket has been escalated for human review
+
+    transitions:
+      success: "end"
+
+  # End state
+  end:
+    type: "terminal"
+    # No reset_behavior - routing agent should not auto-reset
+    # Session manager will handle routing to specialist agent or create new session if needed

--- a/agent-service/src/agent_service/session_manager.py
+++ b/agent-service/src/agent_service/session_manager.py
@@ -1,6 +1,7 @@
 """Session Management for Agent Service."""
 
 import logging
+import os
 import uuid
 from datetime import datetime, timezone
 from typing import Any, Optional, cast
@@ -45,7 +46,7 @@ class ResponsesSessionManager(BaseSessionManager):
     Used by Responses API for full conversation state management.
     """
 
-    ROUTING_AGENT_NAME = "routing-agent"
+    ROUTING_AGENT_NAME = os.environ.get("DEFAULT_AGENT_ID", "routing-agent")
 
     def __init__(
         self,

--- a/evaluations/flows/ticket_laptop_refresh/conversations/escalate-mid-flow.json
+++ b/evaluations/flows/ticket_laptop_refresh/conversations/escalate-mid-flow.json
@@ -1,0 +1,21 @@
+{
+    "metadata": {
+        "authoritative_user_id": "david.chen@company.com",
+        "description": "Eligible user explicitly requests escalation after seeing laptop options — tests CRITICAL STOP CONDITION mid-flow",
+        "use_first_message_as_initial": true
+    },
+    "conversation": [
+        {
+            "role": "user",
+            "content": "I would like to refresh my laptop"
+        },
+        {
+            "role": "user",
+            "content": "yes, show me the laptop options"
+        },
+        {
+            "role": "user",
+            "content": "please escalate this ticket, I want a human to handle it"
+        }
+    ]
+}

--- a/evaluations/flows/ticket_laptop_refresh/conversations/not-eligible-close.json
+++ b/evaluations/flows/ticket_laptop_refresh/conversations/not-eligible-close.json
@@ -1,0 +1,17 @@
+{
+    "metadata": {
+        "authoritative_user_id": "john.doe@company.com",
+        "description": "Not eligible user (laptop ~24 months old) chooses to close the ticket",
+        "use_first_message_as_initial": true
+    },
+    "conversation": [
+        {
+            "role": "user",
+            "content": "I would like to refresh my laptop"
+        },
+        {
+            "role": "user",
+            "content": "close the ticket"
+        }
+    ]
+}

--- a/evaluations/flows/ticket_laptop_refresh/conversations/not-eligible-escalate.json
+++ b/evaluations/flows/ticket_laptop_refresh/conversations/not-eligible-escalate.json
@@ -1,0 +1,17 @@
+{
+    "metadata": {
+        "authoritative_user_id": "john.doe@company.com",
+        "description": "Not eligible user (laptop ~24 months old) chooses to escalate for an exception",
+        "use_first_message_as_initial": true
+    },
+    "conversation": [
+        {
+            "role": "user",
+            "content": "I would like to refresh my laptop"
+        },
+        {
+            "role": "user",
+            "content": "I'd like to escalate and request an exception"
+        }
+    ]
+}

--- a/evaluations/flows/ticket_laptop_refresh/conversations/out-of-scope-close.json
+++ b/evaluations/flows/ticket_laptop_refresh/conversations/out-of-scope-close.json
@@ -1,0 +1,25 @@
+{
+    "metadata": {
+        "authoritative_user_id": "yuki.tanaka@company.com",
+        "description": "User asks out-of-scope questions (password reset, monitor) — agent redirects each time, then user closes the ticket",
+        "use_first_message_as_initial": true
+    },
+    "conversation": [
+        {
+            "role": "user",
+            "content": "I would like to refresh laptop"
+        },
+        {
+            "role": "user",
+            "content": "actually can you help me reset my password? I'm locked out"
+        },
+        {
+            "role": "user",
+            "content": "ok what about my external monitor, it stopped working yesterday"
+        },
+        {
+            "role": "user",
+            "content": "close the ticket"
+        }
+    ]
+}

--- a/evaluations/flows/ticket_laptop_refresh/conversations/success-flow-1.json
+++ b/evaluations/flows/ticket_laptop_refresh/conversations/success-flow-1.json
@@ -1,12 +1,13 @@
 {
     "metadata": {
         "authoritative_user_id": "alice.johnson@company.com",
-        "description": "Successful laptop refresh flow"
+        "description": "Successful laptop refresh flow",
+        "use_first_message_as_initial": true
     },
     "conversation": [
         {
             "role": "user",
-            "content": "refresh"
+            "content": "I would like to refresh my laptop"
         },
         {
             "role": "user",

--- a/evaluations/flows/ticket_laptop_refresh/conversations/success-flow-inline-select-with-send.json
+++ b/evaluations/flows/ticket_laptop_refresh/conversations/success-flow-inline-select-with-send.json
@@ -1,0 +1,25 @@
+{
+    "metadata": {
+        "authoritative_user_id": "oliver.smith@company.com",
+        "description": "Eligible user selects a laptop and requests manager send in the same message — agent must still ask for confirmation separately before sending",
+        "use_first_message_as_initial": true
+    },
+    "conversation": [
+        {
+            "role": "user",
+            "content": "I would like to refresh my laptop"
+        },
+        {
+            "role": "user",
+            "content": "yes, show me the available options"
+        },
+        {
+            "role": "user",
+            "content": "I'll take option 1, please send it to my manager for approval"
+        },
+        {
+            "role": "user",
+            "content": "yes"
+        }
+    ]
+}

--- a/evaluations/flows/ticket_laptop_refresh/flow.py
+++ b/evaluations/flows/ticket_laptop_refresh/flow.py
@@ -4,6 +4,8 @@ from typing import List
 
 FLOW_NAME: str = "ticket_laptop_refresh"
 DEFAULT_TEST_SCRIPT: str = "chat-responses-request-mgr.py"
+DEFAULT_RESET_CONVERSATION: bool = True
+DEFAULT_SKIP_INITIAL_MESSAGE: bool = True
 KNOWLEDGE_BASE_DIRS: List[str] = ["laptop-refresh"]
 INCLUDE_SNOW_DATA: bool = True
 
@@ -24,15 +26,45 @@ Your responsibilities:
 Note: Providing clear, factual information about potential rejection or additional approvals is sufficient. You do not need to be overly cautionary or repeatedly emphasize warnings. Always confirm with the user before creating tickets."""
 
 
-def get_scenario(use_structured_output: bool) -> tuple[tuple[str, str, str], str, str]:
-    """Return (scenario, expected_outcome, user_description) for conversation generation."""
-    expected_outcome = "They get a Service now ticket number for their refresh request"
+_USER_DESCRIPTION = (
+    "An employee responding to comments on their IT support ticket in a ticketing system. "
+    "Their messages are brief and direct, as typical ticket comments — for example: 'requesting a laptop refresh', "
+    "'please show me the options', 'option 3', 'yes proceed' — not conversational chat messages. "
+    "When selecting from a numbered list of options, the employee selects option {option_number} from the list. "
+    "The employee responds directly to the agent's most recent question without asking for confirmation "
+    "of information that has already been provided."
+)
 
-    scenario = (
-        "A ticket is created by the user asking to refresh their laptop. An agents responsds on the ticket with their current laptop information and their elligibiblity for a fresh based on the company policy",
-        "If the user is elligible the agent will provide a list of options, the user selects one and the agent will ask if they would like the ticket to be sent to their manager for approval.",
-        "If the user is not elligible the agent will ask if the user would like to close or escalate the ticket.",
-    )
-    user_description = "An employee interacting with an IT self-service agent through a ticket in a ticketing system."
+_SCENARIOS = [
+    (
+        "An employee has submitted a ticket requesting a laptop refresh. The employee opens the conversation by "
+        "requesting a laptop refresh in a short, direct comment. The agent replies with the employee's current laptop "
+        "details and their eligibility status based on company policy. "
+        "The employee responds with short, direct ticket comments and ONLY reacts to what the agent has already said — "
+        "they never select a laptop or take an action before the agent has explicitly presented that option. "
+        "If the agent says they ARE eligible and presents a list of laptops, the employee selects one from the list "
+        "(specifically option {option_number}), "
+        "then confirms when the agent asks before the ticket is sent to their manager for approval. "
+        "If the agent says they are NOT eligible, the employee chooses to escalate the ticket to request an exception.",
+        "The ticket is either routed to the user's manager for approval (if eligible) or escalated for an exception (if not eligible).",
+        _USER_DESCRIPTION,
+    ),
+    (
+        "An employee has submitted a ticket requesting a laptop refresh. The employee opens the conversation by "
+        "requesting a laptop refresh in a short, direct comment. The agent replies with the employee's current laptop "
+        "details and their eligibility status based on company policy. "
+        "The employee responds with short, direct ticket comments and ONLY reacts to what the agent has already said — "
+        "they never select a laptop or take an action before the agent has explicitly presented that option. "
+        "If the agent says they ARE eligible and presents a list of laptops, the employee selects one from the list "
+        "(specifically option {option_number}), "
+        "then confirms when the agent asks before the ticket is sent to their manager for approval. "
+        "If the agent says they are NOT eligible, the employee chooses to close the ticket.",
+        "The ticket is either routed to the user's manager for approval (if eligible) or closed (if not eligible).",
+        _USER_DESCRIPTION,
+    ),
+]
 
-    return scenario, expected_outcome, user_description
+
+def get_scenario(use_structured_output: bool) -> list[tuple[str, str, str]]:
+    """Return a list of (scenario, expected_outcome, user_description) tuples for conversation generation."""
+    return _SCENARIOS

--- a/evaluations/flows/ticket_laptop_refresh/known_bad_conversations/wrong-selection.json
+++ b/evaluations/flows/ticket_laptop_refresh/known_bad_conversations/wrong-selection.json
@@ -10,7 +10,7 @@
     },
     {
       "role": "assistant",
-      "content": "Your laptop, a ThinkPad X1 Carbon, was purchased on 2022-11-10 and is currently 2 years and 11 months old. The company's laptop refresh policy states that standard laptops will be refreshed every 3 years from the date of issuance. Since your laptop is less than 3 years old, you are not eligible for a laptop refresh. You may proceed anyway but the request for refresh may require additional approvals or be rejected. Would you like to proceed with reviewing the available laptop options for your location?"
+      "content": "According to the knowledge base, the refresh interval is 3 years.\nHere is your laptop information:\nEmployee Name: Maria Garcia\nEmployee Location: LATAM\nLaptop Model: ThinkPad X1 Carbon\nLaptop Serial Number: TP1C003\nLaptop Purchase Date: 2022-11-10\nLaptop Age: 3 years and 4 months\nLaptop Warranty Expiry Date: 2025-11-10\nLaptop Warranty: Expired\nYour laptop, a ThinkPad X1 Carbon, was purchased on 2022-11-10 and is currently 3 years and 4 months old (40 total months). The company's laptop refresh policy states that standard laptops will be refreshed every 3 years (36 months) from the date of issuance. Since your laptop is 3 years or older (40 months >= 36 months), you are eligible for a laptop refresh. Would you like to proceed with reviewing the available laptop options for your location?"
     },
     {
       "role": "user",

--- a/evaluations/flows/ticket_laptop_refresh/metrics.py
+++ b/evaluations/flows/ticket_laptop_refresh/metrics.py
@@ -83,9 +83,11 @@ def get_metrics(
                 "  - Completely ignore the user's question or request",
                 "  - Provide unrelated information",
                 "  - Fail to address the user's actual need",
+                "CRITICAL: When a user asks an out-of-scope question (e.g., password reset, monitor issue, software problem), a specialist agent that (a) states it can only help with laptop refresh AND (b) offers to escalate or redirect — is FULLY addressing the user's need within its role. This response is 100% RELEVANT. Do NOT mark it as irrelevant or partially irrelevant. Do NOT penalize for not solving the out-of-scope request directly.",
                 "Do NOT mark as irrelevant:",
                 "  - Specialist agent responses that stay within their scope",
                 "  - Asking if the user would like to escalate for out-of-scope questions",
+                "  - Repeating scope boundaries across multiple out-of-scope questions — this is correct behavior, not irrelevance",
             ],
         ),
         ConversationalGEval(
@@ -168,7 +170,8 @@ def get_metrics(
             model=custom_model,
             evaluation_params=[TurnParams.CONTENT, TurnParams.ROLE],
             evaluation_steps=[
-                "Assess if the assistant presents appropriate laptop options based on user location when the user is engaged in the laptop refresh process.",
+                "FIRST: Determine whether the agent found the user NOT ELIGIBLE for a laptop refresh. If the agent explicitly stated the user is not eligible and offered to escalate or close the ticket instead of presenting laptop options, The agent behavior is PERFECT for this metric. STOP HERE. Do NOT evaluate any further criteria. Do NOT penalize for the absence of laptop options.",
+                "If the user WAS eligible: assess if the assistant presents appropriate laptop options based on user location.",
                 "Evaluate if laptop specifications are clearly and completely presented.",
                 "Check if the assistant guides the user through selection process effectively.",
                 "IGNORE any portions of the conversation involving:",
@@ -263,7 +266,9 @@ def get_metrics(
             evaluation_params=[TurnParams.CONTENT, TurnParams.ROLE],
             evaluation_steps=(
                 [
-                    "First, identify the user's location from the conversation (NA, EMEA, APAC, or LATAM).",
+                    "FIRST: Determine whether the agent found the user NOT ELIGIBLE for a laptop refresh. If the agent explicitly stated the user is not eligible and offered to escalate or close the ticket instead of presenting laptop options, The agent behavior is PERFECT for this metric. STOP HERE. Do NOT evaluate any further criteria. Do NOT penalize for the absence of laptop options.",
+                    "SECOND: Determine if the user asked to escalte or close the ticket. If the user asked to escalate or close the ticket the agent behavior is PERFECT for this metric. STOP HERE. Do NOT evaluate any further criteria. Do NOT penalize for the absence of laptop options.",
+                    "If the user WAS eligible: identify the user's location from the conversation (NA, EMEA, APAC, or LATAM).",
                     "Then, look for where the agent presents laptop options to the user in the conversation.",
                     "Count how many distinct laptop models are presented by the agent in the final laptop presentation. Look for laptop model names like 'MacBook Air M2', 'MacBook Pro 16 M3 Max', 'ThinkPad T14s Gen 5 AMD', 'ThinkPad P16 Gen 2', etc.",
                     "Compare the count of laptop models presented against the total number of laptop models available for that location in the additional context below. For EMEA, there should be exactly 4 laptop models. For NA, APAC, and LATAM, there should also be exactly 4 laptop models each.",
@@ -285,7 +290,8 @@ def get_metrics(
                 ]
                 if validate_full_laptop_details
                 else [
-                    "First, identify the user's location from the conversation (NA, EMEA, APAC, or LATAM).",
+                    "FIRST: Determine whether the agent found the user NOT ELIGIBLE for a laptop refresh. If the agent explicitly stated the user is not eligible and offered to escalate or close the ticket instead of presenting laptop options, The agent behavior is PERFECT for this metric. STOP HERE. Do NOT evaluate any further criteria. Do NOT penalize for the absence of laptop options.",
+                    "If the user WAS eligible: identify the user's location from the conversation (NA, EMEA, APAC, or LATAM).",
                     "Then, look for where the agent presents laptop options to the user in the conversation.",
                     "Count how many distinct laptop models are presented by the agent in the final laptop presentation. Look for laptop model names like 'MacBook Air M2', 'MacBook Pro 16 M3 Max', 'ThinkPad T14s Gen 5 AMD', 'ThinkPad P16 Gen 2', etc.",
                     "Compare the count of laptop models presented against the total number of laptop models available for that location in the additional context below. For EMEA, there should be exactly 4 laptop models. For NA, APAC, and LATAM, there should also be exactly 4 laptop models each.",
@@ -302,12 +308,14 @@ def get_metrics(
             model=custom_model,
             evaluation_params=[TurnParams.CONTENT, TurnParams.ROLE],
             evaluation_steps=[
+                "FIRST: Determine whether the agent found the user NOT ELIGIBLE for a laptop refresh. If the agent explicitly stated the user is not eligible and offered to escalate or close the ticket instead of presenting laptop options, The agent behavior is PERFECT for this metric. STOP HERE. Do NOT evaluate any further criteria. Do NOT penalize for the absence of a laptop selection.",
                 "This metric ONLY checks whether the agent correctly recorded the laptop the user selected. It does not evaluate confirmation, eligibility, or any other part of the conversation.",
-                "Find where the user selects a laptop (e.g., 'I'd like option 3, the Lenovo ThinkPad T14 Gen 4 Intel', 'I'll take the MacBook Air M2', etc.).",
-                "Find where the agent acknowledges or echoes back the selected laptop (e.g., 'You've selected the...', 'I'll proceed with the...', or any statement naming the chosen laptop).",
-                "Verify that the laptop name the agent echoes back matches the laptop the user actually selected.",
-                "PASS this metric if the agent correctly names the laptop the user chose.",
-                "FAIL this metric if the agent names a different laptop than the one the user selected (e.g., user selects 'Lenovo ThinkPad T14 Gen 4 Intel' but agent says 'You've selected the Apple MacBook Air M2').",
+                "Find where the user selects a laptop. The user may select by name (e.g., 'I'll take the MacBook Air M2') OR by number (e.g., '1', 'option 1', 'I'd like option 3'). Both are valid selection methods.",
+                "If the user selected by NUMBER: look at the numbered laptop list the agent presented just before the selection. Find which laptop name corresponds to that number in the list. That is the laptop the user selected.",
+                "Find where the agent acknowledges or echoes back the selected laptop by name (e.g., 'You've selected the...', 'I'll proceed with the...').",
+                "Verify that the laptop name the agent echoes back matches the laptop the user actually selected (whether selected by name or by number).",
+                "PASS this metric if the agent correctly names the laptop corresponding to the user's choice.",
+                "FAIL this metric ONLY if the agent echoes back a DIFFERENT laptop name than the one the user selected (e.g., user selects option 1 which is MacBook Air M2 in the list, but agent says 'You've selected the ThinkPad').",
                 "IMPORTANT: This metric only evaluates the correctness of the selection echo. Do NOT consider whether the laptop was valid, whether confirmation was asked, or any other aspect of the conversation.",
             ],
         ),
@@ -329,6 +337,7 @@ def get_metrics(
                 "If the agent asked for confirmation and the user responded affirmatively, this metric PASSES — regardless of whether the ticket was actually sent afterwards.",
                 "PASS this metric if: the agent asked for confirmation and the user responded affirmatively.",
                 "PASS this metric if: the ticket was never sent to the manager at all (nothing to have skipped confirmation on — Process Completion will catch the missing action).",
+                "PASS this metric if: the ticket was ESCALATED or CLOSED instead of sent to a manager — escalation and closure are separate actions that do not require a manager confirmation step.",
                 "FAIL this metric ONLY if: the ticket is explicitly sent to the manager WITHOUT the agent having asked for confirmation first, or before the user responds.",
                 "IMPORTANT: Do NOT require the agent to confirm the ticket was sent. Do NOT fail this metric because the ticket was never sent. Do NOT consider whether the laptop selection was valid or invalid.",
             ],

--- a/evaluations/generator.py
+++ b/evaluations/generator.py
@@ -223,7 +223,9 @@ def _run_worker(
     message_timeout: int = 60,
     use_structured_output: bool = False,
     results_dir: str = "results/conversation_results",
-    flow_scenario: Optional[tuple[str, ...]] = None,
+    flow_scenario: Optional[list[tuple[str, str, str]]] = None,
+    initial_message: Optional[str] = None,
+    skip_initial_message: bool = False,
 ) -> dict[str, Any]:
     """
     Worker function to generate conversations in parallel.
@@ -360,15 +362,20 @@ def _run_worker(
                 test_script=test_script,
                 reset_conversation=reset_conversation,
                 message_timeout=message_timeout,
+                initial_message=initial_message,
+                skip_initial_message=skip_initial_message,
             )
 
             # Start session
             worker_client.start_session()
-            worker_client.get_agent_initialization()
+            init_response = worker_client.get_agent_initialization()
 
             # Create conversation golden
             if flow_scenario is not None:
-                scenario, expected_outcome, user_description = flow_scenario
+                scenario, expected_outcome, user_description = random.choice(flow_scenario)
+                option_number = random.randint(1, 4)
+                scenario = scenario.format(option_number=option_number)
+                user_description = user_description.format(option_number=option_number)
                 conversation_golden = ConversationalGolden(
                     scenario=scenario,
                     expected_outcome=expected_outcome,
@@ -413,6 +420,12 @@ def _run_worker(
                 conversation = _convert_test_case_to_conversation_format(
                     test_case, conversation_user_id
                 )
+                # Prepend the initial message exchange if reset was used
+                if reset_conversation and initial_message and init_response and conversation.get("conversation"):
+                    conversation["conversation"] = [
+                        {"role": "user", "content": initial_message},
+                        {"role": "assistant", "content": init_response},
+                    ] + conversation["conversation"]
                 if conversation.get("conversation"):
                     base_filename = (
                         f"generated_flow_worker{worker_id}_{test_case_count}"
@@ -523,9 +536,12 @@ if __name__ == "__main__":
     args = _parse_arguments()
 
     # Resolve flow-specific settings if --flow is provided
-    flow_scenario: Optional[tuple[str, ...]] = None
+    flow_scenario: Optional[list[tuple[str, str, str]]] = None
     results_dir = "results/conversation_results"
     test_script = args.test_script
+    reset_conversation = args.reset_conversation
+    initial_message: Optional[str] = None
+    skip_initial_message: bool = False
 
     if args.flow:
         import sys as _sys
@@ -540,6 +556,9 @@ if __name__ == "__main__":
         flow_paths.results_conv_dir.mkdir(parents=True, exist_ok=True)
         results_dir = str(flow_paths.results_conv_dir)
         test_script = getattr(flow_module, "DEFAULT_TEST_SCRIPT", args.test_script)
+        reset_conversation = args.reset_conversation or getattr(flow_module, "DEFAULT_RESET_CONVERSATION", False)
+        initial_message = getattr(flow_module, "DEFAULT_INITIAL_MESSAGE", None)
+        skip_initial_message = getattr(flow_module, "DEFAULT_SKIP_INITIAL_MESSAGE", False)
         flow_scenario = flow_module.get_scenario(args.use_structured_output)
         logger.info(f"Using flow '{args.flow}': saving to {results_dir}")
 
@@ -597,11 +616,13 @@ if __name__ == "__main__":
                 args.num_conversations,
                 args.max_turns,
                 test_script,
-                args.reset_conversation,
+                reset_conversation,
                 args.message_timeout,
                 args.use_structured_output,
                 results_dir,
                 flow_scenario,
+                initial_message,
+                skip_initial_message,
             )
             for i in range(args.concurrency)
         ]

--- a/evaluations/generator.py
+++ b/evaluations/generator.py
@@ -372,7 +372,9 @@ def _run_worker(
 
             # Create conversation golden
             if flow_scenario is not None:
-                scenario, expected_outcome, user_description = random.choice(flow_scenario)
+                scenario, expected_outcome, user_description = random.choice(
+                    flow_scenario
+                )
                 option_number = random.randint(1, 4)
                 scenario = scenario.format(option_number=option_number)
                 user_description = user_description.format(option_number=option_number)
@@ -421,7 +423,12 @@ def _run_worker(
                     test_case, conversation_user_id
                 )
                 # Prepend the initial message exchange if reset was used
-                if reset_conversation and initial_message and init_response and conversation.get("conversation"):
+                if (
+                    reset_conversation
+                    and initial_message
+                    and init_response
+                    and conversation.get("conversation")
+                ):
                     conversation["conversation"] = [
                         {"role": "user", "content": initial_message},
                         {"role": "assistant", "content": init_response},
@@ -556,9 +563,13 @@ if __name__ == "__main__":
         flow_paths.results_conv_dir.mkdir(parents=True, exist_ok=True)
         results_dir = str(flow_paths.results_conv_dir)
         test_script = getattr(flow_module, "DEFAULT_TEST_SCRIPT", args.test_script)
-        reset_conversation = args.reset_conversation or getattr(flow_module, "DEFAULT_RESET_CONVERSATION", False)
+        reset_conversation = args.reset_conversation or getattr(
+            flow_module, "DEFAULT_RESET_CONVERSATION", False
+        )
         initial_message = getattr(flow_module, "DEFAULT_INITIAL_MESSAGE", None)
-        skip_initial_message = getattr(flow_module, "DEFAULT_SKIP_INITIAL_MESSAGE", False)
+        skip_initial_message = getattr(
+            flow_module, "DEFAULT_SKIP_INITIAL_MESSAGE", False
+        )
         flow_scenario = flow_module.get_scenario(args.use_structured_output)
         logger.info(f"Using flow '{args.flow}': saving to {results_dir}")
 

--- a/evaluations/helpers/openshift_chat_client.py
+++ b/evaluations/helpers/openshift_chat_client.py
@@ -137,10 +137,15 @@ class OpenShiftChatClient:
 
             # After reset, send initial message unless skipped
             if self.skip_initial_message:
-                logger.info("Skipping initial message after reset — caller will send first message")
+                logger.info(
+                    "Skipping initial message after reset — caller will send first message"
+                )
                 return ""
 
-            message = self.initial_message or "please introduce yourself and tell me how you can help"
+            message = (
+                self.initial_message
+                or "please introduce yourself and tell me how you can help"
+            )
             logger.info(f"Sending initial message after reset: {message[:100]}...")
             intro_response = self.send_message(message)
             logger.info(

--- a/evaluations/helpers/openshift_chat_client.py
+++ b/evaluations/helpers/openshift_chat_client.py
@@ -20,6 +20,8 @@ class OpenShiftChatClient:
         deployment_name: str = "deploy/self-service-agent-request-manager",
         test_script: str = "chat-responses-request-mgr.py",
         reset_conversation: bool = False,
+        initial_message: Optional[str] = None,
+        skip_initial_message: bool = False,
         message_timeout: int = 60,
     ):
         """
@@ -30,12 +32,18 @@ class OpenShiftChatClient:
             deployment_name: Name of the OpenShift deployment to connect to
             test_script: Name of the test script to execute (default: "chat-responses-request-mgr.py")
             reset_conversation: If True, send "reset" message after initialization
+            initial_message: Message to send after reset instead of the default introduction prompt.
+                             Only used when reset_conversation is True.
+            skip_initial_message: If True, skip sending any initial message after reset, allowing
+                                  the caller to send the first message. Only used when reset_conversation is True.
             message_timeout: Timeout in seconds for individual message send/response operations (default: 60)
         """
         self.deployment_name = deployment_name
         self.test_script = test_script
         self.authoritative_user_id = authoritative_user_id
         self.reset_conversation = reset_conversation
+        self.initial_message = initial_message
+        self.skip_initial_message = skip_initial_message
         self.message_timeout = message_timeout
         self.process: Optional[subprocess.Popen[str]] = None
         self.session_active = False
@@ -127,11 +135,14 @@ class OpenShiftChatClient:
                 f"Reset response: {reset_response[:100] if reset_response else 'empty'}..."
             )
 
-            # After reset, ask for introduction
-            logger.info("Requesting agent introduction after reset")
-            intro_response = self.send_message(
-                "please introduce yourself and tell me how you can help"
-            )
+            # After reset, send initial message unless skipped
+            if self.skip_initial_message:
+                logger.info("Skipping initial message after reset — caller will send first message")
+                return ""
+
+            message = self.initial_message or "please introduce yourself and tell me how you can help"
+            logger.info(f"Sending initial message after reset: {message[:100]}...")
+            intro_response = self.send_message(message)
             logger.info(
                 f"Introduction response: {intro_response[:100] if intro_response else 'empty'}..."
             )

--- a/evaluations/helpers/run_conversation_flow.py
+++ b/evaluations/helpers/run_conversation_flow.py
@@ -206,7 +206,10 @@ class ConversationFlowTester:
 
                 # Optionally use the first user message as the post-reset initial message
                 initial_message = None
-                if metadata.get("use_first_message_as_initial") and self.reset_conversation:
+                if (
+                    metadata.get("use_first_message_as_initial")
+                    and self.reset_conversation
+                ):
                     initial_message = questions[0]
                     questions = questions[1:]
                     logger.info(
@@ -218,7 +221,9 @@ class ConversationFlowTester:
                 )
 
                 # Run the flow with extracted questions and authoritative_user_id
-                results = self.run_flow(questions, authoritative_user_id, initial_message=initial_message)
+                results = self.run_flow(
+                    questions, authoritative_user_id, initial_message=initial_message
+                )
 
                 # Format results in the new conversation format with metadata
                 formatted_results = {

--- a/evaluations/helpers/run_conversation_flow.py
+++ b/evaluations/helpers/run_conversation_flow.py
@@ -3,7 +3,7 @@
 import json
 import logging
 import os
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from .openshift_chat_client import OpenShiftChatClient
 
@@ -19,6 +19,8 @@ class ConversationFlowTester:
         self,
         test_script: str = "chat-responses-request-mgr.py",
         reset_conversation: bool = False,
+        initial_message: Optional[str] = None,
+        skip_initial_message: bool = False,
     ) -> None:
         """
         Initialize the ConversationFlowTester.
@@ -26,14 +28,23 @@ class ConversationFlowTester:
         Args:
             test_script: Name of the test script to execute (default: "chat-responses-request-mgr.py")
             reset_conversation: If True, send 'reset' message at the start of each conversation
+            initial_message: Message to send after reset instead of the default introduction prompt.
+                             Only used when reset_conversation is True.
+            skip_initial_message: If True, skip sending any initial message after reset, allowing
+                                  the first question to serve as the opening message.
         """
         self.test_script = test_script
         self.reset_conversation = reset_conversation
+        self.initial_message = initial_message
+        self.skip_initial_message = skip_initial_message
         self.conversation_history: list[Any] = []
         self.total_app_tokens = {"input": 0, "output": 0, "total": 0, "calls": 0}
 
     def run_flow(
-        self, questions: list[str], authoritative_user_id: str
+        self,
+        questions: list[str],
+        authoritative_user_id: str,
+        initial_message: Optional[str] = None,
     ) -> List[Dict[str, str]]:
         """
         Run a conversation flow with the given questions.
@@ -58,6 +69,8 @@ class ConversationFlowTester:
             authoritative_user_id,
             test_script=self.test_script,
             reset_conversation=self.reset_conversation,
+            initial_message=initial_message or self.initial_message,
+            skip_initial_message=self.skip_initial_message,
         )
 
         try:
@@ -65,7 +78,13 @@ class ConversationFlowTester:
 
             # First, get the agent initialization message
             agent_init = client.get_agent_initialization()
-            conversation.append({"role": "assistant", "content": agent_init})
+            # If an initial message was sent, record it as the first user turn
+            effective_initial = initial_message or self.initial_message
+            if effective_initial and self.reset_conversation:
+                conversation.append({"role": "user", "content": effective_initial})
+            # Only record agent_init if it's non-empty (skip_initial_message returns "")
+            if agent_init:
+                conversation.append({"role": "assistant", "content": agent_init})
 
             # Then process user questions
             for i, question in enumerate(questions):
@@ -185,12 +204,21 @@ class ConversationFlowTester:
                     logger.warning(f"No user questions found in {filename}")
                     continue
 
+                # Optionally use the first user message as the post-reset initial message
+                initial_message = None
+                if metadata.get("use_first_message_as_initial") and self.reset_conversation:
+                    initial_message = questions[0]
+                    questions = questions[1:]
+                    logger.info(
+                        f"Using first message as initial: {initial_message[:100]}"
+                    )
+
                 logger.info(
                     f"Processing {filename} with {len(questions)} questions using authoritative_user_id: {authoritative_user_id}"
                 )
 
                 # Run the flow with extracted questions and authoritative_user_id
-                results = self.run_flow(questions, authoritative_user_id)
+                results = self.run_flow(questions, authoritative_user_id, initial_message=initial_message)
 
                 # Format results in the new conversation format with metadata
                 formatted_results = {

--- a/evaluations/run_conversations.py
+++ b/evaluations/run_conversations.py
@@ -57,13 +57,19 @@ if __name__ == "__main__":
             flow_module, "DEFAULT_TEST_SCRIPT", "chat-responses-request-mgr.py"
         )
         test_script = args.test_script or default_test_script
+        default_reset_conversation = getattr(
+            flow_module, "DEFAULT_RESET_CONVERSATION", False
+        )
+        reset_conversation = args.reset_conversation or default_reset_conversation
     else:
         # Default mode: existing behavior
         conversations_dir = "conversations_config/conversations"
         output_dir = "results/conversation_results"
         test_script = args.test_script or "chat-responses-request-mgr.py"
+        reset_conversation = args.reset_conversation
 
     tester = ConversationFlowTester(
-        test_script=test_script, reset_conversation=args.reset_conversation
+        test_script=test_script,
+        reset_conversation=reset_conversation,
     )
     tester.run_flows(conversations_dir, output_dir)

--- a/mock-employee-data/src/mock_employee_data/data.py
+++ b/mock-employee-data/src/mock_employee_data/data.py
@@ -34,7 +34,7 @@ MOCK_EMPLOYEE_DATA = {
         "active": "true",
         "laptop_model": "MacBook Pro 14-inch",
         "laptop_serial_number": "MBP14002",
-        "purchase_date": "2023-03-20",
+        "purchase_date": "2024-03-20",
         "warranty_expiry": "2026-03-20",
         "warranty_status": "Active",
         "asset_tag": "ASSET-002",

--- a/test/chat-responses-request-mgr.py
+++ b/test/chat-responses-request-mgr.py
@@ -28,12 +28,14 @@ async def main() -> None:
     parser = argparse.ArgumentParser(description="CLI Chat with Request Manager")
     parser.add_argument("--user-id", help="User ID for the chat session")
     parser.add_argument("--request-manager-url", help="Request Manager URL")
+    parser.add_argument("--initial-message", help="Initial message to send to the agent")
     args = parser.parse_args()
 
     # Use command line args or environment variables
     # Priority: command line arg > USER_ID env var > AUTHORITATIVE_USER_ID env var
     user_id = args.user_id or USER_ID or AUTHORITATIVE_USER_ID
     request_manager_url = args.request_manager_url or REQUEST_MANAGER_URL
+    initial_message = args.initial_message or "please introduce yourself and tell me how you can help"
 
     # Create chat client with optional user_id
     chat_client = CLIChatClient(
@@ -51,12 +53,12 @@ async def main() -> None:
     # Interactive mode: run the chat loop (default)
     if sys.stdin.isatty():
         await chat_client.chat_loop(
-            initial_message="please introduce yourself and tell me how you can help",
+            initial_message=initial_message,
         )
     else:
         # Test mode: use a modified chat loop for test framework
         await chat_client.chat_loop_test_mode(
-            initial_message="please introduce yourself and tell me how you can help",
+            initial_message=initial_message,
         )
 
 

--- a/test/chat-responses-request-mgr.py
+++ b/test/chat-responses-request-mgr.py
@@ -28,14 +28,18 @@ async def main() -> None:
     parser = argparse.ArgumentParser(description="CLI Chat with Request Manager")
     parser.add_argument("--user-id", help="User ID for the chat session")
     parser.add_argument("--request-manager-url", help="Request Manager URL")
-    parser.add_argument("--initial-message", help="Initial message to send to the agent")
+    parser.add_argument(
+        "--initial-message", help="Initial message to send to the agent"
+    )
     args = parser.parse_args()
 
     # Use command line args or environment variables
     # Priority: command line arg > USER_ID env var > AUTHORITATIVE_USER_ID env var
     user_id = args.user_id or USER_ID or AUTHORITATIVE_USER_ID
     request_manager_url = args.request_manager_url or REQUEST_MANAGER_URL
-    initial_message = args.initial_message or "please introduce yourself and tell me how you can help"
+    initial_message = (
+        args.initial_message or "please introduce yourself and tell me how you can help"
+    )
 
     # Create chat client with optional user_id
     chat_client = CLIChatClient(


### PR DESCRIPTION
- fix default agent config so that it can be set with DEFAULT_AGENT_ID_ARG environment variable when deploying.
- add phase 1 ticket agents (review and laptop-refresh) in big,small and scout variants. In phase 1 agents just state what they will do instead of using mcp servers to change ticket state. Evals now pass for multiple runs of 20 for each variant.
- tweak evals to generate conversations correctly for ticket flow.
- tweaks to evals to add options needed to drive conversation in way needed by ticket flow. Should have no effect on default flow.
- add additional predefined conversations to cover additional scenarios
- fix mock data so John Doe is not eligible which was the case before march 20 2026.