### PR TITLE
chore: centralize version bumps and align Zammad bootstrap with ticketing Helm

### DIFF
--- a/.github/workflows/create-dev-to-main-pr.yaml
+++ b/.github/workflows/create-dev-to-main-pr.yaml
@@ -139,13 +139,11 @@ jobs:
           # Use the target commit that was already determined
           DEV_REF="${{ steps.check_commits.outputs.target_commit }}"
 
-          # Extract BASE_VERSION from Makefile in dev
+          # Align Makefile BASE_VERSION with every path/scripts/bump-release.manifest.json (Chart, Helm tags, Zammad bootstrap)
+          python3 scripts/bump_release.py --verify --git-ref "$DEV_REF"
+
           DEV_MAKEFILE_VERSION=$(git show "$DEV_REF:Makefile" | grep '^BASE_VERSION' | head -1 | sed 's/BASE_VERSION.*= *//')
 
-          # Extract appVersion from helm/Chart.yaml in dev
-          DEV_HELM_VERSION=$(git show "$DEV_REF:helm/Chart.yaml" | grep '^appVersion:' | sed 's/appVersion: *//')
-
-          # Extract BASE_VERSION from Makefile in main (fallback to VERSION if not found)
           MAIN_MAKEFILE_VERSION=$(git show origin/main:Makefile | grep '^BASE_VERSION' | head -1 | sed 's/BASE_VERSION.*= *//')
           MAIN_VERSION_VAR="BASE_VERSION"
           if [ -z "$MAIN_MAKEFILE_VERSION" ]; then
@@ -153,67 +151,12 @@ jobs:
             MAIN_VERSION_VAR="VERSION"
           fi
 
-          # Extract appVersion from helm/Chart.yaml in main
           MAIN_HELM_VERSION=$(git show origin/main:helm/Chart.yaml | grep '^appVersion:' | sed 's/appVersion: *//')
 
-          echo "Dev branch versions:"
-          echo "  Makefile BASE_VERSION: $DEV_MAKEFILE_VERSION"
-          echo "  Helm appVersion:  $DEV_HELM_VERSION"
+          echo "Dev Makefile BASE_VERSION: $DEV_MAKEFILE_VERSION"
+          echo "Main Makefile $MAIN_VERSION_VAR: $MAIN_MAKEFILE_VERSION"
+          echo "Main Helm appVersion (FYI): $MAIN_HELM_VERSION"
           echo ""
-          echo "Main branch versions:"
-          echo "  Makefile $MAIN_VERSION_VAR: $MAIN_MAKEFILE_VERSION"
-          echo "  Helm appVersion:  $MAIN_HELM_VERSION"
-          echo ""
-
-          # Check 1: Dev versions must match each other
-          if [ "$DEV_MAKEFILE_VERSION" != "$DEV_HELM_VERSION" ]; then
-            echo "::error::Version mismatch in dev branch!"
-            echo ""
-            echo "❌ Makefile BASE_VERSION ($DEV_MAKEFILE_VERSION) does not match Helm appVersion ($DEV_HELM_VERSION)"
-            echo ""
-            echo "All version values must match before promoting to main."
-            echo ""
-            echo "To fix:"
-            echo "  1. Update Makefile BASE_VERSION to match helm/Chart.yaml appVersion, OR"
-            echo "  2. Update helm/Chart.yaml appVersion to match Makefile BASE_VERSION"
-            echo "  3. Update helm/values.yaml image.tag to match (if set)"
-            echo "  4. Update helm/values.yaml MCP server image.tag to match (if set)"
-            echo "  5. Commit and push the change to dev"
-            exit 1
-          fi
-
-          # Check 1a: Extract and validate image.tag values from helm/values.yaml
-          DEV_IMAGE_TAG=$(git show "$DEV_REF:helm/values.yaml" | grep -A 15 '^image:' | grep '  tag:' | head -1 | sed 's/.*tag: *"\?\([^"]*\)"\?.*/\1/')
-          DEV_MCP_TAG=$(git show "$DEV_REF:helm/values.yaml" | grep -B 5 'self-service-agent-snow-mcp' | grep 'tag:' | sed 's/.*tag: *"\?\([^"]*\)"\?.*/\1/')
-
-          echo "Dev branch helm/values.yaml tags:"
-          echo "  image.tag:     $DEV_IMAGE_TAG"
-          echo "  MCP server tag: $DEV_MCP_TAG"
-          echo ""
-
-          # Check if image.tag is set and matches Makefile BASE_VERSION
-          if [ -n "$DEV_IMAGE_TAG" ] && [ "$DEV_IMAGE_TAG" != "$DEV_MAKEFILE_VERSION" ]; then
-            echo "::error::Image tag mismatch in dev branch!"
-            echo ""
-            echo "❌ helm/values.yaml image.tag ($DEV_IMAGE_TAG) does not match Makefile BASE_VERSION ($DEV_MAKEFILE_VERSION)"
-            echo ""
-            echo "To fix:"
-            echo "  1. Update helm/values.yaml image.tag to match Makefile BASE_VERSION ($DEV_MAKEFILE_VERSION)"
-            echo "  2. Commit and push the change to dev"
-            exit 1
-          fi
-
-          # Check if MCP server tag is set and matches Makefile BASE_VERSION
-          if [ -n "$DEV_MCP_TAG" ] && [ "$DEV_MCP_TAG" != "$DEV_MAKEFILE_VERSION" ]; then
-            echo "::error::MCP server image tag mismatch in dev branch!"
-            echo ""
-            echo "❌ helm/values.yaml MCP server tag ($DEV_MCP_TAG) does not match Makefile BASE_VERSION ($DEV_MAKEFILE_VERSION)"
-            echo ""
-            echo "To fix:"
-            echo "  1. Update helm/values.yaml mcp-servers.mcp-servers.self-service-agent-snow.image.tag to match Makefile BASE_VERSION ($DEV_MAKEFILE_VERSION)"
-            echo "  2. Commit and push the change to dev"
-            exit 1
-          fi
 
           # Function to compare semantic versions
           compare_versions() {
@@ -269,13 +212,8 @@ jobs:
             echo ""
             echo "Dev version must be greater than main version for promotion."
             echo ""
-            echo "To fix, increment the version in dev branch:"
-            echo "  1. Update BASE_VERSION in Makefile"
-            echo "  2. Update appVersion in helm/Chart.yaml"
-            echo "  3. Update image.tag in helm/values.yaml (if set)"
-            echo "  4. Update MCP server image.tag in helm/values.yaml (if set)"
-            echo "  5. Ensure all version values match"
-            echo "  6. Commit and push to dev"
+            echo "To fix: ./scripts/bump-release.sh <new-version>   # must be > $MAIN_MAKEFILE_VERSION"
+            echo "See scripts/bump-release.manifest.json for files updated. Commit and push to dev."
             exit 1
           fi
 

--- a/.github/workflows/create-dev-version-bump-pr.yml
+++ b/.github/workflows/create-dev-version-bump-pr.yml
@@ -94,8 +94,8 @@ jobs:
           # Create and checkout new branch
           git checkout -b "$BRANCH_NAME"
 
-          # Stage and commit changes (paths must match scripts/bump-release.manifest.json)
-          git add Makefile helm/Chart.yaml helm/values.yaml helm/zammad/values.yaml
+          # Stage manifest paths (same set bump_release.py updates)
+          python3 scripts/bump_release.py --print-manifest-paths --null | xargs -0 git add --
           git commit -m "chore: increment dev version to $NEW_VERSION"
 
           # Push branch

--- a/.github/workflows/create-dev-version-bump-pr.yml
+++ b/.github/workflows/create-dev-version-bump-pr.yml
@@ -54,14 +54,10 @@ jobs:
 
           echo "Updating version from $CURRENT_VERSION to $NEW_VERSION"
 
-          # Update Makefile
-          sed -i "s/BASE_VERSION := $CURRENT_VERSION/BASE_VERSION := $NEW_VERSION/" Makefile
+          chmod +x scripts/bump-release.sh scripts/bump_release.py
+          ./scripts/bump-release.sh "$NEW_VERSION"
 
-          # Update helm/Chart.yaml
-          sed -i "s/appVersion: $CURRENT_VERSION/appVersion: $NEW_VERSION/" helm/Chart.yaml
-
-          # Update helm/values.yaml (both image.tag locations)
-          sed -i "s/tag: \"$CURRENT_VERSION\"/tag: \"$NEW_VERSION\"/" helm/values.yaml
+          make check-release-manifest
 
           echo "Version updates complete"
 
@@ -98,8 +94,8 @@ jobs:
           # Create and checkout new branch
           git checkout -b "$BRANCH_NAME"
 
-          # Stage and commit changes
-          git add Makefile helm/Chart.yaml helm/values.yaml
+          # Stage and commit changes (paths must match scripts/bump-release.manifest.json)
+          git add Makefile helm/Chart.yaml helm/values.yaml helm/zammad/values.yaml
           git commit -m "chore: increment dev version to $NEW_VERSION"
 
           # Push branch
@@ -144,9 +140,12 @@ jobs:
             echo ""
             echo "## Files Updated"
             echo ""
+            echo "Same scope as \`./scripts/bump-release.sh\` / \`scripts/bump-release.manifest.json\`:"
+            echo ""
             echo "- **Makefile**: \`BASE_VERSION\`"
             echo "- **helm/Chart.yaml**: \`appVersion\`"
-            echo "- **helm/values.yaml**: \`image.tag\` (2 locations)"
+            echo "- **helm/values.yaml**: \`image.tag\` anchor (\`&releaseImageTag\`) and MCP tags that alias it"
+            echo "- **helm/zammad/values.yaml**: \`bootstrap.imageTag\`"
             echo ""
             echo "---"
             echo ""

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -49,6 +49,9 @@ jobs:
       - name: Check requirements.txt files are in sync with lockfiles
         run: make check-requirements
 
+      - name: Check release manifest matches Makefile
+        run: make check-release-manifest
+
       - name: Install the project
         run: make deps-all
 

--- a/Makefile
+++ b/Makefile
@@ -244,7 +244,7 @@ helm_demo_email_args = \
 # Ticketing: Zammad in-cluster URL and MCP secret wiring
 ZAMMAD_CREDENTIALS_SECRET ?= $(MAIN_CHART_NAME)-zammad-credentials
 ZAMMAD_URL ?= http://zammad-nginx.$(NAMESPACE).svc.cluster.local:8080
-# Temp overlay file for cluster-specific Zammad values (FQDN, OpenShift UID) written by helm-install-ticketing
+# Temp overlay file for cluster-specific Zammad Helm values (bootstrap image registry/tag, FQDN, OpenShift UID). Written by helm-install-ticketing.
 ZAMMAD_TICKETING_OVERLAY = /tmp/ssa-zammad-$(NAMESPACE)-overlay.yaml
 # Must match autoWizard.config in helm/values-ticketing.yaml (for UI login).
 ZAMMAD_ADMIN_EMAIL ?= admin@zammad.local
@@ -388,6 +388,7 @@ help:
 	@echo "Lockfile Management:"
 	@echo "  check-lockfiles                     - Check if all uv.lock files are up-to-date"
 	@echo "  check-requirements                  - Check if all requirements.txt files exist and are in sync with uv.lock"
+	@echo "  check-release-manifest              - Check Makefile BASE_VERSION vs scripts/bump-release.manifest.json"
 	@echo "  check-uv-version                    - Check if local uv version matches CI requirement ($(UV_VERSION))"
 	@echo "  update-lockfiles                    - Update all uv.lock files; export requirements.txt for dirs in REQUIREMENTS_DIRS"
 	@echo "  export-requirements                - Export requirements.txt for containerized services (REQUIREMENTS_DIRS only)"
@@ -447,7 +448,8 @@ help:
 	@echo "    INTEGRATION_DISPATCHER_IMG        - Full integration dispatcher image name (default: \$${REGISTRY}/self-service-agent-integration-dispatcher:\$${VERSION})"
 	@echo "    MCP_SNOW_IMG                      - Full snow MCP image name (default: \$${REGISTRY}/self-service-agent-snow-mcp:\$${VERSION})"
 	@echo "    MOCK_SERVICENOW_IMG               - Full mock ServiceNow image name (default: \$${REGISTRY}/self-service-agent-mock-servicenow:\$${VERSION})"
-	@echo "    ZAMMAD_BOOTSTRAP_IMG              - Full Zammad bootstrap image name (default: \$${REGISTRY}/self-service-agent-zammad-bootstrap:\$${VERSION})"
+	@echo "    ZAMMAD_BOOTSTRAP_IMG              - Full Zammad bootstrap image for build/push/retag (default: \$${REGISTRY}/self-service-agent-zammad-bootstrap:\$${VERSION})"
+	@echo "                                        same REGISTRY/VERSION as helm-install-ticketing bootstrap overlay (not via this var)"
 	@echo "    REQUEST_MGR_IMG                   - Full request manager image name (default: \$${REGISTRY}/self-service-agent-request-manager:\$${VERSION})"
 	@echo "    USE_PIP_INSTALL                   - Use pip install from requirements.txt instead of uv sync (default: false)"
 	@echo "                                        ⚠️  Troubleshooting: If you encounter QEMU segmentation faults when building"
@@ -1327,6 +1329,11 @@ export-requirements: check-uv-version
 	done
 	@echo "🎉 All requirements.txt files exported successfully!"
 
+.PHONY: check-release-manifest
+check-release-manifest:
+	@echo "🔍 Checking Makefile BASE_VERSION matches scripts/bump-release.manifest.json..."
+	@python3 scripts/bump_release.py --verify
+
 .PHONY: check-requirements
 check-requirements: check-uv-version
 	@echo "🔍 Checking requirements.txt files are in sync with uv.lock files..."
@@ -1706,7 +1713,9 @@ helm-install-ticketing: namespace helm-depend
 	{ \
 		printf 'ticketingZammad:\n'; \
 		printf '  bootstrap:\n'; \
-		printf '    image: "%s"\n' '$(ZAMMAD_BOOTSTRAP_IMG)'; \
+		printf '    imageRegistry: "%s"\n' '$(REGISTRY)'; \
+		printf '    imageRepository: "%s"\n' 'self-service-agent-zammad-bootstrap'; \
+		printf '    imageTag: "%s"\n' '$(VERSION)'; \
 		if [ -n "$$ZAMMAD_UID" ] || [ -n "$$ZAMMAD_FQDN" ]; then \
 			printf '  zammad:\n'; \
 			if [ -n "$$ZAMMAD_UID" ]; then \

--- a/helm/values-ticketing.yaml
+++ b/helm/values-ticketing.yaml
@@ -7,9 +7,10 @@ ticketingZammad:
   enabled: true
 
   # Subchart config — cluster-specific overrides (FQDN, OpenShift UID) injected by Makefile.
+  # Bootstrap image registry/repo/tag: defaults from helm/zammad/values.yaml (avoid duplicating here).
+  # Makefile overlay still sets ticketingZammad.bootstrap.* from REGISTRY/VERSION at helm-install-ticketing.
   # Bootstrap job: seeds users/groups and (with createToken=true) creates MCP agent token in-cluster.
   bootstrap:
-    image: "quay.io/rh-ai-quickstart/self-service-agent-zammad-bootstrap:latest"
     adminEmail: "admin@zammad.local"
     adminPassword: "ZammadR0cks!"
     autowizardToken: "ssa-zammad-autowizard-9f3a2b1c"

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -17,7 +17,8 @@ image:
   # This sets the pull policy for images.
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "0.0.13"
+  # Anchor: bump once here; subchart defaults (e.g. mcp-servers Snow) alias this tag.
+  tag: &releaseImageTag "0.0.13"
 
 # Test Integration Configuration
 testIntegrationEnabled: false
@@ -249,7 +250,7 @@ mcp-servers:
       deploymentMode: deployment  # Use standard Deployment (no Toolhive)
       image:
         repository: quay.io/rh-ai-quickstart/self-service-agent-snow-mcp
-        tag: "0.0.13"
+        tag: *releaseImageTag
       port: 8000
       targetPort: 8000
       transport: streamable-http
@@ -275,7 +276,7 @@ mcp-servers:
       deploymentMode: deployment
       image:
         repository: quay.io/rh-ai-quickstart/self-service-agent-zammad-mcp
-        tag: "0.0.13"
+        tag: *releaseImageTag
       port: 8000
       targetPort: 8000
       transport: streamable-http

--- a/helm/zammad/templates/bootstrap-job.yaml
+++ b/helm/zammad/templates/bootstrap-job.yaml
@@ -29,7 +29,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: zammad-bootstrap
-          image: {{ .Values.bootstrap.image | quote }}
+          image: "{{ .Values.bootstrap.imageRegistry }}/{{ .Values.bootstrap.imageRepository }}:{{ .Values.bootstrap.imageTag }}"
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false

--- a/helm/zammad/values.yaml
+++ b/helm/zammad/values.yaml
@@ -9,8 +9,11 @@ externalRoute:
   enabled: false
 
 bootstrap:
-  image: "quay.io/rh-ai-quickstart/self-service-agent-zammad-bootstrap:latest"
-  # Must match autoWizard.config Users[0] and Token in helm/values-ticketing.yaml
+  # imageTag ↔ Makefile BASE_VERSION / scripts/bump-release.sh. Ticketing overrides via helm-install-ticketing overlay.
+  imageRegistry: quay.io/rh-ai-quickstart
+  imageRepository: self-service-agent-zammad-bootstrap
+  imageTag: "0.0.13"
+  # Must match autoWizard Users[0] / Token in helm/values-ticketing.yaml (ticketingZammad.zammad.autoWizard).
   adminEmail: "admin@zammad.local"
   adminPassword: "ZammadR0cks!"
   autowizardToken: "ssa-zammad-autowizard-9f3a2b1c"

--- a/scripts/bump-release.manifest.json
+++ b/scripts/bump-release.manifest.json
@@ -1,0 +1,11 @@
+{
+  "replacements": [
+    { "rule": "makefile_base_version", "paths": ["Makefile"] },
+    { "rule": "chart_app_version", "paths": ["helm/Chart.yaml"] },
+    { "rule": "release_image_tag_anchor", "paths": ["helm/values.yaml"] },
+    {
+      "rule": "bootstrap_image_tag",
+      "paths": ["helm/zammad/values.yaml"]
+    }
+  ]
+}

--- a/scripts/bump-release.sh
+++ b/scripts/bump-release.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Bump the blueprint release version. Files and replacement rules are listed in
+# scripts/bump-release.manifest.json (override with bump_release.py --manifest PATH).
+#
+# Usage:
+#   ./scripts/bump-release.sh <new-version>
+#   ./scripts/bump-release.sh --dry-run <new-version>
+#   python3 scripts/bump_release.py --verify
+#   python3 scripts/bump_release.py --verify --git-ref <sha>   # CI (git show)
+#
+# Release checklist (also run CI / image builds as appropriate):
+#   [ ] ./scripts/bump-release.sh X.Y.Z
+#   [ ] git diff — expect BASE_VERSION, appVersion, tag: &releaseImageTag, helm/zammad bootstrap.imageTag
+#   [ ] Build and push container images tagged X.Y.Z if your pipeline requires it
+#   [ ] Merge dev → main when checks pass
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec python3 "${SCRIPT_DIR}/bump_release.py" "$@"

--- a/scripts/bump-release.sh
+++ b/scripts/bump-release.sh
@@ -7,6 +7,7 @@
 #   ./scripts/bump-release.sh --dry-run <new-version>
 #   python3 scripts/bump_release.py --verify
 #   python3 scripts/bump_release.py --verify --git-ref <sha>   # CI (git show)
+#   python3 scripts/bump_release.py --print-manifest-paths --null | xargs -0 git add --
 #
 # Release checklist (also run CI / image builds as appropriate):
 #   [ ] ./scripts/bump-release.sh X.Y.Z

--- a/scripts/bump_release.py
+++ b/scripts/bump_release.py
@@ -177,6 +177,18 @@ if set(EXTRACTORS.keys()) != set(RULES.keys()):
     )
 
 
+def manifest_rel_paths(data: dict) -> list[str]:
+    """Paths from the manifest in JSON order; each path appears once."""
+    seen: set[str] = set()
+    out: list[str] = []
+    for item in data["replacements"]:
+        for p in item["paths"]:
+            if p not in seen:
+                seen.add(p)
+                out.append(p)
+    return out
+
+
 def load_manifest(path: pathlib.Path) -> dict:
     try:
         data = json.loads(path.read_text(encoding="utf-8"))
@@ -209,13 +221,25 @@ def load_manifest(path: pathlib.Path) -> dict:
 def main() -> None:
     parser = argparse.ArgumentParser(
         description=__doc__,
-        usage="%(prog)s [--verify] [--git-ref REF] [--dry-run] [--manifest PATH] [<version>]",
+        usage="%(prog)s [--verify] [--print-manifest-paths [-0]] [--git-ref REF] [--dry-run] [--manifest PATH] [<version>]",
     )
     parser.add_argument(
         "--manifest",
         type=pathlib.Path,
         default=DEFAULT_MANIFEST,
         help=f"JSON manifest of files and rules (default: {DEFAULT_MANIFEST})",
+    )
+    parser.add_argument(
+        "--print-manifest-paths",
+        action="store_true",
+        help="Print manifest-relative paths (one per line, or use -0 for xargs -0 git add)",
+    )
+    parser.add_argument(
+        "-0",
+        "--null",
+        dest="paths_nul_terminated",
+        action="store_true",
+        help="With --print-manifest-paths: write paths separated by ASCII NUL (safe for xargs -0 git add --)",
     )
     parser.add_argument(
         "--verify",
@@ -237,7 +261,7 @@ def main() -> None:
         "version",
         nargs="?",
         default=None,
-        help="New release version (e.g. 0.0.14); required unless --verify",
+        help="New release version (e.g. 0.0.14); required unless --verify or --print-manifest-paths",
     )
     args = parser.parse_args()
 
@@ -245,12 +269,32 @@ def main() -> None:
     if not manifest_path.is_absolute():
         manifest_path = (ROOT / manifest_path).resolve()
 
+    if args.paths_nul_terminated and not args.print_manifest_paths:
+        parser.error("-0/--null is only valid with --print-manifest-paths")
+
+    if args.print_manifest_paths:
+        if args.verify:
+            parser.error("--print-manifest-paths cannot be combined with --verify")
+        if args.git_ref:
+            parser.error("--print-manifest-paths cannot be combined with --git-ref")
+        if args.version:
+            parser.error("version must not be given with --print-manifest-paths")
+        data = load_manifest(manifest_path)
+        paths = manifest_rel_paths(data)
+        if args.paths_nul_terminated:
+            if paths:
+                sys.stdout.buffer.write("\0".join(paths).encode("utf-8"))
+        else:
+            for rel in paths:
+                print(rel)
+        return
+
     if args.verify:
         verify_manifest_alignment(manifest_path, git_ref=args.git_ref, repo_root=ROOT)
         return
 
     if not args.version:
-        parser.error("version is required unless --verify")
+        parser.error("version is required unless --verify or --print-manifest-paths")
 
     data = load_manifest(manifest_path)
     new_ver = args.version.strip().strip('"').strip("'")

--- a/scripts/bump_release.py
+++ b/scripts/bump_release.py
@@ -1,0 +1,300 @@
+#!/usr/bin/env python3
+"""Bump the blueprint release version using bump-release.manifest.json (rule + paths[] per entry)."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import re
+import subprocess
+import sys
+from typing import Callable
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+SCRIPT_DIR = pathlib.Path(__file__).resolve().parent
+DEFAULT_MANIFEST = SCRIPT_DIR / "bump-release.manifest.json"
+
+
+def read_makefile_base_version(makefile: str, **_: object) -> str:
+    m = re.search(r"^BASE_VERSION := (.+)$", makefile, re.MULTILINE)
+    if not m:
+        sys.exit("Could not find BASE_VERSION in Makefile")
+    return m.group(1).strip()
+
+
+def extract_chart_app_version(
+    text: str, *, context_path: str = "", **__: object
+) -> str:
+    for line in text.splitlines():
+        if line.startswith("appVersion:"):
+            rest = line[len("appVersion:") :].strip()
+            return rest.strip('"').strip("'")
+    ctx = f" ({context_path})" if context_path else ""
+    sys.exit(f"Could not find appVersion in Chart.yaml{ctx}")
+
+
+def extract_release_image_tag_anchor(
+    text: str, *, context_path: str = "", **__: object
+) -> str:
+    m = re.search(r'^\s+tag: &releaseImageTag "([^"]+)"', text, flags=re.MULTILINE)
+    if not m:
+        ctx = f" ({context_path})" if context_path else ""
+        sys.exit('Could not find tag: &releaseImageTag "..." in helm values' + ctx)
+    return m.group(1)
+
+
+def extract_bootstrap_image_tag(
+    text: str, *, context_path: str = "", **__: object
+) -> str:
+    m = re.search(r"^(\s+)imageTag:\s*\"([^\"]+)\"", text, flags=re.MULTILINE)
+    if not m:
+        ctx = f" ({context_path})" if context_path else ""
+        sys.exit(f"Could not find bootstrap imageTag in{ctx}")
+    return m.group(2)
+
+
+EXTRACTORS: dict[str, Callable[..., str]] = {
+    "makefile_base_version": read_makefile_base_version,
+    "chart_app_version": extract_chart_app_version,
+    "release_image_tag_anchor": extract_release_image_tag_anchor,
+    "bootstrap_image_tag": extract_bootstrap_image_tag,
+}
+
+
+def read_manifest_file(
+    rel: str, *, git_ref: str | None, repo_root: pathlib.Path
+) -> str:
+    """Load file text from the working tree or via git show REF:path."""
+    if git_ref:
+        cp = subprocess.run(
+            ["git", "show", f"{git_ref}:{rel}"],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+        )
+        if cp.returncode != 0:
+            sys.exit(
+                f"git show {git_ref}:{rel} failed: {cp.stderr.strip() or cp.stdout.strip()}"
+            )
+        return cp.stdout
+    path = repo_root / rel
+    if not path.is_file():
+        sys.exit(f"Manifest path does not exist or is not a file: {rel}")
+    return path.read_text(encoding="utf-8")
+
+
+def verify_manifest_alignment(
+    manifest_path: pathlib.Path, *, git_ref: str | None, repo_root: pathlib.Path
+) -> str:
+    """Ensure every manifest path's embedded version matches Makefile BASE_VERSION. Returns base version."""
+    data = load_manifest(manifest_path)
+    makefile_text = read_manifest_file("Makefile", git_ref=git_ref, repo_root=repo_root)
+    base = read_makefile_base_version(makefile_text)
+
+    errors: list[str] = []
+    for item in data["replacements"]:
+        rule_name = item["rule"]
+        extractor = EXTRACTORS[rule_name]
+        for rel in item["paths"]:
+            text = read_manifest_file(rel, git_ref=git_ref, repo_root=repo_root)
+            found = extractor(text, context_path=rel)
+            if found != base:
+                errors.append(
+                    f"{rel} ({rule_name}): found {found!r}, expected {base!r} (Makefile BASE_VERSION)"
+                )
+
+    if errors:
+        ref_note = f" (git ref {git_ref})" if git_ref else ""
+        print(
+            f"::error::Release version mismatch across manifest{ref_note}; fix with ./scripts/bump-release.sh {base}",
+            file=sys.stderr,
+        )
+        for msg in errors:
+            print(f"::error::{msg}", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"✅ bump-release manifest aligned with Makefile BASE_VERSION ({base})")
+    return base
+
+
+def replace_makefile_base_version(text: str, new_ver: str, **_: object) -> str:
+    def repl(match: re.Match[str]) -> str:
+        return f"{match.group(1)}{new_ver}"
+
+    out, n = re.subn(r"^(BASE_VERSION := ).+$", repl, text, count=1, flags=re.MULTILINE)
+    if n != 1:
+        sys.exit("Failed to replace BASE_VERSION in Makefile")
+    return out
+
+
+def replace_chart_app_version(text: str, new_ver: str, **_: object) -> str:
+    lines = text.splitlines(keepends=True)
+    for i, line in enumerate(lines):
+        if line.startswith("appVersion:"):
+            rest = line[len("appVersion:") :].strip()
+            if rest.startswith('"') and rest.endswith('"'):
+                lines[i] = f'appVersion: "{new_ver}"\n'
+            elif rest.startswith("'") and rest.endswith("'"):
+                lines[i] = f"appVersion: '{new_ver}'\n"
+            else:
+                lines[i] = f"appVersion: {new_ver}\n"
+            return "".join(lines)
+    sys.exit("Could not find appVersion in helm/Chart.yaml")
+
+
+def replace_release_image_tag_anchor(text: str, new_ver: str, **_: object) -> str:
+    pattern = r'(^\s+tag: &releaseImageTag )"[^"]+"'
+    out, n = re.subn(pattern, rf'\1"{new_ver}"', text, count=1, flags=re.MULTILINE)
+    if n != 1:
+        sys.exit(
+            'Could not find exactly one line matching: tag: &releaseImageTag "..." (release_image_tag_anchor rule)'
+        )
+    return out
+
+
+def replace_bootstrap_image_tag(
+    text: str, new_ver: str, *, context_path: pathlib.Path | None = None, **_: object
+) -> str:
+    pattern = r"^(\s+imageTag:\s*)\"[^\"]+\""
+    out, n = re.subn(pattern, rf'\1"{new_ver}"', text, count=1, flags=re.MULTILINE)
+    display = context_path if context_path is not None else "manifest path"
+    if n != 1:
+        sys.exit(f"Could not find bootstrap imageTag in {display}")
+    return out
+
+
+RULES: dict[str, Callable[..., str]] = {
+    "makefile_base_version": replace_makefile_base_version,
+    "chart_app_version": replace_chart_app_version,
+    "release_image_tag_anchor": replace_release_image_tag_anchor,
+    "bootstrap_image_tag": replace_bootstrap_image_tag,
+}
+
+if set(EXTRACTORS.keys()) != set(RULES.keys()):
+    raise RuntimeError(
+        "RULES and EXTRACTORS must define the same rule names (bump vs verify)"
+    )
+
+
+def load_manifest(path: pathlib.Path) -> dict:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        sys.exit(f"Manifest not found: {path}")
+    except json.JSONDecodeError as e:
+        sys.exit(f"Invalid JSON in {path}: {e}")
+    if not isinstance(data, dict):
+        sys.exit("Manifest root must be a JSON object")
+    reps = data.get("replacements")
+    if not isinstance(reps, list) or not reps:
+        sys.exit('Manifest must contain a non-empty "replacements" array')
+    for i, item in enumerate(reps):
+        if not isinstance(item, dict):
+            sys.exit(f"replacements[{i}] must be an object")
+        if "rule" not in item:
+            sys.exit(f'replacements[{i}] must have "rule"')
+        rule = item["rule"]
+        if rule not in RULES:
+            sys.exit(f'Unknown rule {rule!r}; known: {", ".join(sorted(RULES))}')
+        paths = item.get("paths")
+        if not isinstance(paths, list) or not paths:
+            sys.exit(f'replacements[{i}] must have a non-empty "paths" array')
+        for j, p in enumerate(paths):
+            if not isinstance(p, str) or not p.strip():
+                sys.exit(f"replacements[{i}].paths[{j}] must be a non-empty string")
+    return data
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        usage="%(prog)s [--verify] [--git-ref REF] [--dry-run] [--manifest PATH] [<version>]",
+    )
+    parser.add_argument(
+        "--manifest",
+        type=pathlib.Path,
+        default=DEFAULT_MANIFEST,
+        help=f"JSON manifest of files and rules (default: {DEFAULT_MANIFEST})",
+    )
+    parser.add_argument(
+        "--verify",
+        action="store_true",
+        help="Exit 0 if Makefile BASE_VERSION matches every path/rule in the manifest (same scope as bump)",
+    )
+    parser.add_argument(
+        "--git-ref",
+        metavar="REF",
+        default=None,
+        help="With --verify: read files via git show REF:path (CI compares dev commit without checkout)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print planned changes without writing files",
+    )
+    parser.add_argument(
+        "version",
+        nargs="?",
+        default=None,
+        help="New release version (e.g. 0.0.14); required unless --verify",
+    )
+    args = parser.parse_args()
+
+    manifest_path = args.manifest
+    if not manifest_path.is_absolute():
+        manifest_path = (ROOT / manifest_path).resolve()
+
+    if args.verify:
+        verify_manifest_alignment(manifest_path, git_ref=args.git_ref, repo_root=ROOT)
+        return
+
+    if not args.version:
+        parser.error("version is required unless --verify")
+
+    data = load_manifest(manifest_path)
+    new_ver = args.version.strip().strip('"').strip("'")
+    if not re.fullmatch(r"\d+\.\d+\.\d+(-\w+)?", new_ver):
+        sys.exit(f"Version must look like a semver release tag (got {new_ver!r})")
+
+    makefile_path = ROOT / "Makefile"
+    makefile = makefile_path.read_text(encoding="utf-8")
+    old_ver = read_makefile_base_version(makefile)
+
+    updates: list[tuple[pathlib.Path, str, str]] = []
+    for item in data["replacements"]:
+        rule_name = item["rule"]
+        rule_fn = RULES[rule_name]
+        for rel in item["paths"]:
+            path = ROOT / rel
+            if not path.is_file():
+                sys.exit(f"Manifest path does not exist or is not a file: {rel}")
+            text = path.read_text(encoding="utf-8")
+            new_text = rule_fn(text, new_ver, context_path=path)
+            updates.append((path, new_text, text))
+
+    changed = [(path, nt) for path, nt, ot in updates if nt != ot]
+    if not changed:
+        print(f"Already at {new_ver}; all manifest paths aligned.")
+        return
+
+    if old_ver != new_ver:
+        print(f"Bumping release version: {old_ver} -> {new_ver}")
+    else:
+        print(
+            f"Makefile BASE_VERSION already {new_ver}; updating other drifted manifest paths."
+        )
+    for path, _ in changed:
+        print(f"  write {path.relative_to(ROOT)}")
+    if not args.dry_run:
+        for path, content in changed:
+            path.write_text(content, encoding="utf-8")
+        print(
+            "Done. Review with git diff; build/push images for the new tag as needed."
+        )
+    else:
+        print("(dry-run: no files modified)")
+
+
+if __name__ == "__main__":
+    main()

--- a/zammad-bootstrap/bootstrap.py
+++ b/zammad-bootstrap/bootstrap.py
@@ -311,7 +311,7 @@ _KUBE_NS = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
 
 
 def create_mcp_token_and_update_k8s():
-    """Create Zammad MCP agent API token, patch k8s secret, trigger deployment restarts."""
+    """Create Zammad MCP agent API token, update k8s secret (read+replace), restart deployments."""
     credentials_secret = os.environ["ZAMMAD_CREDENTIALS_SECRET"]
     mcp_deployment = os.environ.get("ZAMMAD_MCP_DEPLOYMENT", "")
     request_manager_deployment = os.environ.get("ZAMMAD_REQUEST_MANAGER_DEPLOYMENT", "")
@@ -343,21 +343,30 @@ def create_mcp_token_and_update_k8s():
     def _b64(s):
         return base64.b64encode(s.encode()).decode()
 
-    print(f"  Patching secret {credentials_secret} in namespace {namespace}...")
+    print(f"  Updating secret {credentials_secret} in namespace {namespace}...")
     try:
-        core_v1.patch_namespaced_secret(
+        # Use read + replace instead of PATCH: some clusters (notably OpenShift) return 401 or other
+        # failures on strategic-merge PATCH for Secrets even when RBAC allows patch/update.
+        existing = core_v1.read_namespaced_secret(
+            name=credentials_secret, namespace=namespace
+        )
+        data = dict(existing.data or {})
+        data["zammad-url"] = _b64(zammad_url)
+        data["zammad-api-url"] = _b64(f"{zammad_url}/api/v1")
+        data["zammad-http-token"] = _b64(token)
+        existing.data = data
+        core_v1.replace_namespaced_secret(
             name=credentials_secret,
             namespace=namespace,
-            body={
-                "data": {
-                    "zammad-url": _b64(zammad_url),
-                    "zammad-api-url": _b64(f"{zammad_url}/api/v1"),
-                    "zammad-http-token": _b64(token),
-                }
-            },
+            body=existing,
         )
     except k8s_client.ApiException as e:
-        print(f"  ERROR patching secret: {e.status} {e.reason}", file=sys.stderr)
+        detail = (e.body or "").strip()[:500]
+        extra = f" — {detail}" if detail else ""
+        print(
+            f"  ERROR updating secret: {e.status} {e.reason}{extra}",
+            file=sys.stderr,
+        )
         sys.exit(1)
     print("  Secret updated.")
 


### PR DESCRIPTION
- Add `scripts/bump-release.sh` / `bump_release.py` + manifest to bump `BASE_VERSION`, Chart `appVersion`, `helm/values.yaml` release image anchor, and Zammad bootstrap `imageTag`; skip unchanged files and fix drift when Makefile already matches.
- Zammad bootstrap: registry/repo/tag only in values/templates; Zammad MCP image tag aliases `releaseImageTag`.
- Update dev→main and dev version-bump workflows for YAML anchors/aliases; version-bump workflow runs the bump script instead of `sed`.