### PR TITLE
option to seed a knowledge base via ConfigMap

### DIFF
--- a/agent-service/src/agent_service/knowledge/kb_manager.py
+++ b/agent-service/src/agent_service/knowledge/kb_manager.py
@@ -23,8 +23,12 @@ class KnowledgeBaseManager:
         else:
             logger.debug("Already connected to LlamaStack client")
 
-    def register_knowledge_bases(self) -> bool:
+    def register_knowledge_bases(self, extra_path: Optional[Path] = None) -> bool:
         """Register all knowledge bases by processing directories in knowledge_bases path.
+
+        Args:
+            extra_path: Optional additional directory to scan for knowledge bases
+                        (e.g. a ConfigMap mount). Each subdirectory is treated as a KB.
 
         Returns:
             bool: True if all knowledge bases were registered successfully, False otherwise.
@@ -34,33 +38,35 @@ class KnowledgeBaseManager:
 
         logger.debug("Registering knowledge bases via LlamaStack OpenAI-compatible API")
 
-        if not self._knowledge_bases_path.exists():
-            logger.warning(
-                "Knowledge bases path does not exist",
-                path=str(self._knowledge_bases_path),
-            )
-            return True  # No knowledge bases to register is not a failure
-
         success = True
-        # Process each directory in knowledge_bases
-        for kb_dir in self._knowledge_bases_path.iterdir():
-            if kb_dir.is_dir():
-                # Register via LlamaStack OpenAI-compatible API
-                result = self.register_knowledge_base(kb_dir)
 
-                # Log results
-                kb_name = kb_dir.name
-                if result:
-                    logger.info(
-                        "Successfully registered knowledge base via LlamaStack",
-                        kb_name=kb_name,
-                    )
-                else:
-                    logger.error(
-                        "Failed to register knowledge base via LlamaStack",
-                        kb_name=kb_name,
-                    )
-                    success = False
+        paths_to_scan = [self._knowledge_bases_path]
+        if extra_path is not None:
+            paths_to_scan.append(extra_path)
+
+        for scan_path in paths_to_scan:
+            if not scan_path.exists():
+                logger.warning(
+                    "Knowledge bases path does not exist",
+                    path=str(scan_path),
+                )
+                continue  # No knowledge bases in this path is not a failure
+
+            for kb_dir in scan_path.iterdir():
+                if kb_dir.is_dir():
+                    result = self.register_knowledge_base(kb_dir)
+                    kb_name = kb_dir.name
+                    if result:
+                        logger.info(
+                            "Successfully registered knowledge base via LlamaStack",
+                            kb_name=kb_name,
+                        )
+                    else:
+                        logger.error(
+                            "Failed to register knowledge base via LlamaStack",
+                            kb_name=kb_name,
+                        )
+                        success = False
 
         return success
 

--- a/agent-service/src/agent_service/scripts/register_assets.py
+++ b/agent-service/src/agent_service/scripts/register_assets.py
@@ -1,18 +1,21 @@
 """Asset registration script for agent service."""
 
+import os
 import sys
+from pathlib import Path
 
 from agent_service.knowledge import KnowledgeBaseManager
 
 
 def main() -> None:
     """Main entry point for asset registration."""
-    # Initialize managers
     kb_manager = KnowledgeBaseManager()
 
-    # Register knowledge bases
+    extra_kb_path_str = os.environ.get("EXTRA_KB_PATH", "")
+    extra_path = Path(extra_kb_path_str) if extra_kb_path_str else None
+
     print("Registering knowledge bases...")
-    success = kb_manager.register_knowledge_bases()
+    success = kb_manager.register_knowledge_bases(extra_path=extra_path)
 
     if success:
         print("Asset registration completed successfully")

--- a/helm/templates/init-job.yaml
+++ b/helm/templates/init-job.yaml
@@ -56,6 +56,10 @@ spec:
               value: {{ .Values.llamastack.timeout | quote }}
             {{- end }}
             {{- end }}
+            {{- if and (hasKey .Values "knowledgeBases") .Values.knowledgeBases.configMaps }}
+            - name: EXTRA_KB_PATH
+              value: /mnt/knowledge-bases
+            {{- end }}
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
@@ -67,6 +71,14 @@ spec:
           {{- if and (hasKey .Values "requestManagement") (hasKey .Values.requestManagement "initJob") .Values.requestManagement.initJob.resources }}
           resources:
             {{- toYaml .Values.requestManagement.initJob.resources | nindent 12 }}
+          {{- end }}
+          {{- if and (hasKey .Values "knowledgeBases") .Values.knowledgeBases.configMaps }}
+          volumeMounts:
+            {{- range .Values.knowledgeBases.configMaps }}
+            - name: kb-cm-{{ .kbName | default .name | lower | replace "_" "-" | replace "." "-" }}
+              mountPath: /mnt/knowledge-bases/{{ .kbName | default .name }}
+              readOnly: true
+            {{- end }}
           {{- end }}
           command:
             - /bin/bash
@@ -93,3 +105,11 @@ spec:
               
               # If we get here, the script succeeded (set -e will exit on failure)
               echo "Initialization job completed successfully"
+      {{- if and (hasKey .Values "knowledgeBases") .Values.knowledgeBases.configMaps }}
+      volumes:
+        {{- range .Values.knowledgeBases.configMaps }}
+        - name: kb-cm-{{ .kbName | default .name | lower | replace "_" "-" | replace "." "-" }}
+          configMap:
+            name: {{ .name }}
+        {{- end }}
+      {{- end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -91,6 +91,18 @@ affinity: {}
 
 llama_stack_url: http://llamastack:8321
 
+# Knowledge Base Configuration
+knowledgeBases:
+  # Optional: seed additional knowledge bases from pre-existing ConfigMaps.
+  # Each ConfigMap's files are registered as a separate knowledge base.
+  # This is additive — built-in KBs from the agent-service image are always registered.
+  #
+  # Example:
+  #   configMaps:
+  #     - name: my-kb-configmap   # Name of the ConfigMap in the same namespace
+  #       kbName: my-custom-kb    # KB name to register under (defaults to ConfigMap name)
+  configMaps: []
+
 # LlamaStack Client Configuration
 # These settings configure both the native LlamaStack client and OpenAI-compatible client
 # By default, clients use Kubernetes auto-injected service discovery environment variables


### PR DESCRIPTION
1. **User creates a ConfigMap** with their KB documents (each key = a file):

>     apiVersion: v1 
>     kind: ConfigMap
>     metadata:
>       name: my-kb-configmap
>     data:
>       policy.txt: |
>         Content here...
>       faq.txt: |
>         More content...

    
2. **User references it in `values.yaml`**:

>     knowledgeBases:
>       configMaps:
>         - name: my-kb-configmap   # pre-existing ConfigMap
>           kbName: my-custom-kb    # optional, defaults to ConfigMap name

    
3. **Helm renders the init job** with:
    - `EXTRA_KB_PATH=/mnt/knowledge-bases` env var
    - Each ConfigMap mounted as a subdirectory: `/mnt/knowledge-bases/my-custom-kb/`
4. **`register_assets.py`** reads `EXTRA_KB_PATH` and passes it to the KB manager.
5. **`KnowledgeBaseManager.register_knowledge_bases()`** scans both the built-in `config/knowledge_bases/` path and the extra path. Each subdirectory in the extra path becomes a KB — registered in LlamaStack exactly like the image-bundled ones.