### PR TITLE
feat: mitigate ServiceNow ticket creation timeouts APPENG-4787

### DIFF
--- a/.github/workflows/build-and-push-manual.yaml
+++ b/.github/workflows/build-and-push-manual.yaml
@@ -25,7 +25,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  REGISTRY: quay.io/rh-ai-quickstart
+  REGISTRY: quay.io/rh-ee-tgolan
   # uv version must match Makefile UV_VERSION (currently 0.8.9)
   # Update this when UV_VERSION in Makefile changes
   UV_VERSION: "0.8.9"

--- a/.github/workflows/build-and-push-manual.yaml
+++ b/.github/workflows/build-and-push-manual.yaml
@@ -25,7 +25,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  REGISTRY: quay.io/rh-ee-tgolan
+  REGISTRY: quay.io/rh-ai-quickstart
   # uv version must match Makefile UV_VERSION (currently 0.8.9)
   # Update this when UV_VERSION in Makefile changes
   UV_VERSION: "0.8.9"

--- a/mcp-servers/snow/src/snow/servicenow/client.py
+++ b/mcp-servers/snow/src/snow/servicenow/client.py
@@ -177,12 +177,15 @@ class ServiceNowClient:
         if self.laptop_avoid_duplicates or self.laptop_request_limits is not None:
             user_sys_id = params.who_is_this_request_for
             logger.info("Checking for existing open requests", user_sys_id=user_sys_id)
-            existing_requests_result = self.get_open_laptop_requests_for_user(user_sys_id)
+            existing_requests_result = self.get_open_laptop_requests_for_user(
+                user_sys_id
+            )
             if not existing_requests_result["success"]:
                 return existing_requests_result
             existing_requests = existing_requests_result["requests"]
             logger.info(
-                "Found existing open request(s)", existing_requests=len(existing_requests)
+                "Found existing open request(s)",
+                existing_requests=len(existing_requests),
             )
 
         # Step 2: Check if there's already an open request for the same laptop model

--- a/mcp-servers/snow/src/snow/servicenow/client.py
+++ b/mcp-servers/snow/src/snow/servicenow/client.py
@@ -187,10 +187,8 @@ class ServiceNowClient:
 
         # Step 2: Check if there's already an open request for the same laptop model
         current_laptop_model = params.laptop_choices
-        existing_request = (
-            self._has_existing_request_for_laptop_model(
-                existing_requests, current_laptop_model
-            )
+        existing_request = self._has_existing_request_for_laptop_model(
+            existing_requests, current_laptop_model
         )
         if existing_request:
             return {

--- a/mcp-servers/snow/src/snow/servicenow/client.py
+++ b/mcp-servers/snow/src/snow/servicenow/client.py
@@ -551,9 +551,14 @@ class ServiceNowClient:
         # - who_is_this_request_for equals user_sys_id
         # - state is open (typically states 1, 2)
         # - cat_item points to the laptop refresh catalog item
+        # Limit results to avoid timeouts on large tables.
+        # We only need enough to check limits and duplicates.
+        max_results = (self.laptop_request_limits or 10) + 1
         params = {
-            "sysparm_query": f"who_is_this_request_for={user_sys_id}^stateIN1,2^cat_item={self.laptop_refresh_id}",
+            "sysparm_query": f"cat_item={self.laptop_refresh_id}^stateIN1,2^who_is_this_request_for={user_sys_id}",
             "sysparm_fields": "number,variables.laptop_choices,state,request.number",
+            "sysparm_no_count": "true",
+            "sysparm_limit": str(max_results),
         }
 
         try:

--- a/mcp-servers/snow/src/snow/servicenow/client.py
+++ b/mcp-servers/snow/src/snow/servicenow/client.py
@@ -95,7 +95,7 @@ class ServiceNowClient:
 
     def _has_existing_request_for_laptop_model(
         self, existing_requests: List[Dict[str, Any]], laptop_model: str
-    ) -> tuple[bool, Optional[Dict[str, Any]]]:
+    ) -> Optional[Dict[str, Any]]:
         """
         Check if there's already an open request for the same laptop model.
 
@@ -104,13 +104,11 @@ class ServiceNowClient:
             laptop_model: The laptop model to check for.
 
         Returns:
-            Tuple of (bool, Optional[Dict]):
-            - True if existing request found, False otherwise
             - The existing request data if found, None otherwise
         """
         # If avoid_duplicates is disabled, skip the duplicate check entirely
         if not self.laptop_avoid_duplicates:
-            return False, None
+            return None
 
         for request in existing_requests:
             # Extract laptop choice from request - using new sc_req_item format
@@ -129,9 +127,9 @@ class ServiceNowClient:
                 # to maintain interface compatibility with calling code
                 modified_request = request.copy()
                 modified_request["number"] = req_number
-                return True, modified_request
+                return modified_request
 
-        return False, None
+        return None
 
     def _would_exceed_request_limit(
         self, existing_requests: List[Dict[str, Any]]
@@ -189,15 +187,12 @@ class ServiceNowClient:
 
         # Step 2: Check if there's already an open request for the same laptop model
         current_laptop_model = params.laptop_choices
-        has_existing_model_request, existing_request = (
+        existing_request = (
             self._has_existing_request_for_laptop_model(
                 existing_requests, current_laptop_model
             )
         )
-        if has_existing_model_request:
-            assert (
-                existing_request is not None
-            ), "existing_request should not be None when has_existing_model_request is True"
+        if existing_request:
             return {
                 "success": True,
                 "message": f"Existing open request found for the same laptop model: {existing_request.get('number', 'N/A')}",

--- a/mcp-servers/snow/src/snow/servicenow/client.py
+++ b/mcp-servers/snow/src/snow/servicenow/client.py
@@ -172,18 +172,18 @@ class ServiceNowClient:
         """
         logger.info("Opening ServiceNow laptop refresh request")
 
-        # Step 1: Check for existing open requests for this user
-        user_sys_id = params.who_is_this_request_for
-        logger.info("Checking for existing open requests", user_sys_id=user_sys_id)
-
-        existing_requests_result = self.get_open_laptop_requests_for_user(user_sys_id)
-        if not existing_requests_result["success"]:
-            return existing_requests_result
-
-        existing_requests = existing_requests_result["requests"]
-        logger.info(
-            "Found existing open request(s)", existing_requests=len(existing_requests)
-        )
+        # Step 1: Check for existing open requests for this user (only if needed)
+        existing_requests = []
+        if self.laptop_avoid_duplicates or self.laptop_request_limits is not None:
+            user_sys_id = params.who_is_this_request_for
+            logger.info("Checking for existing open requests", user_sys_id=user_sys_id)
+            existing_requests_result = self.get_open_laptop_requests_for_user(user_sys_id)
+            if not existing_requests_result["success"]:
+                return existing_requests_result
+            existing_requests = existing_requests_result["requests"]
+            logger.info(
+                "Found existing open request(s)", existing_requests=len(existing_requests)
+            )
 
         # Step 2: Check if there's already an open request for the same laptop model
         current_laptop_model = params.laptop_choices


### PR DESCRIPTION
Ref: https://issues.redhat.com/browse/APPENG-4787

## Changes
- Improve `get_open_laptop_requests_for_user` to run more efficiently by adding `sysparm_no_count` and `sysparm_limit` query parameters
- Only call `get_open_laptop_requests_for_user` if duplicate checks or ticket limits are enabled
- Simplify `_has_existing_request_for_laptop_model` to return a single response instead of a tuple