### PR TITLE
Rename Zammad specialist users for AI agent display in UI

### DIFF
--- a/zammad-bootstrap/bootstrap.py
+++ b/zammad-bootstrap/bootstrap.py
@@ -1209,15 +1209,15 @@ def main():
     }
     get_or_create_user(
         "agent.laptop-specialist",
-        "Laptop",
-        "Specialist",
+        "Laptop Refresh AI",
+        "Agent",
         "agent.laptop-specialist@example.com",
         role_ids=agent_role_ids,
         group_ids=specialist_group_ids,
     )
     get_or_create_user(
         "agent.general",
-        "General",
+        "General AI",
         "Agent",
         "agent.general@example.com",
         role_ids=agent_role_ids,


### PR DESCRIPTION
## Summary

Renames how the ticket specialist agents appear in the **Zammad UI** (firstname/lastname) to make it obvious these are automated AI agents.

- **Laptop specialist** (`agent.laptop-specialist@example.com`): **Laptop Refresh AI** / **Agent** → displays as **Laptop Refresh AI Agent**
- **General specialist** (`agent.general@example.com`): **General AI** / **Agent** → displays as **General AI Agent**
