### PR TITLE
chore: update llama-stack to v0.6.0

### DIFF
--- a/agent-service/pyproject.toml
+++ b/agent-service/pyproject.toml
@@ -13,8 +13,8 @@ dependencies = [
     "cloudevents>=1.10.0",
     "httpx>=0.25.0",
     "structlog>=23.2.0",
-    # LlamaStack integration (matches server version 0.5.0)
-    "llama-stack-client==0.5.0",
+    # LlamaStack integration (matches server version 0.6.0)
+    "llama-stack-client==0.6.0",
     "requests>=2.31.0",
     "self-service-agent-shared-models",
     "protobuf>=6.33.5",

--- a/agent-service/requirements.txt
+++ b/agent-service/requirements.txt
@@ -403,9 +403,9 @@ langsmith==0.6.6 \
     --hash=sha256:64ba70e7b795cff3c498fe6f2586314da1cc855471a5e5b6a357950324af3874 \
     --hash=sha256:fe655e73b198cd00d0ecd00a26046eaf1f78cd0b2f0d94d1e5591f3143c5f592
     # via langchain-core
-llama-stack-client==0.5.0 \
-    --hash=sha256:5e7272c7fb58cd169985191c42af78dc6c4d212b7050949b063788bfb9e7ed36 \
-    --hash=sha256:e005ae9d975cda30b3b86261057f228d700107e263e12b796b920cd1fb9ba968
+llama-stack-client==0.6.0 \
+    --hash=sha256:3290aac36dcafbd1bc0baaf995522e2037f57056672b5a1516af112a4210f3ea \
+    --hash=sha256:7e514a6ffd92f237aceb062dadc4db44e24a3cd9c4ea35e25173d1e0739beb8e
     # via self-service-agent-service
 mako==1.3.10 \
     --hash=sha256:99579a6f39583fa7e5630a28c3c1f440e4e97a414b80372649c0ce338da2ea28 \

--- a/agent-service/uv.lock
+++ b/agent-service/uv.lock
@@ -864,7 +864,7 @@ wheels = [
 
 [[package]]
 name = "llama-stack-client"
-version = "0.5.0"
+version = "0.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -883,9 +883,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/af/a1/1bd9ed2b6982fb1edf0215be1a4569eb65c9354b86bfdcb5b1414b489162/llama_stack_client-0.5.0.tar.gz", hash = "sha256:e005ae9d975cda30b3b86261057f228d700107e263e12b796b920cd1fb9ba968", size = 368629, upload-time = "2026-02-05T17:23:06.688Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b7/e9/62dc71e7d6003d9b56a1e632445065f55687c891e62eff1636e10b5dd629/llama_stack_client-0.6.0.tar.gz", hash = "sha256:3290aac36dcafbd1bc0baaf995522e2037f57056672b5a1516af112a4210f3ea", size = 368695, upload-time = "2026-03-11T15:04:19.267676Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2d/93/63b434955cdb80d54c69bdb51ecd1a12595451ce238667fdaa125fb7d1ec/llama_stack_client-0.5.0-py3-none-any.whl", hash = "sha256:5e7272c7fb58cd169985191c42af78dc6c4d212b7050949b063788bfb9e7ed36", size = 391950, upload-time = "2026-02-05T17:23:04.238Z" },
+    { url = "https://files.pythonhosted.org/packages/83/a3/33d3e066a320a993b6f9cca9c8efe8da7deb2045df61235d327d0a05b25f/llama_stack_client-0.6.0-py3-none-any.whl", hash = "sha256:7e514a6ffd92f237aceb062dadc4db44e24a3cd9c4ea35e25173d1e0739beb8e", size = 392001, upload-time = "2026-03-11T15:04:17.772620Z" },
 ]
 
 [[package]]
@@ -1903,7 +1903,7 @@ requires-dist = [
     { name = "langfuse", specifier = ">=3.0.0" },
     { name = "langgraph", specifier = "==1.0.7" },
     { name = "langgraph-checkpoint-postgres", specifier = ">=2.0.0" },
-    { name = "llama-stack-client", specifier = "==0.5.0" },
+    { name = "llama-stack-client", specifier = "==0.6.0" },
     { name = "openai", specifier = ">=1.0.0" },
     { name = "opentelemetry-exporter-otlp-proto-http", specifier = ">=1.37.0" },
     { name = "opentelemetry-instrumentation-fastapi", specifier = ">=0.58b0" },

--- a/helm/Chart.lock
+++ b/helm/Chart.lock
@@ -7,12 +7,12 @@ dependencies:
   version: 0.5.6
 - name: llama-stack
   repository: https://rh-ai-quickstart.github.io/ai-architecture-charts
-  version: 0.7.0
+  version: 0.7.4
 - name: mcp-servers
   repository: https://rh-ai-quickstart.github.io/ai-architecture-charts
   version: 0.5.17
 - name: ticketingZammad
   repository: file://./zammad
   version: 0.1.0
-digest: sha256:94c6930f6e999095f2f6e1bd03f3d7e85b5a69abd1cd3c0051a8618e48c249e8
-generated: "2026-04-22T17:53:32.70222144-04:00"
+digest: sha256:719f5c9287f5b8abd77b5e4b6b645added37c0f009a829057bcb18d9ca32733a
+generated: "2026-05-04T15:30:41.624154252+03:00"

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -17,7 +17,7 @@ dependencies:
     repository: https://rh-ai-quickstart.github.io/ai-architecture-charts
     condition: llm-service.enabled
   - name: llama-stack
-    version: 0.7.0
+    version: 0.7.4
     repository: https://rh-ai-quickstart.github.io/ai-architecture-charts
   - name: mcp-servers
     version: 0.5.17

--- a/request-manager/requirements.txt
+++ b/request-manager/requirements.txt
@@ -510,9 +510,9 @@ langsmith==0.6.6 \
     --hash=sha256:64ba70e7b795cff3c498fe6f2586314da1cc855471a5e5b6a357950324af3874 \
     --hash=sha256:fe655e73b198cd00d0ecd00a26046eaf1f78cd0b2f0d94d1e5591f3143c5f592
     # via langchain-core
-llama-stack-client==0.5.0 \
-    --hash=sha256:5e7272c7fb58cd169985191c42af78dc6c4d212b7050949b063788bfb9e7ed36 \
-    --hash=sha256:e005ae9d975cda30b3b86261057f228d700107e263e12b796b920cd1fb9ba968
+llama-stack-client==0.6.0 \
+    --hash=sha256:3290aac36dcafbd1bc0baaf995522e2037f57056672b5a1516af112a4210f3ea \
+    --hash=sha256:7e514a6ffd92f237aceb062dadc4db44e24a3cd9c4ea35e25173d1e0739beb8e
     # via self-service-agent-service
 mako==1.3.10 \
     --hash=sha256:99579a6f39583fa7e5630a28c3c1f440e4e97a414b80372649c0ce338da2ea28 \

--- a/request-manager/uv.lock
+++ b/request-manager/uv.lock
@@ -974,7 +974,7 @@ wheels = [
 
 [[package]]
 name = "llama-stack-client"
-version = "0.5.0"
+version = "0.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -993,9 +993,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/af/a1/1bd9ed2b6982fb1edf0215be1a4569eb65c9354b86bfdcb5b1414b489162/llama_stack_client-0.5.0.tar.gz", hash = "sha256:e005ae9d975cda30b3b86261057f228d700107e263e12b796b920cd1fb9ba968", size = 368629, upload-time = "2026-02-05T17:23:06.688Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b7/e9/62dc71e7d6003d9b56a1e632445065f55687c891e62eff1636e10b5dd629/llama_stack_client-0.6.0.tar.gz", hash = "sha256:3290aac36dcafbd1bc0baaf995522e2037f57056672b5a1516af112a4210f3ea", size = 368695, upload-time = "2026-03-11T15:04:19.267676Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2d/93/63b434955cdb80d54c69bdb51ecd1a12595451ce238667fdaa125fb7d1ec/llama_stack_client-0.5.0-py3-none-any.whl", hash = "sha256:5e7272c7fb58cd169985191c42af78dc6c4d212b7050949b063788bfb9e7ed36", size = 391950, upload-time = "2026-02-05T17:23:04.238Z" },
+    { url = "https://files.pythonhosted.org/packages/83/a3/33d3e066a320a993b6f9cca9c8efe8da7deb2045df61235d327d0a05b25f/llama_stack_client-0.6.0-py3-none-any.whl", hash = "sha256:7e514a6ffd92f237aceb062dadc4db44e24a3cd9c4ea35e25173d1e0739beb8e", size = 392001, upload-time = "2026-03-11T15:04:17.772620Z" },
 ]
 
 [[package]]
@@ -2097,7 +2097,7 @@ requires-dist = [
     { name = "langfuse", specifier = ">=3.0.0" },
     { name = "langgraph", specifier = "==1.0.7" },
     { name = "langgraph-checkpoint-postgres", specifier = ">=2.0.0" },
-    { name = "llama-stack-client", specifier = "==0.5.0" },
+    { name = "llama-stack-client", specifier = "==0.6.0" },
     { name = "openai", specifier = ">=1.0.0" },
     { name = "opentelemetry-exporter-otlp-proto-http", specifier = ">=1.37.0" },
     { name = "opentelemetry-instrumentation-fastapi", specifier = ">=0.58b0" },


### PR DESCRIPTION
**ref:** https://redhat.atlassian.net/browse/APPENG-4807

Updates llama-stack chart to v0.6.0 (chart v0.7.4). No breaking API changes for our usage.

## Changes
- Llama-stack chart: Updated from `0.7.0` → `0.7.4`
- Llama-stack-client: Updated from `0.5.0` → `0.6.0` in `agent-service` and `request-manager`

Tested end-to-end following the [llama stack upgrade checks](https://docs.google.com/document/d/1b4sdWRlj1cvdus1tWyLQqrYa7WfCsHhJ6iuhPjiHK0o/edit?tab=t.0)