### PR TITLE
Zammad login fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1784,7 +1784,7 @@ _helm-install-ticketing-print-checklist:
 		echo "     Web UI: https://$$ZAMMAD_ROUTE"; \
 		echo "     API:    https://$$ZAMMAD_ROUTE/api/v1"; \
 		if [ -n "$$ZAMMAD_DEMO_SITE_INSTALLED" ]; then \
-			echo "     Demo site (same host): https://$$ZAMMAD_ROUTE/$(ZAMMAD_DEMO_SITE_PATH)/ — chat snippet page: /$(ZAMMAD_DEMO_SITE_PATH)/chat-embed.html"; \
+			echo "     Demo site (same host): https://$$ZAMMAD_ROUTE/$(ZAMMAD_DEMO_SITE_PATH)/ — chat-embed: /$(ZAMMAD_DEMO_SITE_PATH)/chat-embed.html (widget needs agents online for chat; Admin → Channels → Chat)."; \
 		else \
 			echo "     Demo site: not installed — ZAMMAD_DEMO_SITE_ENABLED was not true. Re-run with ZAMMAD_DEMO_SITE_ENABLED=true (default) or omit it."; \
 		fi; \
@@ -1794,12 +1794,6 @@ _helm-install-ticketing-print-checklist:
 		echo "     API:    http://localhost:8080/api/v1"; \
 	fi
 	@echo ""
-	@ZAMMAD_DEMO_SITE_INSTALLED=$$(oc get route ssa-zammad-demo-site -n $(NAMESPACE) -o name 2>/dev/null); \
-	if [ -z "$$ZAMMAD_DEMO_SITE_INSTALLED" ]; then ZAMMAD_DEMO_SITE_INSTALLED=$$(oc get route ssa-zammad-embed -n $(NAMESPACE) -o name 2>/dev/null); fi; \
-	if [ -n "$$ZAMMAD_DEMO_SITE_INSTALLED" ]; then \
-		echo "  2. Demo site: login at /$(ZAMMAD_DEMO_SITE_PATH)/; chat widget snippet + preview at /$(ZAMMAD_DEMO_SITE_PATH)/chat-embed.html on the Web UI host. Admin → Channels → Chat (agents must be available for the widget)."; \
-		echo ""; \
-	fi
 	@echo "  Admin login defaults: ZAMMAD_ADMIN_EMAIL / ZAMMAD_ADMIN_PASSWORD (see Makefile; must match autoWizard in helm/values-ticketing.yaml)."
 	@echo "  More: README.md, docs/HELM_EXPORT_ANSIBLE.md"
 	@echo ""

--- a/helm/zammad-demo-site/templates/_demo-site.tpl
+++ b/helm/zammad-demo-site/templates/_demo-site.tpl
@@ -500,16 +500,43 @@
       }
     }
 
+    function browserFingerprint() {
+      var key = 'zammad-demo-fp';
+      try {
+        var s = sessionStorage.getItem(key);
+        if (s && s.length <= 160) return s;
+        s = '';
+        if (window.crypto && crypto.getRandomValues) {
+          var buf = new Uint8Array(16);
+          crypto.getRandomValues(buf);
+          for (var i = 0; i < buf.length; i++) {
+            s += (buf[i] < 16 ? '0' : '') + buf[i].toString(16);
+          }
+        } else {
+          for (var j = 0; j < 32; j++) s += Math.floor(Math.random() * 16).toString(16);
+        }
+        sessionStorage.setItem(key, s);
+        return s;
+      } catch (e) {
+        return 'fp' + String(Date.now()) + String(Math.random()).slice(2, 18);
+      }
+    }
+
     function signInToZammad(username, password) {
       var base = ZAMMAD_BASE + '/';
-      var json = { 'Content-Type': 'application/json', Accept: 'application/json' };
+      var fp = browserFingerprint();
+      var json = {
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+        'X-Browser-Fingerprint': fp
+      };
       var signshow = new URL('api/v1/signshow', base);
       var signin = new URL('api/v1/signin', base);
       return fetch(signshow.toString(), {
         method: 'POST',
         credentials: 'include',
         headers: json,
-        body: '{}'
+        body: JSON.stringify({ fingerprint: fp })
       }).then(function(res) {
         var csrf = res.headers.get('csrf-token') || res.headers.get('CSRF-TOKEN');
         if (!csrf) {
@@ -519,7 +546,7 @@
           method: 'POST',
           credentials: 'include',
           headers: Object.assign({ 'X-CSRF-Token': csrf }, json),
-          body: JSON.stringify({ username: username, password: password })
+          body: JSON.stringify({ username: username, password: password, fingerprint: fp })
         });
       }).then(function(res) {
         if (res.status === 201) return;


### PR DESCRIPTION
**What was going wrong**
- Zammad’s login API expects a small “fingerprint” string that identifies the browser (for device/security logging).
- The full Zammad website sets that when you use it. Our demo page was not sending it, so the first time you used persona quick sign-in (without opening Zammad first), the server could answer with “Need fingerprint param!”.
- Opening “Open Zammad” once made it seem “fixed” because the real Zammad UI had already supplied that fingerprint in your session.

**What we changed (the fix)**
The demo page now creates a stable random fingerprint in the browser (and remembers it for that tab), and sends it on both steps it already used:
- signshow (to get the CSRF token)
- signin (actual login)

So persona sign-in works on the first try, without needing to open Zammad first, including in incognito.