### PR TITLE
feat: make agents use mcp server for ticket flow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1437,7 +1437,7 @@ check-known-bad-conversations: sync-evaluations
 .PHONY: test-short-ticket-laptop-refresh
 test-short-ticket-laptop-refresh:
 	@echo "Running short responses integration test for ticket-laptop-refresh flow..."
-	uv --directory evaluations run evaluate.py -n 1 --flow ticket_laptop_refresh $(VALIDATE_LAPTOP_DETAILS_FLAG) $(STRUCTURED_OUTPUT_FLAG)
+	uv --directory evaluations run evaluate.py --message-timeout 1800 --timeout=1800 -n 1 --flow ticket_laptop_refresh $(VALIDATE_LAPTOP_DETAILS_FLAG) $(STRUCTURED_OUTPUT_FLAG)
 	@echo "short responses integration test for ticket-laptop-refresh flow completed successfully!"
 
 .PHONY: test-short-resp-integration-request-mgr

--- a/agent-service/config/agents/ticket-laptop-refresh-agent.yaml
+++ b/agent-service/config/agents/ticket-laptop-refresh-agent.yaml
@@ -26,7 +26,7 @@ sampling_params:
     temperature: 0.7
     top_p: 0.95
 mcp_servers:
-  - name: "snow"
-    uri: "http://mcp-self-service-agent-snow:8000/mcp"
+  - name: "zammad-mcp"
+    uri: "http://mcp-zammad-mcp:8000/mcp"
     require_approval: "never"
 knowledge_bases: ["laptop-refresh"]

--- a/agent-service/config/agents/ticket-review-agent.yaml
+++ b/agent-service/config/agents/ticket-review-agent.yaml
@@ -21,5 +21,8 @@ ignored_output_shield_categories:
   - "Specialized Advice"  # IT support routing flagged as specialized advice
   - "Privacy"  # Routing responses may mention employee/IT topics
   - "Non-Violent Crimes"  # IT support routing falsely flagged
-mcp_servers: []
+mcp_servers:
+  - name: "zammad-mcp"
+    uri: "http://mcp-zammad-mcp:8000/mcp"
+    require_approval: "never"
 knowledge_bases: []

--- a/agent-service/config/lg-prompts/ticket-laptop-refresh-lg-prompt-big.yaml
+++ b/agent-service/config/lg-prompts/ticket-laptop-refresh-lg-prompt-big.yaml
@@ -38,8 +38,8 @@ states:
       CRITICAL: Do not share your internal thinking with the user. CRITICAL: Do NOT announce what you are about to do (e.g., "I will now check the policy", "Let me get your information"). Execute all tool calls silently and present only the results to the user.
 
       CRITICAL STOP CONDITIONS - CHECK THESE FIRST BEFORE DOING ANYTHING ELSE:
-      1. If the user explicitly asks to escalate the ticket at any point, reply with: Your ticket has been escalated for human review. ticket_escalated
-      2. If the user explicitly asks to close the ticket at any point, reply with: Your ticket has been closed. ticket_closed
+      1. If the user explicitly asks to escalate the ticket at any point, call the escalate_for_human_review tool, then reply with: Your ticket has been escalated for human review. ticket_escalated
+      2. If the user explicitly asks to close the ticket at any point, call the close tool, then reply with: Your ticket has been closed. ticket_closed
 
       CRITICAL: Do not greet the user, start the process outline below immediately
 
@@ -57,7 +57,7 @@ states:
           - the summary of whether they can request a replacement today.
           CRITICAL The laptop information section must be the VERBATIM output from get_employee_laptop_info including all fields: Employee Name, Employee Location, Laptop Model, Laptop Serial Number, Laptop Purchase Date, Laptop Age, Laptop Warranty Expiry Date, Laptop Warranty. CRITICAL If any values are missing in the tool output, keep them empty - do NOT invent values.
           - If ELIGIBLE: ask the user if they would like to proceed to the next step which is reviewing the laptop options. CRITICAL Do not present a list of laptop options until they have confirmed they would like to proceed. Continue to step 5. CRITICAL do not accept a laptop seclection in this step as the options have not yet been presented.
-          - If NOT ELIGIBLE: inform the user they are not yet eligible and that their options are to escalate the ticket to request an exception, or to close the ticket. CRITICAL ABSOLUTE PROHIBITION: You MUST NEVER proceed to steps 5, 6, 7, or 8 when the user is NOT ELIGIBLE even if the user explicity asks to see the laptop list, you MUST refuse and repeat their options: escalate or close the ticket. There are NO exceptions to this rule. If the user chooses to escalate, reply with: Your ticket has been escalated for human review. ticket_escalated. If the user chooses to close, reply with: Your ticket has been closed. ticket_closed.
+          - If NOT ELIGIBLE: inform the user they are not yet eligible and that their options are to escalate the ticket to request an exception, or to close the ticket. CRITICAL ABSOLUTE PROHIBITION: You MUST NEVER proceed to steps 5, 6, 7, or 8 when the user is NOT ELIGIBLE even if the user explicity asks to see the laptop list, you MUST refuse and repeat their options: escalate or close the ticket. There are NO exceptions to this rule. If the user chooses to escalate, call the escalate_for_human_review tool then reply with: Your ticket has been escalated for human review. ticket_escalated. If the user chooses to close, call the close tool then reply with: Your ticket has been closed. ticket_closed.
 
         5) CRITICAL get the COMPLETE list of laptops and ALL their specifications available to the user STRICTLY by calling the knowledge_search tool with "what laptops are availble for a user in XXXX: where XXXX is the Employees location. CRITICAL: The employee's current laptop model is irrelevant to the available replacement options. Do NOT use the employee's current laptop model, manufacturer, or any characteristic of their current laptop to inform the laptop options you retrieve or present. The available options are determined SOLELY by the employee's location as returned by the knowledge base query. CRITICAL You MUST retrieve and preserve EVERY specification field for EVERY laptop including but not limited to: model name, category, processor/CPU, RAM/memory, storage/SSD, display/screen size, graphics/GPU, battery, weight, ports, connectivity, operating system, warranty, and any other specifications listed. CRITICAL The list should be based on their location and must contain ALL laptops available to the user based on the laptop-refresh knowledge base. CRITICAL Strictly limit the list of laptops to those in the laptop-refresh documents. CRITICAL Do not use any outside knowledge. CRITICAL Do not invent information. CRITICAL Do not summarize, abbreviate, or omit ANY specification details from the knowledge base results. Before proceeding to the next step validate that you have obtained the laptop options for the users region from the laptop-refresh knowledge base, if not try again. CRITICAL PROOF REQUIREMENT: Before presenting the formatted list to the user, you MUST internally verify you have raw tool output. If you cannot identify raw tool output from the knowledge base query you just made, you have NOT called the tool — stop and call it now before continuing. You MUST NOT present laptop options that did not come directly from a tool call in this step.
 
@@ -65,7 +65,7 @@ states:
 
         7) CRITICAL MANDATORY CONFIRMATION STEP: After the user selects a laptop, you MUST ask them if they would like to send the existing ticket to their manager for approval. CRITICAL DO NOT send the ticket yet. Your response must acknowledge their selection and explicitly ask for confirmation (e.g., "You've selected [laptop name]. Would you like to send this ticket to your manager for approval?"). CRITICAL This confirmation question MUST be asked in a SEPARATE agent response after laptop selection. CRITICAL Even if the user says "please send it" or "yes proceed" when selecting the laptop, you MUST STILL ask for confirmation in your response and wait for their next message. CRITICAL Wait for the user's next message confirming they want to proceed before moving to step 8.
 
-        8) CRITICAL MANAGER APPROVAL STEP: Only after the user explicitly confirms in step 7, reply with ONLY this exact text and nothing else: Your ticket has been sent to your manager for approval. You will receive updates as your request is reviewed. ticket_complete. CRITICAL: Do NOT include laptop information, eligibility details, or any other text in this response.
+        8) CRITICAL MANAGER APPROVAL STEP: Only after the user explicitly confirms in step 7, call the send_to_manager_review tool, then reply with ONLY this exact text and nothing else: Your ticket has been sent to your manager for approval. You will receive updates as your request is reviewed. ticket_complete. CRITICAL: Do NOT include laptop information, eligibility details, or any other text in this response.
 
         CRITICAL DUPLICATE PREVENTION: Once you have sent the ticket to the manager in this conversation session, you MUST NOT send it again. If the user asks to proceed again, simply remind them that the ticket has already been sent to their manager for approval.
 
@@ -117,7 +117,7 @@ states:
 
       **User:** Yes, please.
 
-      **Assistant:** Your ticket has been sent to your manager for approval. You will receive updates as your request is reviewed. ticket_complete
+      **Assistant:** [calls send_to_manager_review tool] Your ticket has been sent to your manager for approval. You will receive updates as your request is reviewed. ticket_complete
 
       ## Example Conversation Flow 2 - Not Eligible
 
@@ -139,7 +139,7 @@ states:
 
       **User:** I'd like to escalate it.
 
-      **Assistant:** Your ticket has been escalated for human review. ticket_escalated
+      **Assistant:** [calls escalate_for_human_review tool] Your ticket has been escalated for human review. ticket_escalated
 
       ## CRITICAL: Always Ask for Confirmation Before Sending to Manager
 
@@ -178,7 +178,7 @@ states:
       - Security or compliance questions
       - Any other IT topics outside of laptop refresh/replacement
 
-      CRITICAL OUT-OF-SCOPE HANDLING: If the user asks about anything outside the laptop refresh process, politely redirect them back to the laptop refresh topic. If they continue to ask about unrelated topics, ask if they would like to escalate the ticket for human review or close the ticket. If they choose to escalate, reply with: Your ticket has been escalated for human review. ticket_escalated. If they choose to close, reply with: Your ticket has been closed. ticket_closed.
+      CRITICAL OUT-OF-SCOPE HANDLING: If the user asks about anything outside the laptop refresh process, politely redirect them back to the laptop refresh topic. If they continue to ask about unrelated topics, ask if they would like to escalate the ticket for human review or close the ticket. If they choose to escalate, call the escalate_for_human_review tool then reply with: Your ticket has been escalated for human review. ticket_escalated. If they choose to close, call the close tool then reply with: Your ticket has been closed. ticket_closed.
 
       Based on the conversation history and the user's current message, determine what step in the process we are at and continue accordingly. Review the conversation to understand what has already been accomplished and what the next appropriate step should be. CRITICAL: If the conversation history shows the user was determined NOT ELIGIBLE, you MUST NOT show laptop options or proceed to steps 5-8 regardless of what the user asks. Always repeat the only available options: escalate or close the ticket.
     response_analysis:

--- a/agent-service/config/lg-prompts/ticket-laptop-refresh-lg-prompt-small-scout.yaml
+++ b/agent-service/config/lg-prompts/ticket-laptop-refresh-lg-prompt-small-scout.yaml
@@ -248,15 +248,13 @@ states:
       Respond with only the classification: ESCALATE, CLOSE, or GENERAL_QUESTION
     intent_actions:
       ESCALATE:
-        response: "Your ticket has been escalated for human review. ticket_escalated"
         data_storage:
           ticket_action: "escalated"
-        next_state: "end"
+        next_state: "escalate_ticket"
       CLOSE:
-        response: "Your ticket has been closed. ticket_closed"
         data_storage:
           ticket_action: "closed"
-        next_state: "end"
+        next_state: "close_ticket"
       GENERAL_QUESTION:
         prompt: |
           Previously retrieved information on laptop eligibility: {laptop_eligibility.response}
@@ -293,15 +291,13 @@ states:
         data_storage:
           laptop_options_retry_count: 0
       ESCALATE:
-        response: "Your ticket has been escalated for human review. ticket_escalated"
         data_storage:
           ticket_action: "escalated"
-        next_state: "end"
+        next_state: "escalate_ticket"
       CLOSE:
-        response: "Your ticket has been closed. ticket_closed"
         data_storage:
           ticket_action: "closed"
-        next_state: "end"
+        next_state: "close_ticket"
       OUT_OF_SCOPE:
         response: "I'm only able to assist with laptop refresh requests. Would you like to proceed with reviewing the available laptop options, escalate the ticket, or close the ticket?"
         next_state: "waiting_proceed_confirmation"
@@ -435,15 +431,13 @@ states:
       Respond with only: VALID_SELECTION, ESCALATE, CLOSE, OUT_OF_SCOPE, INVALID_SELECTION, or UNCLEAR
     intent_actions:
       ESCALATE:
-        response: "Your ticket has been escalated for human review. ticket_escalated"
         data_storage:
           ticket_action: "escalated"
-        next_state: "end"
+        next_state: "escalate_ticket"
       CLOSE:
-        response: "Your ticket has been closed. ticket_closed"
         data_storage:
           ticket_action: "closed"
-        next_state: "end"
+        next_state: "close_ticket"
       OUT_OF_SCOPE:
         response: "I'm only able to assist with laptop refresh requests. Please select one of the laptop options shown above, or let me know if you'd like to escalate or close the ticket."
         next_state: "waiting_laptop_selection"
@@ -505,15 +499,13 @@ states:
       "YES":
         next_state: "send_to_manager"
       ESCALATE:
-        response: "Your ticket has been escalated for human review. ticket_escalated"
         data_storage:
           ticket_action: "escalated"
-        next_state: "end"
+        next_state: "escalate_ticket"
       CLOSE:
-        response: "Your ticket has been closed. ticket_closed"
         data_storage:
           ticket_action: "closed"
-        next_state: "end"
+        next_state: "close_ticket"
       "UNCLEAR":
         response: "Please let me know if you'd like to send this ticket to your manager for approval (yes/no)."
         next_state: "waiting_manager_confirmation"
@@ -522,9 +514,9 @@ states:
   send_to_manager:
     type: "llm_processor"
     temperature: 0.1
-    uses_tools: "No"
+    allowed_tools: ["send_to_manager_review"]
     prompt: |
-      Reply with ONLY this exact text and nothing else:
+      Call the send_to_manager_review tool, then reply with ONLY this exact text and nothing else:
       Your ticket has been sent to your manager for approval. You will receive updates as your request is reviewed. ticket_complete
     response_analysis:
       conditions:
@@ -534,6 +526,42 @@ states:
             - type: "set_field"
               field_name: "ticket_action"
               value: "complete"
+            - type: "transition"
+              target: "end"
+      default_transition: "end"
+
+  # State: Escalate ticket in Zammad then end
+  escalate_ticket:
+    type: "llm_processor"
+    temperature: 0.1
+    allowed_tools: ["escalate_for_human_review"]
+    failure_transition: "end"
+    prompt: |
+      Call the escalate_for_human_review tool, then reply with ONLY this exact text and nothing else:
+      Your ticket has been escalated for human review. ticket_escalated
+    response_analysis:
+      conditions:
+        - name: "ticket_escalated"
+          trigger_phrases: ["ticket_escalated"]
+          actions:
+            - type: "transition"
+              target: "end"
+      default_transition: "end"
+
+  # State: Close ticket in Zammad then end
+  close_ticket:
+    type: "llm_processor"
+    temperature: 0.1
+    allowed_tools: ["close"]
+    failure_transition: "end"
+    prompt: |
+      Call the close tool, then reply with ONLY this exact text and nothing else:
+      Your ticket has been closed. ticket_closed
+    response_analysis:
+      conditions:
+        - name: "ticket_closed"
+          trigger_phrases: ["ticket_closed"]
+          actions:
             - type: "transition"
               target: "end"
       default_transition: "end"

--- a/agent-service/config/lg-prompts/ticket-laptop-refresh-lg-prompt-small.yaml
+++ b/agent-service/config/lg-prompts/ticket-laptop-refresh-lg-prompt-small.yaml
@@ -245,15 +245,13 @@ states:
       Respond with only the classification: ESCALATE, CLOSE, or GENERAL_QUESTION
     intent_actions:
       ESCALATE:
-        response: "Your ticket has been escalated for human review. ticket_escalated"
         data_storage:
           ticket_action: "escalated"
-        next_state: "end"
+        next_state: "escalate_ticket"
       CLOSE:
-        response: "Your ticket has been closed. ticket_closed"
         data_storage:
           ticket_action: "closed"
-        next_state: "end"
+        next_state: "close_ticket"
       GENERAL_QUESTION:
         prompt: |
           Previously retrieved information on laptop eligibility: {laptop_eligibility.response}
@@ -290,15 +288,13 @@ states:
         data_storage:
           laptop_options_retry_count: 0
       ESCALATE:
-        response: "Your ticket has been escalated for human review. ticket_escalated"
         data_storage:
           ticket_action: "escalated"
-        next_state: "end"
+        next_state: "escalate_ticket"
       CLOSE:
-        response: "Your ticket has been closed. ticket_closed"
         data_storage:
           ticket_action: "closed"
-        next_state: "end"
+        next_state: "close_ticket"
       OUT_OF_SCOPE:
         response: "I'm only able to assist with laptop refresh requests. Would you like to proceed with reviewing the available laptop options, escalate the ticket, or close the ticket?"
         next_state: "waiting_proceed_confirmation"
@@ -431,15 +427,13 @@ states:
       Respond with only: VALID_SELECTION, ESCALATE, CLOSE, OUT_OF_SCOPE, INVALID_SELECTION, or UNCLEAR
     intent_actions:
       ESCALATE:
-        response: "Your ticket has been escalated for human review. ticket_escalated"
         data_storage:
           ticket_action: "escalated"
-        next_state: "end"
+        next_state: "escalate_ticket"
       CLOSE:
-        response: "Your ticket has been closed. ticket_closed"
         data_storage:
           ticket_action: "closed"
-        next_state: "end"
+        next_state: "close_ticket"
       OUT_OF_SCOPE:
         response: "I'm only able to assist with laptop refresh requests. Please select one of the laptop options shown above, or let me know if you'd like to escalate or close the ticket."
         next_state: "waiting_laptop_selection"
@@ -500,15 +494,13 @@ states:
       "YES":
         next_state: "send_to_manager"
       ESCALATE:
-        response: "Your ticket has been escalated for human review. ticket_escalated"
         data_storage:
           ticket_action: "escalated"
-        next_state: "end"
+        next_state: "escalate_ticket"
       CLOSE:
-        response: "Your ticket has been closed. ticket_closed"
         data_storage:
           ticket_action: "closed"
-        next_state: "end"
+        next_state: "close_ticket"
       "UNCLEAR":
         response: "Please let me know if you'd like to send this ticket to your manager for approval (yes/no)."
         next_state: "waiting_manager_confirmation"
@@ -517,9 +509,9 @@ states:
   send_to_manager:
     type: "llm_processor"
     temperature: 0.1
-    allowed_tools: [ "" ]
+    allowed_tools: ["send_to_manager_review"]
     prompt: |
-      Reply with ONLY this exact text and nothing else:
+      Call the send_to_manager_review tool, then reply with ONLY this exact text and nothing else:
       Your ticket has been sent to your manager for approval. You will receive updates as your request is reviewed. ticket_complete
     response_analysis:
       conditions:
@@ -529,6 +521,42 @@ states:
             - type: "set_field"
               field_name: "ticket_action"
               value: "complete"
+            - type: "transition"
+              target: "end"
+      default_transition: "end"
+
+  # State: Escalate ticket in Zammad then end
+  escalate_ticket:
+    type: "llm_processor"
+    temperature: 0.1
+    allowed_tools: ["escalate_for_human_review"]
+    failure_transition: "end"
+    prompt: |
+      Call the escalate_for_human_review tool, then reply with ONLY this exact text and nothing else:
+      Your ticket has been escalated for human review. ticket_escalated
+    response_analysis:
+      conditions:
+        - name: "ticket_escalated"
+          trigger_phrases: ["ticket_escalated"]
+          actions:
+            - type: "transition"
+              target: "end"
+      default_transition: "end"
+
+  # State: Close ticket in Zammad then end
+  close_ticket:
+    type: "llm_processor"
+    temperature: 0.1
+    allowed_tools: ["close"]
+    failure_transition: "end"
+    prompt: |
+      Call the close tool, then reply with ONLY this exact text and nothing else:
+      Your ticket has been closed. ticket_closed
+    response_analysis:
+      conditions:
+        - name: "ticket_closed"
+          trigger_phrases: ["ticket_closed"]
+          actions:
             - type: "transition"
               target: "end"
       default_transition: "end"

--- a/agent-service/config/lg-prompts/ticket-routing.yaml
+++ b/agent-service/config/lg-prompts/ticket-routing.yaml
@@ -27,6 +27,8 @@ states:
   classify_user_intent:
     type: "llm_processor"
     temperature: 0.1  # Very deterministic for classification
+    allowed_tools: []  # Classification only — no tools needed
+    uses_tools: "No"  # Scout model fix: forces skip_all_tools=True, sends empty tools array
     failure_transition: "classify_user_intent"
     prompt: |
       You are an agent that reviews new tickets to figure out if the ticket is related to a request to refresh the user's laptop. Be helpful, friendly, and efficient in determining their needs.
@@ -57,7 +59,7 @@ states:
             - type: "add_message"
               message: "laptop-refresh"
             - type: "transition"
-              target: "end"
+              target: "handle_laptop_refresh_ticket"
         - name: "other_request"
           trigger_phrases: ["OTHER"]
           actions:
@@ -65,15 +67,37 @@ states:
               target: "handle_other_request"
       default_transition: "handle_other_request"
 
-  # State 3: Handle Other/Unclear Requests
-  handle_other_request:
+  # State 3a: Mark laptop refresh ticket in Zammad, then end
+  handle_laptop_refresh_ticket:
     type: "llm_processor"
-    temperature: 0.3
+    temperature: 0.1
+    allowed_tools: ["mark_as_agent_managed_laptop_refresh"]
     failure_transition: "end"
     prompt: |
-      The user said: "{last_user_message}"
+      This ticket has been classified as a laptop refresh request.
+      Call the mark_as_agent_managed_laptop_refresh tool to tag this ticket in Zammad as agent-managed.
+      After the tool call succeeds, output exactly: LAPTOP_REFRESH_TAGGED
+    response_analysis:
+      conditions:
+        - name: "tagged"
+          trigger_phrases: ["LAPTOP_REFRESH_TAGGED"]
+          actions:
+            - type: "transition"
+              target: "end"
+      default_transition: "end"
 
-      Reply ONLY with: Your ticket has been escalated for human review
+  # State 3b: Handle Other/Unclear Requests — route to human-managed queue in Zammad
+  handle_other_request:
+    type: "llm_processor"
+    temperature: 0.1
+    allowed_tools: ["route_to_human_managed_queue"]
+    failure_transition: "end"
+    prompt: |
+      This ticket has been classified as a non-laptop-refresh request.
+      You MUST immediately call the route_to_human_managed_queue tool. It requires no arguments.
+      Do not ask for more information. Do not explain. Just call the tool.
+      If the tool call succeeds, reply ONLY with: Your ticket has been escalated for human review
+      If the tool call fails, reply ONLY with: We were unable to escalate your ticket for human review due to a temporary issue. Please try again later.
 
     transitions:
       success: "end"

--- a/evaluations/evaluate.py
+++ b/evaluations/evaluate.py
@@ -989,7 +989,12 @@ def run_evaluation_pipeline(
         step_num += 1
         step_label = f"{step_num}/{step_total}"
         logger.info(f"📋 Step {step_label}: Running predefined conversation flows...")
-        run_conversations_args = ["--test-script", test_script]
+        run_conversations_args = [
+            "--test-script",
+            test_script,
+            "--message-timeout",
+            str(message_timeout),
+        ]
         if reset_conversation:
             run_conversations_args.append("--reset-conversation")
         if flow:

--- a/evaluations/flows/ticket_laptop_refresh/conversations/close-mid-flow.json
+++ b/evaluations/flows/ticket_laptop_refresh/conversations/close-mid-flow.json
@@ -1,0 +1,21 @@
+{
+    "metadata": {
+        "authoritative_user_id": "david.chen@company.com",
+        "description": "Eligible user explicitly requests to close the ticket after seeing laptop options — tests CRITICAL STOP CONDITION mid-flow",
+        "use_first_message_as_initial": true
+    },
+    "conversation": [
+        {
+            "role": "user",
+            "content": "I would like to refresh my laptop"
+        },
+        {
+            "role": "user",
+            "content": "yes, show me the laptop options"
+        },
+        {
+            "role": "user",
+            "content": "please close this ticket, I've changed my mind"
+        }
+    ]
+}

--- a/evaluations/flows/ticket_laptop_refresh/metrics.py
+++ b/evaluations/flows/ticket_laptop_refresh/metrics.py
@@ -171,7 +171,8 @@ def get_metrics(
             evaluation_params=[TurnParams.CONTENT, TurnParams.ROLE],
             evaluation_steps=[
                 "FIRST: Determine whether the agent found the user NOT ELIGIBLE for a laptop refresh. If the agent explicitly stated the user is not eligible and offered to escalate or close the ticket instead of presenting laptop options, The agent behavior is PERFECT for this metric. STOP HERE. Do NOT evaluate any further criteria. Do NOT penalize for the absence of laptop options.",
-                "If the user WAS eligible: assess if the assistant presents appropriate laptop options based on user location.",
+                "SECOND: Determine whether the user closed or escalated the ticket before reaching the laptop selection step. If the conversation ended (closed or escalated) before the user ever requested to see laptop options — regardless of eligibility — the agent could not have presented options, so PASS this metric. STOP HERE. Do NOT penalize for absent laptop options when the user terminated the conversation early.",
+                "If the user WAS eligible and did not terminate early: assess if the assistant presents appropriate laptop options based on user location.",
                 "Evaluate if laptop specifications are clearly and completely presented.",
                 "Check if the assistant guides the user through selection process effectively.",
                 "IGNORE any portions of the conversation involving:",

--- a/evaluations/flows/ticket_unrelated/flow.py
+++ b/evaluations/flows/ticket_unrelated/flow.py
@@ -1,0 +1,45 @@
+"""Flow configuration for ticket_unrelated evaluation."""
+
+from typing import List
+
+FLOW_NAME: str = "ticket_unrelated"
+DEFAULT_TEST_SCRIPT: str = "ticket-responses-request-mgr.py"
+DEFAULT_RESET_CONVERSATION: bool = False
+DEFAULT_SKIP_INITIAL_MESSAGE: bool = True
+DEFAULT_INITIAL_MESSAGE: str = "requesting a laptop refresh"
+DEFAULT_TICKET_TITLE: str = "non laptop refresh request"
+DEFAULT_MAX_TURNS: int = 1  # One user message → one agent response → done
+KNOWLEDGE_BASE_DIRS: List[str] = ["laptop-refresh"]
+INCLUDE_SNOW_DATA: bool = True
+
+CHATBOT_ROLE: str = """You are an IT Support Agent specializing in hardware replacement (laptop refresh).
+You only handle laptop refresh requests. For any other topic you politely inform the user
+you cannot help and that their ticket has been escalated for human review."""
+
+_USER_DESCRIPTION = (
+    "An employee who has submitted a ticket on an unrelated topic (not laptop refresh). "
+    "Their messages are brief and direct, as typical ticket comments. "
+    "The employee asks their unrelated question. Once the agent responds that it cannot help "
+    "and that the ticket has been escalated, the employee does not reply — the conversation ends."
+)
+
+_SCENARIOS = [
+    (
+        "An employee has submitted a support ticket asking about something completely unrelated "
+        "to laptop refresh — for example a password reset, a software installation request, "
+        "a question about office supplies, or a general IT question. "
+        "The employee sends a single message with their unrelated request. "
+        "The agent responds that it cannot help with that topic and that the ticket has been "
+        "escalated for human review. "
+        "After receiving that response the employee does NOT reply — the conversation is over.",
+        "The agent has explicitly stated it cannot help with the request AND has confirmed the "
+        "ticket has been escalated for human review. The conversation is complete and requires "
+        "no further user response.",
+        _USER_DESCRIPTION,
+    ),
+]
+
+
+def get_scenario(use_structured_output: bool) -> list[tuple[str, str, str]]:
+    """Return a list of (scenario, expected_outcome, user_description) tuples for conversation generation."""
+    return _SCENARIOS

--- a/evaluations/flows/ticket_unrelated/metrics.py
+++ b/evaluations/flows/ticket_unrelated/metrics.py
@@ -1,0 +1,86 @@
+"""DeepEval metrics for ticket_unrelated flow."""
+
+from typing import Any, List, Optional
+
+from deepeval.metrics import ConversationalGEval
+from deepeval.models import DeepEvalBaseLLM
+from deepeval.test_case import TurnParams
+
+
+def get_metrics(
+    custom_model: Optional[DeepEvalBaseLLM] = None,
+    validate_full_laptop_details: bool = True,
+) -> List[Any]:
+    """Create evaluation metrics for the ticket_unrelated flow."""
+
+    metrics = [
+        ConversationalGEval(
+            name="Scope Refusal",
+            threshold=0.9,
+            model=custom_model,
+            evaluation_params=[TurnParams.CONTENT, TurnParams.ROLE],
+            evaluation_steps=[
+                "Evaluate whether the agent correctly refused to help with the user's unrelated request.",
+                "The agent MUST:",
+                "  1. Clearly communicate that it cannot help with the user's request",
+                "  2. Not attempt to answer or partially answer the unrelated question",
+                "PASS if the agent clearly declines the out-of-scope request.",
+                "FAIL if the agent attempts to answer the unrelated question or provides any relevant information about it.",
+            ],
+        ),
+        ConversationalGEval(
+            name="Escalation Confirmation",
+            threshold=0.9,
+            model=custom_model,
+            evaluation_params=[TurnParams.CONTENT, TurnParams.ROLE],
+            evaluation_steps=[
+                "Evaluate whether the agent informed the user that their ticket has been escalated for human review.",
+                "PASS if the agent explicitly states the ticket has been escalated for human review (or similar — e.g. 'routed to human review', 'passed to a human agent').",
+                "FAIL if the agent refuses without mentioning escalation, or if the conversation ends without the user being told what will happen next.",
+            ],
+        ),
+        ConversationalGEval(
+            name="Conversation Brevity",
+            threshold=0.8,
+            model=custom_model,
+            evaluation_params=[TurnParams.CONTENT, TurnParams.ROLE],
+            evaluation_steps=[
+                "Evaluate whether the conversation ends promptly after the agent declines and escalates.",
+                "For an unrelated request the correct flow is: user asks → agent declines and escalates → conversation ends.",
+                "PASS if the conversation completes within 2 agent turns.",
+                "FAIL if the agent continues the conversation unnecessarily after declining and escalating.",
+            ],
+        ),
+        ConversationalGEval(
+            name="User Experience",
+            threshold=0.8,
+            model=custom_model,
+            evaluation_params=[TurnParams.CONTENT, TurnParams.ROLE],
+            evaluation_steps=[
+                "Evaluate whether the agent is polite and professional when escalating the out-of-scope request.",
+                "IMPORTANT: This is a backend ticket-routing agent. It is NOT expected to address the user's specific request or provide domain expertise.",
+                "The correct and complete agent response is simply to inform the user their ticket has been escalated for human review.",
+                "Do NOT penalise the agent for failing to help with the user's topic (e.g. password resets, software installs) — that is intentional.",
+                "PASS if the agent's escalation message is polite, professional, and clearly tells the user what will happen next.",
+                "FAIL only if the agent is rude, dismissive, confusing, or provides no information about what will happen to the ticket.",
+            ],
+        ),
+        ConversationalGEval(
+            name="No errors reported by agent",
+            threshold=1.0,
+            model=custom_model,
+            evaluation_params=[TurnParams.CONTENT, TurnParams.ROLE],
+            evaluation_steps=[
+                "This metric ONLY checks for explicit technical/system errors reported by the agent.",
+                "FAIL ONLY if the agent explicitly reports a technical or system error such as:",
+                "  - Any HTTP error code",
+                "  - 'I could not complete this request due to an error'",
+                "  - 'An error occurred while processing your request'",
+                "  - 'Something went wrong' or 'I encountered an error'",
+                "  - Tool call failures or stack traces visible in the response",
+                "PASS if the agent responds normally even if it simply declines to help.",
+            ],
+        ),
+    ]
+
+    return metrics

--- a/evaluations/generator.py
+++ b/evaluations/generator.py
@@ -226,6 +226,7 @@ def _run_worker(
     flow_scenario: Optional[list[tuple[str, str, str]]] = None,
     initial_message: Optional[str] = None,
     skip_initial_message: bool = False,
+    ticket_title: Optional[str] = None,
 ) -> dict[str, Any]:
     """
     Worker function to generate conversations in parallel.
@@ -364,6 +365,7 @@ def _run_worker(
                 message_timeout=message_timeout,
                 initial_message=initial_message,
                 skip_initial_message=skip_initial_message,
+                ticket_title=ticket_title,
             )
 
             # Start session
@@ -549,6 +551,7 @@ if __name__ == "__main__":
     reset_conversation = args.reset_conversation
     initial_message: Optional[str] = None
     skip_initial_message: bool = False
+    ticket_title: Optional[str] = None
 
     if args.flow:
         import sys as _sys
@@ -570,6 +573,10 @@ if __name__ == "__main__":
         skip_initial_message = getattr(
             flow_module, "DEFAULT_SKIP_INITIAL_MESSAGE", False
         )
+        ticket_title = getattr(flow_module, "DEFAULT_TICKET_TITLE", None)
+        flow_max_turns = getattr(flow_module, "DEFAULT_MAX_TURNS", None)
+        if flow_max_turns is not None:
+            args.max_turns = flow_max_turns
         flow_scenario = flow_module.get_scenario(args.use_structured_output)
         logger.info(f"Using flow '{args.flow}': saving to {results_dir}")
 
@@ -634,6 +641,7 @@ if __name__ == "__main__":
                 flow_scenario,
                 initial_message,
                 skip_initial_message,
+                ticket_title,
             )
             for i in range(args.concurrency)
         ]

--- a/evaluations/helpers/openshift_chat_client.py
+++ b/evaluations/helpers/openshift_chat_client.py
@@ -23,6 +23,7 @@ class OpenShiftChatClient:
         initial_message: Optional[str] = None,
         skip_initial_message: bool = False,
         message_timeout: int = 60,
+        ticket_title: Optional[str] = None,
     ):
         """
         Initialize the OpenShift chat client.
@@ -37,6 +38,7 @@ class OpenShiftChatClient:
             skip_initial_message: If True, skip sending any initial message after reset, allowing
                                   the caller to send the first message. Only used when reset_conversation is True.
             message_timeout: Timeout in seconds for individual message send/response operations (default: 60)
+            ticket_title: Optional title to pass as --ticket-title to the test script.
         """
         self.deployment_name = deployment_name
         self.test_script = test_script
@@ -45,6 +47,7 @@ class OpenShiftChatClient:
         self.initial_message = initial_message
         self.skip_initial_message = skip_initial_message
         self.message_timeout = message_timeout
+        self.ticket_title = ticket_title
         self.process: Optional[subprocess.Popen[str]] = None
         self.session_active = False
         self.session_output: list[str] = []  # Capture all output for token parsing
@@ -88,6 +91,9 @@ class OpenShiftChatClient:
             if self.initial_message:
                 escaped_msg = self.initial_message.replace("'", "'\\''")
                 script_cmd += f" --initial-message '{escaped_msg}'"
+            if self.ticket_title:
+                escaped_title = self.ticket_title.replace("'", "'\\''")
+                script_cmd += f" --ticket-title '{escaped_title}'"
             cmd = [
                 "oc",
                 "exec",

--- a/evaluations/helpers/run_conversation_flow.py
+++ b/evaluations/helpers/run_conversation_flow.py
@@ -21,6 +21,7 @@ class ConversationFlowTester:
         reset_conversation: bool = False,
         initial_message: Optional[str] = None,
         skip_initial_message: bool = False,
+        message_timeout: int = 60,
     ) -> None:
         """
         Initialize the ConversationFlowTester.
@@ -32,11 +33,13 @@ class ConversationFlowTester:
                              Only used when reset_conversation is True.
             skip_initial_message: If True, skip sending any initial message after reset, allowing
                                   the first question to serve as the opening message.
+            message_timeout: Timeout in seconds for individual message send/response operations (default: 60)
         """
         self.test_script = test_script
         self.reset_conversation = reset_conversation
         self.initial_message = initial_message
         self.skip_initial_message = skip_initial_message
+        self.message_timeout = message_timeout
         self.conversation_history: list[Any] = []
         self.total_app_tokens = {"input": 0, "output": 0, "total": 0, "calls": 0}
 
@@ -71,6 +74,7 @@ class ConversationFlowTester:
             reset_conversation=self.reset_conversation,
             initial_message=initial_message or self.initial_message,
             skip_initial_message=self.skip_initial_message,
+            message_timeout=self.message_timeout,
         )
 
         try:

--- a/evaluations/run_conversations.py
+++ b/evaluations/run_conversations.py
@@ -32,6 +32,12 @@ def _parse_arguments() -> argparse.Namespace:
         help="Run predefined conversations for a specific flow (e.g., ticket_laptop_refresh). "
         "Uses flows/{name}/conversations/ as input and results/{name}/conversation_results/ as output.",
     )
+    parser.add_argument(
+        "--message-timeout",
+        type=int,
+        default=60,
+        help="Timeout in seconds for individual message send/response operations (default: 60)",
+    )
     return parser.parse_args()
 
 
@@ -71,5 +77,6 @@ if __name__ == "__main__":
     tester = ConversationFlowTester(
         test_script=test_script,
         reset_conversation=reset_conversation,
+        message_timeout=args.message_timeout,
     )
     tester.run_flows(conversations_dir, output_dir)

--- a/helm/values-ticketing.yaml
+++ b/helm/values-ticketing.yaml
@@ -17,6 +17,14 @@ zammad:
     enabled: true
     uri: "http://mcp-zammad:8000/mcp"
 
+agent:
+  defaultAgentId: ticket-review-agent
+
+requestManagement:
+  agentService:
+    promptOverrides:
+      lg-prompt-ticket-laptop-refresh: /app/agent-service/config/lg-prompts/ticket-laptop-refresh-lg-prompt-big.yaml
+
 # Enable zammad-mcp MCP server
 mcp-servers:
   mcp-servers:

--- a/mcp-servers/mcp-common/src/mcp_common/tracing.py
+++ b/mcp-servers/mcp-common/src/mcp_common/tracing.py
@@ -45,9 +45,7 @@ def _extract_context_from_request(args: tuple[Any, ...], kwargs: dict[str, Any])
                     trace_id=span.get_span_context().trace_id,
                 )
             return extracted_context
-    except BaseException as e:
-        if isinstance(e, (KeyboardInterrupt, SystemExit)):
-            raise
+    except Exception as e:
         logger.debug("Failed to extract context from request", error=str(e))
 
     return context.get_current()
@@ -95,9 +93,7 @@ def trace_mcp_tool(
                     result = func(*args, **kwargs)
                     span.set_status(Status(StatusCode.OK))
                     return result
-                except BaseException as e:
-                    if isinstance(e, (KeyboardInterrupt, SystemExit)):
-                        raise
+                except Exception as e:
                     span.record_exception(e)
                     span.set_status(Status(StatusCode.ERROR, str(e)))
                     raise

--- a/mcp-servers/zammad/src/zammad_mcp/server.py
+++ b/mcp-servers/zammad/src/zammad_mcp/server.py
@@ -1,7 +1,9 @@
 """Zammad ticket MCP"""
 
 import functools
+import json
 from contextlib import asynccontextmanager
+from datetime import datetime
 from typing import Any, AsyncGenerator, Callable, Literal, ParamSpec, cast
 
 from mcp.server.fastmcp import Context, FastMCP
@@ -22,6 +24,30 @@ from zammad_mcp.zammad_rest_client import fetch_zammad_customer_user_rest
 SERVICE_NAME = "zammad-mcp-server"
 logger = configure_logging(SERVICE_NAME)
 auto_tracing_run(SERVICE_NAME, logger)
+
+
+def _calculate_laptop_age(purchase_date_str: str) -> str:
+    """Calculate laptop age in years and months from a YYYY-MM-DD purchase date."""
+    try:
+        from datetime import datetime
+
+        purchase_date = datetime.strptime(purchase_date_str, "%Y-%m-%d")
+        current_date = datetime.now()
+        years = current_date.year - purchase_date.year
+        months = current_date.month - purchase_date.month
+        if current_date.day < purchase_date.day:
+            months -= 1
+        if months < 0:
+            years -= 1
+            months += 12
+        if years == 0:
+            return f"{months} month{'s' if months != 1 else ''}"
+        elif months == 0:
+            return f"{years} year{'s' if years != 1 else ''}"
+        else:
+            return f"{years} year{'s' if years != 1 else ''} and {months} month{'s' if months != 1 else ''}"
+    except (ValueError, TypeError):
+        return "Unable to calculate age (invalid date format)"
 
 
 def _tool_error_text(exc: BaseException) -> str:
@@ -102,7 +128,9 @@ def _authorize_ticket(ctx: Context[Any, Any]) -> tuple[str, int, int]:
 @mcp.tool()
 @_handle_tool_errors
 @trace_mcp_tool()
-def mark_as_agent_managed_laptop_refresh(ctx: Context[Any, Any]) -> str:
+def mark_as_agent_managed_laptop_refresh(
+    ctx: Context[Any, Any], dummy_parameter: str = ""
+) -> str:
     """Tag this ticket for agent-managed laptop refresh."""
     _, ticket_id, _ = _authorize_ticket(ctx)
     tag = zammad_mcp_settings.ZAMMAD_MCP_SETTINGS.agent_managed_tag
@@ -124,7 +152,7 @@ def mark_as_agent_managed_laptop_refresh(ctx: Context[Any, Any]) -> str:
 @mcp.tool()
 @_handle_tool_errors
 @trace_mcp_tool()
-def close(ctx: Context[Any, Any]) -> str:
+def close(ctx: Context[Any, Any], dummy_parameter: str = "") -> str:
     """Close the ticket."""
     _, ticket_id, _ = _authorize_ticket(ctx)
     state = zammad_mcp_settings.ZAMMAD_MCP_SETTINGS.state_closed
@@ -135,7 +163,7 @@ def close(ctx: Context[Any, Any]) -> str:
 @mcp.tool()
 @_handle_tool_errors
 @trace_mcp_tool()
-def escalate_for_human_review(ctx: Context[Any, Any]) -> str:
+def escalate_for_human_review(ctx: Context[Any, Any], dummy_parameter: str = "") -> str:
     """Escalate this ticket to the human escalation queue."""
     _, ticket_id, _ = _authorize_ticket(ctx)
     tag = zammad_mcp_settings.ZAMMAD_MCP_SETTINGS.tag_escalate_human
@@ -156,7 +184,7 @@ def escalate_for_human_review(ctx: Context[Any, Any]) -> str:
 @mcp.tool()
 @_handle_tool_errors
 @trace_mcp_tool()
-def send_to_manager_review(ctx: Context[Any, Any]) -> str:
+def send_to_manager_review(ctx: Context[Any, Any], dummy_parameter: str = "") -> str:
     """Assign this ticket to the customer's manager for approval."""
     _, ticket_id, cust_uid = _authorize_ticket(ctx)
     customer_user = fetch_zammad_customer_user_rest(cust_uid)
@@ -184,7 +212,9 @@ def send_to_manager_review(ctx: Context[Any, Any]) -> str:
 @mcp.tool()
 @_handle_tool_errors
 @trace_mcp_tool()
-def route_to_human_managed_queue(ctx: Context[Any, Any]) -> str:
+def route_to_human_managed_queue(
+    ctx: Context[Any, Any], dummy_parameter: str = ""
+) -> str:
     """Route this ticket to the human-managed queue."""
     _, ticket_id, _ = _authorize_ticket(ctx)
     gname = zammad_mcp_settings.ZAMMAD_MCP_SETTINGS.group_human_managed
@@ -196,6 +226,83 @@ def route_to_human_managed_queue(ctx: Context[Any, Any]) -> str:
         )
     gmsg = f"group {gname!r}" if gstrip else "no group change"
     return f"Ticket {ticket_id} routed to {gmsg}."
+
+
+@mcp.tool()
+@_handle_tool_errors
+@trace_mcp_tool()
+def get_employee_laptop_info(
+    ctx: Context[Any, Any],
+    dummy_parameter: str = "",
+) -> str:
+    """Get laptop information for an employee using their authoritative user ID from request headers.
+
+    Reads laptop data from the employee's Zammad user profile (current_laptop field)
+    and returns it in a formatted string identical to the ServiceNow MCP server output.
+
+    Args:
+        dummy_parameter: Optional parameter as validation fails unless there is at least one parameter
+
+    Returns:
+        A formatted multi-line string containing the following information:
+        - Employee Name: Full name of the employee
+        - Employee Location: Geographic region (EMEA, LATAM, APAC, etc.)
+        - Laptop Model: Brand and model of the laptop
+        - Laptop Serial Number: Unique serial number
+        - Laptop Purchase Date: Date when laptop was purchased (YYYY-MM-DD format)
+        - Laptop Age: Calculated age in years and months from purchase date to current date
+        - Laptop Warranty Expiry Date: When the warranty expires (YYYY-MM-DD format)
+        - Laptop Warranty: Current warranty status (Active/Expired)
+    """
+    email, _ticket_id, cust_uid = _authorize_ticket(ctx)
+    user = fetch_zammad_customer_user_rest(cust_uid)
+
+    logger.info(
+        "Getting laptop info from Zammad user profile",
+        tool="get_employee_laptop_info",
+        authoritative_user_id=email,
+    )
+
+    current_laptop_raw = user.get("current_laptop")
+    if not current_laptop_raw:
+        raise ValueError(
+            f"No laptop data found for user {email}. "
+            "Ensure the 'current_laptop' field is populated on the Zammad user profile."
+        )
+
+    laptop = json.loads(current_laptop_raw)
+
+    purchase_date = laptop.get("purchase_date", "N/A")
+    warranty_expiry = laptop.get("warranty_expiry", "N/A")
+
+    laptop_age = _calculate_laptop_age(purchase_date)
+
+    warranty_status = "Unknown"
+    if warranty_expiry and warranty_expiry != "N/A":
+        try:
+            expiry_date = datetime.strptime(warranty_expiry, "%Y-%m-%d")
+            warranty_status = "Active" if expiry_date > datetime.now() else "Expired"
+        except ValueError:
+            pass
+
+    result = f"""
+Employee Name: {laptop.get("name", "N/A")}
+Employee Location: {laptop.get("location", "N/A")}
+Laptop Model: {laptop.get("laptop_model", "N/A")}
+Laptop Serial Number: {laptop.get("serial_number", "N/A")}
+Laptop Purchase Date: {purchase_date}
+Laptop Age: {laptop_age}
+Laptop Warranty Expiry Date: {warranty_expiry}
+Laptop Warranty: {warranty_status}
+"""
+
+    logger.info(
+        "Returning laptop info for employee",
+        tool="get_employee_laptop_info",
+        authoritative_user_id=email,
+    )
+
+    return result
 
 
 def main() -> None:

--- a/test/ticket-responses-request-mgr.py
+++ b/test/ticket-responses-request-mgr.py
@@ -51,16 +51,16 @@ def _zammad_get_state_map(base_url: str, token: str) -> dict[int, str]:
     return {s["id"]: s["name"] for s in response.json()}
 
 
-TICKET_TITLE = "Laptop refresh help request"
+DEFAULT_TICKET_TITLE = "Laptop refresh help request"
 
 
 def _zammad_create_ticket(
-    base_url: str, token: str, customer_email: str
+    base_url: str, token: str, customer_email: str, title: str = DEFAULT_TICKET_TITLE
 ) -> tuple[int, str]:
     """Create a Zammad ticket and return (ticket_id, ticket_number)."""
     url = f"{_zammad_api_base(base_url)}/tickets"
     payload = {
-        "title": TICKET_TITLE,
+        "title": title,
         "group": "Users",
         "customer": customer_email,
     }
@@ -303,6 +303,11 @@ async def main() -> None:
         "--initial-message", help="Initial message to send to the agent"
     )
     parser.add_argument(
+        "--ticket-title",
+        default=DEFAULT_TICKET_TITLE,
+        help=f"Title for the created Zammad ticket (default: '{DEFAULT_TICKET_TITLE}')",
+    )
+    parser.add_argument(
         "--delete-ticket-on-close",
         action="store_true",
         help="Delete the Zammad ticket when the session ends",
@@ -335,15 +340,16 @@ async def main() -> None:
                 zammad_base_url, zammad_token, AGENT_EMAIL
             )
             ticket_id, ticket_number = _zammad_create_ticket(
-                zammad_base_url, zammad_token, base_user_id
+                zammad_base_url, zammad_token, base_user_id, title=args.ticket_title
             )
             print(f"Created Zammad ticket #{ticket_number} (id={ticket_id})")
         except Exception as e:
             print(f"Warning: could not create Zammad ticket: {e}", file=sys.stderr)
 
-    # Append ticket number to user_id for session uniqueness
-    if ticket_number:
-        user_id = f"{base_user_id}-{ticket_number}"
+    # Append internal ticket id (not display number) to user_id for session uniqueness
+    # The Zammad MCP server expects the internal id from /api/v1/tickets/{id}, not the display number
+    if ticket_id:
+        user_id = f"{base_user_id}-{ticket_id}"
     else:
         user_id = base_user_id
 

--- a/zammad-bootstrap/bootstrap.py
+++ b/zammad-bootstrap/bootstrap.py
@@ -10,6 +10,7 @@ Required env vars:
   ZAMMAD_ADMIN_PASSWORD matching password
 """
 
+import json
 import os
 import sys
 import time
@@ -138,6 +139,24 @@ def get_or_create_group(name):
 # ---------------------------------------------------------------------------
 
 
+def build_current_laptop_json(emp: dict) -> str:
+    """Build the JSON string to store in the current_laptop Zammad field."""
+    purchase_date = emp.get("purchase_date", "N/A")
+    warranty_expiry = emp.get("warranty_expiry", "N/A")
+    location = (emp.get("location") or "N/A").upper()
+
+    return json.dumps(
+        {
+            "name": emp.get("name", "N/A"),
+            "location": location,
+            "laptop_model": emp.get("laptop_model", "N/A"),
+            "serial_number": emp.get("laptop_serial_number", "N/A"),
+            "purchase_date": purchase_date,
+            "warranty_expiry": warranty_expiry,
+        }
+    )
+
+
 def ensure_manager_email_attribute():
     for a in api("GET", "object_manager_attributes"):
         if a.get("object") == "User" and a.get("name") == "manager_email":
@@ -156,6 +175,44 @@ def ensure_manager_email_attribute():
             "data_option": {
                 "type": "email",
                 "maxlength": 255,
+                "null": True,
+                "note": "",
+            },
+            "active": True,
+            "screens": {
+                "edit": {
+                    "Admin": {"shown": True, "required": False},
+                    "Agent": {"shown": True, "required": False},
+                },
+                "view": {
+                    "Admin": {"shown": True, "required": False},
+                    "Agent": {"shown": True, "required": False},
+                },
+            },
+        },
+    )
+    print("  Executing attribute migrations...")
+    api("POST", "object_manager_attributes_execute_migrations")
+    print("  Attribute migration complete.")
+
+
+def ensure_current_laptop_attribute():
+    for a in api("GET", "object_manager_attributes"):
+        if a.get("object") == "User" and a.get("name") == "current_laptop":
+            print("  Custom attribute 'current_laptop' already exists.")
+            return
+
+    print("  Creating custom attribute 'current_laptop' on User...")
+    api(
+        "POST",
+        "object_manager_attributes",
+        json={
+            "object": "User",
+            "name": "current_laptop",
+            "display": "Current Laptop",
+            "data_type": "textarea",
+            "data_option": {
+                "maxlength": 5000,
                 "null": True,
                 "note": "",
             },
@@ -208,7 +265,14 @@ def find_user_by_email(email):
 
 
 def get_or_create_user(
-    login, firstname, lastname, email, role_ids, group_ids=None, manager_email=None
+    login,
+    firstname,
+    lastname,
+    email,
+    role_ids,
+    group_ids=None,
+    manager_email=None,
+    current_laptop=None,
 ):
     existing = find_user_by_email(email)
     payload = {
@@ -224,6 +288,8 @@ def get_or_create_user(
         payload["group_ids"] = group_ids
     if manager_email:
         payload["manager_email"] = manager_email
+    if current_laptop:
+        payload["current_laptop"] = current_laptop
 
     if existing:
         print(f"  User '{email}' already exists (id={existing['id']}), updating...")
@@ -243,10 +309,12 @@ def main():
     trigger_autowizard()
     acquire_token()
 
-    print("\n[1/5] Ensuring custom attribute 'manager_email' exists...")
+    print("\n[1/5] Ensuring custom attributes exist...")
     ensure_manager_email_attribute()
+    ensure_current_laptop_attribute()
 
     print("\n[2/5] Creating groups...")
+    users_group_id = get_or_create_group("Users")
     group_id = get_or_create_group("human_managed_tickets")
     escalated_group_id = get_or_create_group("escalated_laptop_refresh_tickets")
 
@@ -256,6 +324,24 @@ def main():
     customer_role_ids = [role_map["Customer"]]
     print(f"  Agent role id={agent_role_ids}, Customer role id={customer_role_ids}")
 
+    print("\n[3b/5] Adding admin user to all groups...")
+    admin = find_user_by_email("admin@zammad.local")
+    if admin:
+        api(
+            "PUT",
+            f"users/{admin['id']}",
+            json={
+                "group_ids": {
+                    str(users_group_id): ["full"],
+                    str(group_id): ["full"],
+                    str(escalated_group_id): ["full"],
+                }
+            },
+        )
+        print(f"  Admin user (id={admin['id']}) added to all groups.")
+    else:
+        print("  WARNING: admin@zammad.local not found, skipping group assignment.")
+
     print("\n[4/5] Creating ticket handlers, managers and specialists...")
     get_or_create_user(
         "agent.laptop-specialist",
@@ -263,7 +349,7 @@ def main():
         "Specialist",
         "agent.laptop-specialist@example.com",
         role_ids=agent_role_ids,
-        group_ids={str(group_id): ["full"]},
+        group_ids={str(users_group_id): ["full"]},
     )
     get_or_create_user(
         "ticket_handler1",
@@ -302,14 +388,16 @@ def main():
         "Manager",
         "One",
         MANAGER1_EMAIL,
-        role_ids=agent_role_ids,
+        role_ids=agent_role_ids + customer_role_ids,
+        group_ids={str(users_group_id): ["full"]},
     )
     get_or_create_user(
         "manager2",
         "Manager",
         "Two",
         MANAGER2_EMAIL,
-        role_ids=agent_role_ids,
+        role_ids=agent_role_ids + customer_role_ids,
+        group_ids={str(users_group_id): ["full"]},
     )
 
     print("\n[5/5] Creating employees from mock-employee-data...")
@@ -324,6 +412,7 @@ def main():
             emp["email"],
             role_ids=customer_role_ids,
             manager_email=manager_email,
+            current_laptop=build_current_laptop_json(emp),
         )
 
     print("\nZammad bootstrap complete.")


### PR DESCRIPTION
- update agent to use mcp server for ticket flows and adjust evals
  to better cover ticket flow
  - make agents use mcp server for ticket flow
  - add predefined eval for close mid flight
  - adjust bootstrap to get users into correct roles and groups so ticket
    changes can be made
  - add ticket-unrelated flow so that we can test cases where tickets not
    related to laptop refresh are submitted
  - allow message timeout to be used with evaluate

- fetch laptop information form Zammad instead of snow
  - add the laptop information to Zammad as part of the bootstrap
    so we don't need to use the snow MCP server
  - add function to MCP server to get laptop information from Zammad
  - update helm values so ticketing deploy uses the right agents by
    default
    
    Signed-off-by: Michael Dawson <midawson@redhat.com>
