### PR TITLE
fix(helm): pin integration-dispatcher to one Uvicorn worker

### DIFF
--- a/guides/PERFORMANCE_SCALING_GUIDE.md
+++ b/guides/PERFORMANCE_SCALING_GUIDE.md
@@ -42,7 +42,7 @@ Asyncio is a great fit for this quickstart as we've seen that most of the time a
 
 ### Quickstart components
 
-Use standard kubernetes scaling techniques. For agent-service, integration-dispatcher, request-manager, you can scale the number of uvicorn workers as well as the number of replicas. For MCP servers (such as snow) the same is true, but special considerations which are covered in a later section. Both the number of workers and number of replicas can be configured in helm/values.yaml. As an example this snippet which is part of the configuration for the agent service sets 4 workers and 2 replicas:
+Use standard kubernetes scaling techniques. For **agent-service** and **request-manager**, you can scale the number of uvicorn workers as well as the number of replicas. **integration-dispatcher** is fixed at **one Uvicorn worker** per pod in the Helm chart (lifespan runs IMAP polling and the outbox publisher; multiple workers would duplicate that work). Scale integration-dispatcher by **replicas** only. For MCP servers (such as snow) the same is true, but special considerations which are covered in a later section. Both the number of workers and number of replicas can be configured in helm/values.yaml. As an example this snippet which is part of the configuration for the agent service sets 4 workers and 2 replicas:
 
 ```
  agentService:
@@ -58,7 +58,7 @@ These are a few documents which may be of interest:
 - [Scalability and performance | OpenShift Container Platform 4.20 Documentation](https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/scalability_and_performance/index)
 - [Capacity management and overcommitment best practices in Red Hat OpenShift](https://www.redhat.com/en/blog/capacity-management-overcommitment-best-practices-openshift)
 
-The quickstart already uses 4 uvicornWorkers for each of the components. If you would like to try out multiple pods for each of the components you can set `REPLICA_COUNT` to set the number of pods to use. For example:
+The quickstart uses 4 uvicornWorkers for agent-service and request-manager by default; integration-dispatcher always uses 1 worker per pod. If you would like to try out multiple pods for each of the components you can set `REPLICA_COUNT` to set the number of pods to use. For example:
 
 ```
 make helm-install-test REPLICA_COUNT=2 ....

--- a/helm/templates/_service-deployment.tpl
+++ b/helm/templates/_service-deployment.tpl
@@ -60,7 +60,11 @@ spec:
         - name: OTEL_EXPORTER_OTLP_ENDPOINT
           value: {{ $context.Values.otelExporter }}
         {{- end }}
-        {{- if $serviceConfig.uvicornWorkers }}
+        {{- if eq $serviceName "integration-dispatcher" }}
+        # Single process only: lifespan runs IMAP + outbox per worker; multi-worker duplicates work.
+        - name: UVICORN_WORKERS
+          value: "1"
+        {{- else if $serviceConfig.uvicornWorkers }}
         - name: UVICORN_WORKERS
           value: {{ $serviceConfig.uvicornWorkers | quote }}
         {{- end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -480,7 +480,6 @@ requestManagement:
   # Integration Dispatcher Service
   integrationDispatcher:
     replicas: 1
-    uvicornWorkers: 4  # Number of uvicorn worker processes for handling concurrent requests
     resources: {}
     # External Access Configuration
     # When enabled, only /slack/* endpoints are externally accessible (path-restricted for security)


### PR DESCRIPTION
Integration-dispatcher runs IMAP + outbox in **lifespan**; multiple Uvicorn workers duplicate that work and stress CPU/memory/DB pools. This PR **always sets `UVICORN_WORKERS=1`** in `_service-deployment.tpl` for that service and removes the Helm value. **request-manager** and **agent-service** still use `uvicornWorkers` from values.

## Symptoms
- `Child process [4] died` / several `Started server process [N]`
- Startup probe: `connection refused` on `:8080`; restarts; exit **137**
- CrashLoopBackOff on a new ReplicaSet while an older pod still looked healthy

## Changes
- Template: fixed `UVICORN_WORKERS` for integration-dispatcher only  
- `values.yaml` / `values-demo.yaml`: removed `integrationDispatcher.uvicornWorkers`  
- `guides/PERFORMANCE_SCALING_GUIDE.md`: scale integration-dispatcher by **replicas**, not workers

## Verify
`helm template …` for integration-dispatcher → `UVICORN_WORKERS: "1"`