### PR TITLE
update laptop option prompts

### DIFF
--- a/agent-service/config/lg-prompts/lg-prompt-small-scout.yaml
+++ b/agent-service/config/lg-prompts/lg-prompt-small-scout.yaml
@@ -297,6 +297,8 @@ states:
 
       The user was asked if they want to proceed with reviewing laptop options. They responded: "{user_input}"
 
+      IMPORTANT: Classify based on the user's overall intent, not individual words in isolation. If the response expresses a desire to continue with or see laptop options, classify as YES.
+
       Classify their response as one of the following:
       1. RETURN_TO_ROUTER - User wants to return to the routing agent or stop laptop refresh process (e.g., "return to router", "go back", "stop", "cancel laptop refresh")
       2. YES - User wants to proceed (yes, sure, okay, proceed, continue, etc.)

--- a/agent-service/config/lg-prompts/lg-prompt-small.yaml
+++ b/agent-service/config/lg-prompts/lg-prompt-small.yaml
@@ -294,6 +294,8 @@ states:
 
       The user was asked if they want to proceed with reviewing laptop options. They responded: "{user_input}"
 
+      IMPORTANT: Classify based on the user's overall intent, not individual words in isolation. If the response expresses a desire to continue with or see laptop options, classify as YES.
+
       Classify their response as one of the following:
       1. RETURN_TO_ROUTER - User wants to return to the routing agent or stop laptop refresh process (e.g., "return to router", "go back", "stop", "cancel laptop refresh")
       2. YES - User wants to proceed (yes, sure, okay, proceed, continue, etc.)

--- a/evaluations/conversations_config/conversations/failed-flow-replication-test.json
+++ b/evaluations/conversations_config/conversations/failed-flow-replication-test.json
@@ -1,0 +1,28 @@
+{
+    "metadata": {
+        "authoritative_user_id": "maria.garcia@company.com",
+        "description": "Failed flow Replication Test"
+    },
+    "conversation": [
+        {
+            "role": "user",
+            "content": "refresh my laptop"
+        },
+        {
+            "role": "user",
+            "content": "what's my name?"
+        },
+        {
+            "role": "user",
+            "content": "no, i want to see my laptop options"
+        },
+        {
+            "role": "user",
+            "content": "I'll go with the MacBook Air M2"
+        },
+        {
+            "role": "user",
+            "content": "Yes, please create the ticket"
+        }
+    ]
+}


### PR DESCRIPTION
update laptop option classification to classify user responses based on overall intent rather than individual words in the lg-prompt-small and lg-prompt-small-scout prompt configs

[make_test_long_resp_integration_request_mgr.log](https://github.com/user-attachments/files/26799116/make_test_long_resp_integration_request_mgr.log)
