### PR TITLE
feat: add eval capabilities for ticket Status

### DIFF
--- a/evaluations/deep_eval.py
+++ b/evaluations/deep_eval.py
@@ -58,7 +58,10 @@ Your responsibilities:
 Note: Providing clear, factual information about potential rejection or additional approvals is sufficient. You do not need to be overly cautionary or repeatedly emphasize warnings. Always confirm with the user before creating tickets."""
 
 
-def _convert_to_turns(conversation_data: List[Dict[str, str]]) -> List[Turn]:
+def _convert_to_turns(
+    conversation_data: List[Dict[str, Any]],
+    include_conversation_metadata: bool = False,
+) -> List[Turn]:
     """
     Convert conversation data from role/content format to DeepEval Turn objects.
 
@@ -66,9 +69,15 @@ def _convert_to_turns(conversation_data: List[Dict[str, str]]) -> List[Turn]:
     'role' and 'content' keys into DeepEval Turn objects that can be used for
     conversational evaluation. Empty content is automatically filtered out.
 
+    When include_conversation_metadata is True, conversation metadata
+    (expected/actual) is stored in Turn.additional_metadata so custom
+    metrics can access it without polluting turn content.
+
     Args:
         conversation_data: List of dictionaries with 'role' and 'content' keys
                           representing the conversation turns
+        include_conversation_metadata: If True, store conversation metadata in
+                          Turn.additional_metadata for custom metric evaluation.
 
     Returns:
         List[Turn]: List of DeepEval Turn objects ready for evaluation
@@ -86,7 +95,16 @@ def _convert_to_turns(conversation_data: List[Dict[str, str]]) -> List[Turn]:
         if role not in ["user", "assistant"]:
             role = "user"  # Default to user if role is invalid
 
-        turns.append(Turn(role=role, content=content))  # type: ignore[arg-type]
+        # Store conversation metadata in Turn.additional_metadata
+        # so custom metrics can access it without polluting content.
+        metadata = None
+        if include_conversation_metadata:
+            if role == "user" and "expected_conversation_metadata" in turn_data:
+                metadata = turn_data["expected_conversation_metadata"]
+            elif role == "assistant" and "actual_conversation_metadata" in turn_data:
+                metadata = turn_data["actual_conversation_metadata"]
+
+        turns.append(Turn(role=role, content=content, additional_metadata=metadata))
 
     return turns
 
@@ -102,6 +120,7 @@ def _evaluate_conversations(
     metrics: Optional[List[Any]] = None,
     chatbot_role: Optional[str] = None,
     default_context_dir: Optional[str] = None,
+    include_conversation_metadata: bool = False,
 ) -> int:
     """
     Main evaluation function that processes conversation files and generates assessment reports.
@@ -127,6 +146,7 @@ def _evaluate_conversations(
         metrics: Pre-loaded metrics list. If None, uses default get_metrics() with a new model.
         chatbot_role: Override for the chatbot role description. If None, uses the default role.
         default_context_dir: Override for the default context directory. If None, uses the standard path.
+        include_conversation_metadata: Whether to store in Turn.additional_metadata for custom metric evaluation.
 
     Returns:
         int: Exit code (0 for success, 1 for failure) indicating evaluation outcome
@@ -218,7 +238,7 @@ def _evaluate_conversations(
             )
 
             # Convert to turns
-            turns = _convert_to_turns(conversation_data)
+            turns = _convert_to_turns(conversation_data, include_conversation_metadata)
 
             if len(turns) < 2:
                 logger.warning(
@@ -627,6 +647,9 @@ if __name__ == "__main__":
         )
         flow_chatbot_role = getattr(flow_module, "CHATBOT_ROLE", None)
         flow_context_dir = str(flow_paths.context_dir)
+        flow_include_metadata = getattr(
+            flow_module, "DEFAULT_INCLUDE_CONVERSATION_METADATA", False
+        )
 
         print(f"Running flow '{flow_name}': {results_dir} -> {output_dir}")
         exit_code = _evaluate_conversations(
@@ -640,6 +663,7 @@ if __name__ == "__main__":
             metrics=flow_metrics,
             chatbot_role=flow_chatbot_role,
             default_context_dir=flow_context_dir,
+            include_conversation_metadata=flow_include_metadata,
         )
         overall_exit_code = max(overall_exit_code, exit_code)
 

--- a/evaluations/flows/ticket_laptop_refresh/conversations/close-mid-flow.json
+++ b/evaluations/flows/ticket_laptop_refresh/conversations/close-mid-flow.json
@@ -7,15 +7,30 @@
     "conversation": [
         {
             "role": "user",
-            "content": "I would like to refresh my laptop"
+            "content": "I would like to refresh my laptop",
+            "expected_conversation_metadata": {
+                "state": "open",
+                "owner": "agent.laptop-specialist",
+                "group": "Users"
+            }
         },
         {
             "role": "user",
-            "content": "yes, show me the laptop options"
+            "content": "yes, show me the laptop options",
+            "expected_conversation_metadata": {
+                "state": "open",
+                "owner": "agent.laptop-specialist",
+                "group": "Users"
+            }
         },
         {
             "role": "user",
-            "content": "please close this ticket, I've changed my mind"
+            "content": "please close this ticket, I've changed my mind",
+            "expected_conversation_metadata": {
+                "state": "closed",
+                "owner": "agent.laptop-specialist",
+                "group": "Users"
+            }
         }
     ]
 }

--- a/evaluations/flows/ticket_laptop_refresh/conversations/escalate-mid-flow.json
+++ b/evaluations/flows/ticket_laptop_refresh/conversations/escalate-mid-flow.json
@@ -7,15 +7,30 @@
     "conversation": [
         {
             "role": "user",
-            "content": "I would like to refresh my laptop"
+            "content": "I would like to refresh my laptop",
+            "expected_conversation_metadata": {
+                "state": "open",
+                "owner": "agent.laptop-specialist",
+                "group": "Users"
+            }
         },
         {
             "role": "user",
-            "content": "yes, show me the laptop options"
+            "content": "yes, show me the laptop options",
+            "expected_conversation_metadata": {
+                "state": "open",
+                "owner": "agent.laptop-specialist",
+                "group": "Users"
+            }
         },
         {
             "role": "user",
-            "content": "please escalate this ticket, I want a human to handle it"
+            "content": "please escalate this ticket, I want a human to handle it",
+            "expected_conversation_metadata": {
+                "state": "open",
+                "owner": "-",
+                "group": "escalated_laptop_refresh_tickets"
+            }
         }
     ]
 }

--- a/evaluations/flows/ticket_laptop_refresh/conversations/not-eligible-close.json
+++ b/evaluations/flows/ticket_laptop_refresh/conversations/not-eligible-close.json
@@ -7,11 +7,21 @@
     "conversation": [
         {
             "role": "user",
-            "content": "I would like to refresh my laptop"
+            "content": "I would like to refresh my laptop",
+            "expected_conversation_metadata": {
+                "state": "open",
+                "owner": "agent.laptop-specialist",
+                "group": "Users"
+            }
         },
         {
             "role": "user",
-            "content": "close the ticket"
+            "content": "close the ticket",
+            "expected_conversation_metadata": {
+                "state": "closed",
+                "owner": "agent.laptop-specialist",
+                "group": "Users"
+            }
         }
     ]
 }

--- a/evaluations/flows/ticket_laptop_refresh/conversations/not-eligible-escalate.json
+++ b/evaluations/flows/ticket_laptop_refresh/conversations/not-eligible-escalate.json
@@ -7,11 +7,21 @@
     "conversation": [
         {
             "role": "user",
-            "content": "I would like to refresh my laptop"
+            "content": "I would like to refresh my laptop",
+            "expected_conversation_metadata": {
+                "state": "open",
+                "owner": "agent.laptop-specialist",
+                "group": "Users"
+            }
         },
         {
             "role": "user",
-            "content": "I'd like to escalate and request an exception"
+            "content": "I'd like to escalate and request an exception",
+            "expected_conversation_metadata": {
+                "state": "open",
+                "owner": "-",
+                "group": "escalated_laptop_refresh_tickets"
+            }
         }
     ]
 }

--- a/evaluations/flows/ticket_laptop_refresh/conversations/out-of-scope-close.json
+++ b/evaluations/flows/ticket_laptop_refresh/conversations/out-of-scope-close.json
@@ -7,19 +7,39 @@
     "conversation": [
         {
             "role": "user",
-            "content": "I would like to refresh laptop"
+            "content": "I would like to refresh laptop",
+            "expected_conversation_metadata": {
+                "state": "open",
+                "owner": "agent.laptop-specialist",
+                "group": "Users"
+            }
         },
         {
             "role": "user",
-            "content": "actually can you help me reset my password? I'm locked out"
+            "content": "actually can you help me reset my password? I'm locked out",
+            "expected_conversation_metadata": {
+                "state": "open",
+                "owner": "agent.laptop-specialist",
+                "group": "Users"
+            }
         },
         {
             "role": "user",
-            "content": "ok what about my external monitor, it stopped working yesterday"
+            "content": "ok what about my external monitor, it stopped working yesterday",
+            "expected_conversation_metadata": {
+                "state": "open",
+                "owner": "agent.laptop-specialist",
+                "group": "Users"
+            }
         },
         {
             "role": "user",
-            "content": "close the ticket"
+            "content": "close the ticket",
+            "expected_conversation_metadata": {
+                "state": "closed",
+                "owner": "agent.laptop-specialist",
+                "group": "Users"
+            }
         }
     ]
 }

--- a/evaluations/flows/ticket_laptop_refresh/conversations/success-flow-1.json
+++ b/evaluations/flows/ticket_laptop_refresh/conversations/success-flow-1.json
@@ -7,19 +7,39 @@
     "conversation": [
         {
             "role": "user",
-            "content": "I would like to refresh my laptop"
+            "content": "I would like to refresh my laptop",
+            "expected_conversation_metadata": {
+                "state": "open",
+                "owner": "agent.laptop-specialist",
+                "group": "Users"
+            }
         },
         {
             "role": "user",
-            "content": "I would like to see the options"
+            "content": "I would like to see the options",
+            "expected_conversation_metadata": {
+                "state": "open",
+                "owner": "agent.laptop-specialist",
+                "group": "Users"
+            }
         },
         {
             "role": "user",
-            "content": "3"
+            "content": "3",
+            "expected_conversation_metadata": {
+                "state": "open",
+                "owner": "agent.laptop-specialist",
+                "group": "Users"
+            }
         },
         {
             "role": "user",
-            "content": "proceed"
+            "content": "proceed",
+            "expected_conversation_metadata": {
+                "state": "open",
+                "owner": "manager1",
+                "group": "Users"
+            }
         }
     ]
 }

--- a/evaluations/flows/ticket_laptop_refresh/conversations/success-flow-inline-select-with-send.json
+++ b/evaluations/flows/ticket_laptop_refresh/conversations/success-flow-inline-select-with-send.json
@@ -7,19 +7,39 @@
     "conversation": [
         {
             "role": "user",
-            "content": "I would like to refresh my laptop"
+            "content": "I would like to refresh my laptop",
+            "expected_conversation_metadata": {
+                "state": "open",
+                "owner": "agent.laptop-specialist",
+                "group": "Users"
+            }
         },
         {
             "role": "user",
-            "content": "yes, show me the available options"
+            "content": "yes, show me the available options",
+            "expected_conversation_metadata": {
+                "state": "open",
+                "owner": "agent.laptop-specialist",
+                "group": "Users"
+            }
         },
         {
             "role": "user",
-            "content": "I'll take option 1, please send it to my manager for approval"
+            "content": "I'll take option 1, please send it to my manager for approval",
+            "expected_conversation_metadata": {
+                "state": "open",
+                "owner": "agent.laptop-specialist",
+                "group": "Users"
+            }
         },
         {
             "role": "user",
-            "content": "yes"
+            "content": "yes",
+            "expected_conversation_metadata": {
+                "state": "open",
+                "owner": "manager1",
+                "group": "Users"
+            }
         }
     ]
 }

--- a/evaluations/flows/ticket_laptop_refresh/flow.py
+++ b/evaluations/flows/ticket_laptop_refresh/flow.py
@@ -9,6 +9,7 @@ DEFAULT_SKIP_INITIAL_MESSAGE: bool = True
 DEFAULT_INITIAL_MESSAGE: str = "requesting a laptop refresh"
 # Explicit subject for Zammad ticket creation (same default as test/ticket-responses-request-mgr.py).
 DEFAULT_TICKET_TITLE: str = "Laptop refresh help request"
+DEFAULT_INCLUDE_CONVERSATION_METADATA: bool = True
 KNOWLEDGE_BASE_DIRS: List[str] = ["laptop-refresh"]
 INCLUDE_SNOW_DATA: bool = True
 

--- a/evaluations/flows/ticket_laptop_refresh/known_bad_conversations/wrong-escalate-flow-group-status.json
+++ b/evaluations/flows/ticket_laptop_refresh/known_bad_conversations/wrong-escalate-flow-group-status.json
@@ -1,0 +1,62 @@
+{
+  "metadata": {
+    "authoritative_user_id": "david.chen@company.com",
+    "description": "Actual conversation metadata does not match expected — fails with conversation metadata group for escalate flow"
+  },
+  "conversation": [
+    {
+      "role": "user",
+      "content": "I would like to refresh my laptop",
+      "expected_conversation_metadata": {
+        "state": "open",
+        "owner": "agent.laptop-specialist",
+        "group": "Users"
+      }
+    },
+    {
+      "role": "assistant",
+      "content": "According to the knowledge base, the refresh interval is 3 years.\nYour laptop, a ZenBook Pro 15, was purchased on 2020-07-22 and is currently 5 years and 9 months old (69 total months). The company's laptop refresh policy states that standard laptops will be refreshed every 3 years (36 months) from the date of issuance. Since your laptop is 5 years and 9 months old (69 months), which is greater than or equal to 3 years (36 months), you are eligible for a laptop refresh.\nHere is your laptop information:\nEmployee Name: David Chen\nEmployee Location: APAC\nLaptop Model: ZenBook Pro 15\nLaptop Serial Number: AS15008\nLaptop Purchase Date: 2020-07-22\nLaptop Age: 5 years and 9 months\nLaptop Warranty Expiry Date: 2023-07-22\nLaptop Warranty: Expired\nWould you like to proceed with reviewing the available laptop options for your location?",
+      "actual_conversation_metadata": {
+        "state": "open",
+        "owner": "agent.laptop-specialist",
+        "group": "Users"
+      }
+    },
+    {
+      "role": "user",
+      "content": "yes, show me the laptop options",
+      "expected_conversation_metadata": {
+        "state": "open",
+        "owner": "agent.laptop-specialist",
+        "group": "Users"
+      }
+    },
+    {
+      "role": "assistant",
+      "content": "Here are the available laptop options for your location (APAC):\n1. Model: MacBook Air M2 - ServiceNow Code: apple_mac_book_air_m_2\n- Manufacturer: Apple\n- Target User: General Office\n- Cost: ¥11,000 CNY\n- Operating System: macOS\n- Display Size: 13.6 inches\n- Display Resolution: 2560 x 1664\n- Graphics Card: Apple M2 GPU\n- Minimum Storage: 256 GB SSD\n- Weight: 2.7 lbs\n- Ports: 2 x Thunderbolt/USB 4, MagSafe\n- Minimum Processor: Apple M2\n- Minimum Memory: 8 GB\n- Dimensions: 11.97 x 8.46 x 0.44 inches\n2. Model: MacBook Pro 14 M3 - ServiceNow Code: apple_mac_book_pro_14_m_3\n- Manufacturer: Apple\n- Target User: Developers\n- Cost: ¥15,000 CNY\n- Operating System: macOS\n- Display Size: 14.2 inches\n- Display Resolution: 3024 x 1964\n- Graphics Card: Apple M3 GPU\n- Minimum Storage: 512 GB SSD\n- Weight: 3.5 lbs\n- Ports: 3 x Thunderbolt 4, HDMI, SDXC, MagSafe\n- Minimum Processor: Apple M3\n- Minimum Memory: 18 GB\n- Dimensions: 12.31 x 8.71 x 0.61 inches\n3. Model: ThinkPad T14 Gen 5 AMD - ServiceNow Code: lenovo_think_pad_t_14_gen_5_amd\n- Manufacturer: Lenovo\n- Target User: General Office\n- Cost: ¥10,000 CNY\n- Operating System: Windows 11 Pro\n- Display Size: 14 inches\n- Display Resolution: 1920 x 1200\n- Graphics Card: Integrated AMD Radeon\n- Minimum Storage: 512 GB SSD\n- Weight: 3.1 lbs\n- Ports: 2 x USB-C, 2 x USB-A, HDMI, Ethernet, Audio Jack\n- Minimum Processor: AMD Ryzen 7 PRO 7840U\n- Minimum Memory: 16 GB\n- Dimensions: 12.5 x 8.8 x 0.7 inches\n4. Model: ThinkPad P1 Gen 6 - ServiceNow Code: lenovo_think_pad_p_1_gen_6\n- Manufacturer: Lenovo\n- Target User: Engineers\n- Cost: ¥18,000 CNY\n- Operating System: Red Hat Linux\n- Display Size: 16 inches\n- Display Resolution: 3840 x 2400\n- Graphics Card: NVIDIA RTX A2000\n- Minimum Storage: 1 TB SSD\n- Weight: 4.1 lbs\n- Ports: 2 x USB-C, 2 x USB-A, HDMI, SD Card, Audio Jack\n- Minimum Processor: Intel Core i9-13900H\n- Minimum Memory: 32 GB\n- Dimensions: 14.1 x 9.9 x 0.7 inches\nPlease select one of the above options. Remember to consider your job role and requirements when making your selection.",
+      "actual_conversation_metadata": {
+        "state": "open",
+        "owner": "agent.laptop-specialist",
+        "group": "Users"
+      }
+    },
+    {
+      "role": "user",
+      "content": "please escalate this ticket, I want a human to handle it",
+      "expected_conversation_metadata": {
+        "state": "open",
+        "owner": "-",
+        "group": "escalated_laptop_refresh_tickets"
+      }
+    },
+    {
+      "role": "assistant",
+      "content": "Your ticket has been escalated for human review. ticket_escalated",
+      "actual_conversation_metadata": {
+        "state": "open",
+        "owner": "-",
+        "group": "Users"
+      }
+    }
+  ]
+}

--- a/evaluations/flows/ticket_laptop_refresh/known_bad_conversations/wrong-escalate-flow-owner-status.json
+++ b/evaluations/flows/ticket_laptop_refresh/known_bad_conversations/wrong-escalate-flow-owner-status.json
@@ -1,0 +1,62 @@
+{
+  "metadata": {
+    "authoritative_user_id": "david.chen@company.com",
+    "description": "Actual conversation metadata does not match expected — fails with conversation metadata owner for escalate flow"
+  },
+  "conversation": [
+    {
+      "role": "user",
+      "content": "I would like to refresh my laptop",
+      "expected_conversation_metadata": {
+        "state": "open",
+        "owner": "agent.laptop-specialist",
+        "group": "Users"
+      }
+    },
+    {
+      "role": "assistant",
+      "content": "According to the knowledge base, the refresh interval is 3 years.\nYour laptop, a ZenBook Pro 15, was purchased on 2020-07-22 and is currently 5 years and 9 months old (69 total months). The company's laptop refresh policy states that standard laptops will be refreshed every 3 years (36 months) from the date of issuance. Since your laptop is 5 years and 9 months old (69 months), which is greater than or equal to 3 years (36 months), you are eligible for a laptop refresh.\nHere is your laptop information:\nEmployee Name: David Chen\nEmployee Location: APAC\nLaptop Model: ZenBook Pro 15\nLaptop Serial Number: AS15008\nLaptop Purchase Date: 2020-07-22\nLaptop Age: 5 years and 9 months\nLaptop Warranty Expiry Date: 2023-07-22\nLaptop Warranty: Expired\nWould you like to proceed with reviewing the available laptop options for your location?",
+      "actual_conversation_metadata": {
+        "state": "open",
+        "owner": "agent.laptop-specialist",
+        "group": "Users"
+      }
+    },
+    {
+      "role": "user",
+      "content": "yes, show me the laptop options",
+      "expected_conversation_metadata": {
+        "state": "open",
+        "owner": "agent.laptop-specialist",
+        "group": "Users"
+      }
+    },
+    {
+      "role": "assistant",
+      "content": "Here are the available laptop options for your location (APAC):\n1. Model: MacBook Air M2 - ServiceNow Code: apple_mac_book_air_m_2\n- Manufacturer: Apple\n- Target User: General Office\n- Cost: ¥11,000 CNY\n- Operating System: macOS\n- Display Size: 13.6 inches\n- Display Resolution: 2560 x 1664\n- Graphics Card: Apple M2 GPU\n- Minimum Storage: 256 GB SSD\n- Weight: 2.7 lbs\n- Ports: 2 x Thunderbolt/USB 4, MagSafe\n- Minimum Processor: Apple M2\n- Minimum Memory: 8 GB\n- Dimensions: 11.97 x 8.46 x 0.44 inches\n2. Model: MacBook Pro 14 M3 - ServiceNow Code: apple_mac_book_pro_14_m_3\n- Manufacturer: Apple\n- Target User: Developers\n- Cost: ¥15,000 CNY\n- Operating System: macOS\n- Display Size: 14.2 inches\n- Display Resolution: 3024 x 1964\n- Graphics Card: Apple M3 GPU\n- Minimum Storage: 512 GB SSD\n- Weight: 3.5 lbs\n- Ports: 3 x Thunderbolt 4, HDMI, SDXC, MagSafe\n- Minimum Processor: Apple M3\n- Minimum Memory: 18 GB\n- Dimensions: 12.31 x 8.71 x 0.61 inches\n3. Model: ThinkPad T14 Gen 5 AMD - ServiceNow Code: lenovo_think_pad_t_14_gen_5_amd\n- Manufacturer: Lenovo\n- Target User: General Office\n- Cost: ¥10,000 CNY\n- Operating System: Windows 11 Pro\n- Display Size: 14 inches\n- Display Resolution: 1920 x 1200\n- Graphics Card: Integrated AMD Radeon\n- Minimum Storage: 512 GB SSD\n- Weight: 3.1 lbs\n- Ports: 2 x USB-C, 2 x USB-A, HDMI, Ethernet, Audio Jack\n- Minimum Processor: AMD Ryzen 7 PRO 7840U\n- Minimum Memory: 16 GB\n- Dimensions: 12.5 x 8.8 x 0.7 inches\n4. Model: ThinkPad P1 Gen 6 - ServiceNow Code: lenovo_think_pad_p_1_gen_6\n- Manufacturer: Lenovo\n- Target User: Engineers\n- Cost: ¥18,000 CNY\n- Operating System: Red Hat Linux\n- Display Size: 16 inches\n- Display Resolution: 3840 x 2400\n- Graphics Card: NVIDIA RTX A2000\n- Minimum Storage: 1 TB SSD\n- Weight: 4.1 lbs\n- Ports: 2 x USB-C, 2 x USB-A, HDMI, SD Card, Audio Jack\n- Minimum Processor: Intel Core i9-13900H\n- Minimum Memory: 32 GB\n- Dimensions: 14.1 x 9.9 x 0.7 inches\nPlease select one of the above options. Remember to consider your job role and requirements when making your selection.",
+      "actual_conversation_metadata": {
+        "state": "open",
+        "owner": "agent.laptop-specialist",
+        "group": "Users"
+      }
+    },
+    {
+      "role": "user",
+      "content": "please escalate this ticket, I want a human to handle it",
+      "expected_conversation_metadata": {
+        "state": "open",
+        "owner": "-",
+        "group": "escalated_laptop_refresh_tickets"
+      }
+    },
+    {
+      "role": "assistant",
+      "content": "Your ticket has been escalated for human review. ticket_escalated",
+      "actual_conversation_metadata": {
+        "state": "open",
+        "owner": "agent.laptop-specialist",
+        "group": "escalated_laptop_refresh_tickets"
+      }
+    }
+  ]
+}

--- a/evaluations/flows/ticket_laptop_refresh/known_bad_conversations/wrong-escalate-flow-state-status.json
+++ b/evaluations/flows/ticket_laptop_refresh/known_bad_conversations/wrong-escalate-flow-state-status.json
@@ -1,0 +1,62 @@
+{
+  "metadata": {
+    "authoritative_user_id": "david.chen@company.com",
+    "description": "Actual conversation metadata does not match expected — fails with conversation metadata state for escalate flow"
+  },
+  "conversation": [
+    {
+      "role": "user",
+      "content": "I would like to refresh my laptop",
+      "expected_conversation_metadata": {
+        "state": "open",
+        "owner": "agent.laptop-specialist",
+        "group": "Users"
+      }
+    },
+    {
+      "role": "assistant",
+      "content": "According to the knowledge base, the refresh interval is 3 years.\nYour laptop, a ZenBook Pro 15, was purchased on 2020-07-22 and is currently 5 years and 9 months old (69 total months). The company's laptop refresh policy states that standard laptops will be refreshed every 3 years (36 months) from the date of issuance. Since your laptop is 5 years and 9 months old (69 months), which is greater than or equal to 3 years (36 months), you are eligible for a laptop refresh.\nHere is your laptop information:\nEmployee Name: David Chen\nEmployee Location: APAC\nLaptop Model: ZenBook Pro 15\nLaptop Serial Number: AS15008\nLaptop Purchase Date: 2020-07-22\nLaptop Age: 5 years and 9 months\nLaptop Warranty Expiry Date: 2023-07-22\nLaptop Warranty: Expired\nWould you like to proceed with reviewing the available laptop options for your location?",
+      "actual_conversation_metadata": {
+        "state": "open",
+        "owner": "agent.laptop-specialist",
+        "group": "Users"
+      }
+    },
+    {
+      "role": "user",
+      "content": "yes, show me the laptop options",
+      "expected_conversation_metadata": {
+        "state": "open",
+        "owner": "agent.laptop-specialist",
+        "group": "Users"
+      }
+    },
+    {
+      "role": "assistant",
+      "content": "Here are the available laptop options for your location (APAC):\n1. Model: MacBook Air M2 - ServiceNow Code: apple_mac_book_air_m_2\n- Manufacturer: Apple\n- Target User: General Office\n- Cost: ¥11,000 CNY\n- Operating System: macOS\n- Display Size: 13.6 inches\n- Display Resolution: 2560 x 1664\n- Graphics Card: Apple M2 GPU\n- Minimum Storage: 256 GB SSD\n- Weight: 2.7 lbs\n- Ports: 2 x Thunderbolt/USB 4, MagSafe\n- Minimum Processor: Apple M2\n- Minimum Memory: 8 GB\n- Dimensions: 11.97 x 8.46 x 0.44 inches\n2. Model: MacBook Pro 14 M3 - ServiceNow Code: apple_mac_book_pro_14_m_3\n- Manufacturer: Apple\n- Target User: Developers\n- Cost: ¥15,000 CNY\n- Operating System: macOS\n- Display Size: 14.2 inches\n- Display Resolution: 3024 x 1964\n- Graphics Card: Apple M3 GPU\n- Minimum Storage: 512 GB SSD\n- Weight: 3.5 lbs\n- Ports: 3 x Thunderbolt 4, HDMI, SDXC, MagSafe\n- Minimum Processor: Apple M3\n- Minimum Memory: 18 GB\n- Dimensions: 12.31 x 8.71 x 0.61 inches\n3. Model: ThinkPad T14 Gen 5 AMD - ServiceNow Code: lenovo_think_pad_t_14_gen_5_amd\n- Manufacturer: Lenovo\n- Target User: General Office\n- Cost: ¥10,000 CNY\n- Operating System: Windows 11 Pro\n- Display Size: 14 inches\n- Display Resolution: 1920 x 1200\n- Graphics Card: Integrated AMD Radeon\n- Minimum Storage: 512 GB SSD\n- Weight: 3.1 lbs\n- Ports: 2 x USB-C, 2 x USB-A, HDMI, Ethernet, Audio Jack\n- Minimum Processor: AMD Ryzen 7 PRO 7840U\n- Minimum Memory: 16 GB\n- Dimensions: 12.5 x 8.8 x 0.7 inches\n4. Model: ThinkPad P1 Gen 6 - ServiceNow Code: lenovo_think_pad_p_1_gen_6\n- Manufacturer: Lenovo\n- Target User: Engineers\n- Cost: ¥18,000 CNY\n- Operating System: Red Hat Linux\n- Display Size: 16 inches\n- Display Resolution: 3840 x 2400\n- Graphics Card: NVIDIA RTX A2000\n- Minimum Storage: 1 TB SSD\n- Weight: 4.1 lbs\n- Ports: 2 x USB-C, 2 x USB-A, HDMI, SD Card, Audio Jack\n- Minimum Processor: Intel Core i9-13900H\n- Minimum Memory: 32 GB\n- Dimensions: 14.1 x 9.9 x 0.7 inches\nPlease select one of the above options. Remember to consider your job role and requirements when making your selection.",
+      "actual_conversation_metadata": {
+        "state": "open",
+        "owner": "agent.laptop-specialist",
+        "group": "Users"
+      }
+    },
+    {
+      "role": "user",
+      "content": "please escalate this ticket, I want a human to handle it",
+      "expected_conversation_metadata": {
+        "state": "open",
+        "owner": "-",
+        "group": "escalated_laptop_refresh_tickets"
+      }
+    },
+    {
+      "role": "assistant",
+      "content": "Your ticket has been escalated for human review. ticket_escalated",
+      "actual_conversation_metadata": {
+        "state": "closed",
+        "owner": "-",
+        "group": "escalated_laptop_refresh_tickets"
+      }
+    }
+  ]
+}

--- a/evaluations/flows/ticket_laptop_refresh/metrics.py
+++ b/evaluations/flows/ticket_laptop_refresh/metrics.py
@@ -11,6 +11,7 @@ from typing import Any, List, Optional
 from deepeval.metrics import ConversationalGEval
 from deepeval.models import DeepEvalBaseLLM
 from deepeval.test_case import ConversationalTestCase, TurnParams
+from helpers.conversation_metadata_eval import ConversationMetadataEval
 from helpers.load_conversation_context import load_default_context
 
 # Context directory for this flow (populated at eval time by copy_flow_context).
@@ -343,6 +344,10 @@ def get_metrics(
                 "FAIL this metric ONLY if: the ticket is explicitly sent to the manager WITHOUT the agent having asked for confirmation first, or before the user responds.",
                 "IMPORTANT: Do NOT require the agent to confirm the ticket was sent. Do NOT fail this metric because the ticket was never sent. Do NOT consider whether the laptop selection was valid or invalid.",
             ],
+        ),
+        ConversationMetadataEval(
+            name="Correct conversation metadata",
+            threshold=1.0,
         ),
     ]
 

--- a/evaluations/flows/ticket_unrelated/conversations/follow-up-close.json
+++ b/evaluations/flows/ticket_unrelated/conversations/follow-up-close.json
@@ -7,15 +7,30 @@
     "conversation": [
         {
             "role": "user",
-            "content": "I can't access a shared drive, I'm getting an authentication error"
+            "content": "I can't access a shared drive, I'm getting an authentication error",
+            "expected_conversation_metadata": {
+                "state": "open",
+                "owner": "agent.general",
+                "group": "Users"
+            }
         },
         {
             "role": "user",
-            "content": "What if I don't have admin rights to change those settings?"
+            "content": "What if I don't have admin rights to change those settings?",
+            "expected_conversation_metadata": {
+                "state": "open",
+                "owner": "agent.general",
+                "group": "Users"
+            }
         },
         {
             "role": "user",
-            "content": "OK thanks, please close the ticket"
+            "content": "OK thanks, please close the ticket",
+            "expected_conversation_metadata": {
+                "state": "closed",
+                "owner": "agent.general",
+                "group": "Users"
+            }
         }
     ]
 }

--- a/evaluations/flows/ticket_unrelated/conversations/out-of-scope-escalate.json
+++ b/evaluations/flows/ticket_unrelated/conversations/out-of-scope-escalate.json
@@ -1,13 +1,13 @@
 {
     "metadata": {
-        "authoritative_user_id": "ahmed.hassan@company.com",
-        "description": "User asks a question, asks a follow-up, then escalates for further human assistance",
+        "authoritative_user_id": "yuki.tanaka@company.com",
+        "description": "User reports a slow laptop, then decides to explore replacing it and asks for escalation to a human.",
         "use_first_message_as_initial": true
     },
     "conversation": [
         {
             "role": "user",
-            "content": "My work email stopped syncing on my phone this morning",
+            "content": "My laptop works very slow this morning",
             "expected_conversation_metadata": {
                 "state": "open",
                 "owner": "agent.general",
@@ -16,7 +16,7 @@
         },
         {
             "role": "user",
-            "content": "I've already tried removing and re-adding the account but it still isn't working",
+            "content": "actually can you help me refresh my laptop? It's really slow and I think it's time for a new one",
             "expected_conversation_metadata": {
                 "state": "open",
                 "owner": "agent.general",
@@ -25,7 +25,7 @@
         },
         {
             "role": "user",
-            "content": "Please escalate this ticket, I need someone to take a proper look",
+            "content": "I would like to explore options for replacing my laptop. Please escalate this ticket, I need someone to take a proper look",
             "expected_conversation_metadata": {
                 "state": "open",
                 "owner": "-",

--- a/evaluations/flows/ticket_unrelated/conversations/simple-close.json
+++ b/evaluations/flows/ticket_unrelated/conversations/simple-close.json
@@ -7,11 +7,21 @@
     "conversation": [
         {
             "role": "user",
-            "content": "How do I set up two-factor authentication on my work account?"
+            "content": "How do I set up two-factor authentication on my work account?",
+            "expected_conversation_metadata": {
+                "state": "open",
+                "owner": "agent.general",
+                "group": "Users"
+            }
         },
         {
             "role": "user",
-            "content": "That worked, please close the ticket"
+            "content": "That worked, please close the ticket",
+            "expected_conversation_metadata": {
+                "state": "closed",
+                "owner": "agent.general",
+                "group": "Users"
+            }
         }
     ]
 }

--- a/evaluations/flows/ticket_unrelated/conversations/simple-escalate.json
+++ b/evaluations/flows/ticket_unrelated/conversations/simple-escalate.json
@@ -7,11 +7,21 @@
     "conversation": [
         {
             "role": "user",
-            "content": "My VPN keeps disconnecting every few minutes"
+            "content": "My VPN keeps disconnecting every few minutes",
+            "expected_conversation_metadata": {
+                "state": "open",
+                "owner": "agent.general",
+                "group": "Users"
+            }
         },
         {
             "role": "user",
-            "content": "Please escalate this to a network specialist"
+            "content": "Please escalate this to a network specialist",
+            "expected_conversation_metadata": {
+                "state": "open",
+                "owner": "-",
+                "group": "human_managed_tickets"
+            }
         }
     ]
 }

--- a/evaluations/flows/ticket_unrelated/flow.py
+++ b/evaluations/flows/ticket_unrelated/flow.py
@@ -9,6 +9,7 @@ DEFAULT_SKIP_INITIAL_MESSAGE: bool = True
 # Neutral wording — avoid "refresh" in the title or routing may classify LAPTOP_REFRESH from the title alone.
 DEFAULT_INITIAL_MESSAGE: str = "General IT assistance"
 DEFAULT_TICKET_TITLE: str = "General workplace IT issue"
+DEFAULT_INCLUDE_CONVERSATION_METADATA: bool = True
 DEFAULT_MAX_TURNS: int = 10
 KNOWLEDGE_BASE_DIRS: List[str] = []
 INCLUDE_SNOW_DATA: bool = False

--- a/evaluations/flows/ticket_unrelated/known_bad_conversations/wrong_ticket_status.json
+++ b/evaluations/flows/ticket_unrelated/known_bad_conversations/wrong_ticket_status.json
@@ -1,0 +1,44 @@
+{
+  "metadata": {
+    "authoritative_user_id": "sophie.dubois@company.com",
+    "description": "Actual conversation metadata does not match expected — fails with conversation metadata group and owner"
+  },
+  "conversation": [
+    {
+      "role": "user",
+      "content": "My printer is not working",
+      "expected_conversation_metadata": {
+        "state": "open",
+        "owner": "agent.general",
+        "group": "Users"
+      }
+    },
+    {
+      "role": "assistant",
+      "content": "Hello! I'm a general support agent. Let me help you with your printer issue. Have you tried restarting the printer?",
+      "actual_conversation_metadata": {
+        "state": "open",
+        "owner": "agent.general",
+        "group": "Users"
+      }
+    },
+    {
+      "role": "user",
+      "content": "Yes I tried, please close the ticket",
+      "expected_conversation_metadata": {
+        "state": "closed",
+        "owner": "agent.general",
+        "group": "Users"
+      }
+    },
+    {
+      "role": "assistant",
+      "content": "Your ticket has been closed. ticket_closed",
+      "actual_conversation_metadata": {
+        "state": "closed",
+        "owner": "-",
+        "group": "human_managed_tickets"
+      }
+    }
+  ]
+}

--- a/evaluations/flows/ticket_unrelated/metrics.py
+++ b/evaluations/flows/ticket_unrelated/metrics.py
@@ -5,6 +5,7 @@ from typing import Any, List, Optional
 from deepeval.metrics import ConversationalGEval
 from deepeval.models import DeepEvalBaseLLM
 from deepeval.test_case import TurnParams
+from helpers.conversation_metadata_eval import ConversationMetadataEval
 
 
 def get_metrics(
@@ -69,6 +70,10 @@ def get_metrics(
                 "  - Tool call failures or stack traces visible in the response",
                 "PASS if the agent responds normally even if it cannot fully resolve the user's issue.",
             ],
+        ),
+        ConversationMetadataEval(
+            name="Correct conversation metadata",
+            threshold=1.0,
         ),
     ]
 

--- a/evaluations/helpers/conversation_metadata_eval.py
+++ b/evaluations/helpers/conversation_metadata_eval.py
@@ -1,0 +1,112 @@
+"""
+A custom deterministic conversational metric for comparing expected vs actual conversation metadata.
+
+This metric compares metadata stored in Turn.additional_metadata between
+paired user/assistant turns. It is fully deterministic — no LLM is used.
+
+User turns hold expected metadata, assistant turns hold actual metadata.
+The metric compares all fields in each pair and reports mismatches.
+
+Usage:
+    from helpers.conversation_metadata_eval import ConversationMetadataEval
+
+    metric = ConversationMetadataEval(
+        name="Correct conversation metadata",
+        threshold=1.0,
+    )
+"""
+
+from typing import Any, List
+
+from deepeval.metrics import BaseConversationalMetric
+from deepeval.test_case import ConversationalTestCase
+
+
+class ConversationMetadataEval(BaseConversationalMetric):
+    """
+    Deterministic metric that compares expected vs actual metadata per turn pair.
+
+    For each user turn with additional_metadata (expected), finds the immediately
+    following assistant turn's additional_metadata (actual) and compares all fields.
+
+    Scores 1.0 if all pairs match, 0.0 if any pair has a mismatch.
+    Skips (scores 1.0) if no turn has additional_metadata.
+    """
+
+    def __init__(
+        self,
+        name: str = "Correct conversation metadata",
+        threshold: float = 1.0,
+        include_reason: bool = True,
+        async_mode: bool = True,
+        **kwargs: Any,
+    ) -> None:
+        self.threshold = threshold
+        self.name = name
+        self.include_reason = include_reason
+        self.async_mode = async_mode
+
+    def measure(
+        self, test_case: ConversationalTestCase, *args: Any, **kwargs: Any
+    ) -> float:
+        turns = test_case.turns
+        mismatches: List[str] = []
+        pair_count = 0
+
+        for i, turn in enumerate(turns):
+            if turn.role != "user" or turn.additional_metadata is None:
+                continue
+
+            expected = turn.additional_metadata
+            pair_count += 1
+            next_turn = turns[i + 1] if i + 1 < len(turns) else None
+
+            if not next_turn or next_turn.role != "assistant":
+                mismatches.append(
+                    f"pair {pair_count}: no assistant turn following user turn"
+                )
+                continue
+
+            actual = next_turn.additional_metadata
+            if actual is None:
+                mismatches.append(
+                    f"pair {pair_count}: assistant turn has no actual metadata"
+                )
+                continue
+
+            for key in expected.keys() | actual.keys():
+                if expected.get(key) != actual.get(key):
+                    mismatches.append(
+                        f"pair {pair_count}: {key} expected='{expected.get(key)}' actual='{actual.get(key)}'"
+                    )
+
+        self.score = 0.0 if mismatches else 1.0
+        self.reason = (
+            "No conversation metadata to evaluate"
+            if pair_count == 0
+            else (
+                f"All {pair_count} metadata pair(s) match"
+                if not mismatches
+                else f"Metadata mismatch: {'; '.join(mismatches)}"
+            )
+        )
+        self.success = self.score >= self.threshold
+        return self.score
+
+    async def a_measure(
+        self, test_case: ConversationalTestCase, *args: Any, **kwargs: Any
+    ) -> float:
+        return self.measure(test_case)
+
+    def is_successful(self) -> bool:
+        if self.error is not None:
+            self.success = False
+        elif self.score is None:
+            self.success = False
+        else:
+            self.success = self.score >= self.threshold
+        return self.success
+
+    @property
+    def __name__(self) -> str:
+        return self.name

--- a/evaluations/helpers/openshift_chat_client.py
+++ b/evaluations/helpers/openshift_chat_client.py
@@ -2,6 +2,7 @@
 
 import logging
 import os
+import select
 import subprocess
 import time
 from typing import Dict, List, Optional
@@ -24,6 +25,7 @@ class OpenShiftChatClient:
         skip_initial_message: bool = False,
         message_timeout: int = 60,
         ticket_title: Optional[str] = None,
+        include_conversation_metadata: bool = False,
     ):
         """
         Initialize the OpenShift chat client.
@@ -39,6 +41,7 @@ class OpenShiftChatClient:
                                   the caller to send the first message. Only used when reset_conversation is True.
             message_timeout: Timeout in seconds for individual message send/response operations (default: 60)
             ticket_title: Optional title to pass as --ticket-title to the test script.
+            include_conversation_metadata: If True, pass --include-conversation_metadata to the test script to emit TICKET_STATUS lines after each agent response.
         """
         self.deployment_name = deployment_name
         self.test_script = test_script
@@ -48,6 +51,8 @@ class OpenShiftChatClient:
         self.skip_initial_message = skip_initial_message
         self.message_timeout = message_timeout
         self.ticket_title = ticket_title
+        self.include_conversation_metadata = include_conversation_metadata
+        self.last_conversation_metadata: Optional[Dict[str, str]] = None
         self.process: Optional[subprocess.Popen[str]] = None
         self.session_active = False
         self.session_output: list[str] = []  # Capture all output for token parsing
@@ -94,6 +99,8 @@ class OpenShiftChatClient:
             if self.ticket_title:
                 escaped_title = self.ticket_title.replace("'", "'\\''")
                 script_cmd += f" --ticket-title '{escaped_title}'"
+            if self.include_conversation_metadata:
+                script_cmd += " --include-conversation_metadata"
             cmd = [
                 "oc",
                 "exec",
@@ -198,12 +205,17 @@ class OpenShiftChatClient:
         if timeout is None:
             timeout = self.message_timeout
 
+        self.last_conversation_metadata = None
+
         try:
             if self.process.stdin is not None:
                 self.process.stdin.write(message + "\n")
                 self.process.stdin.flush()
 
             response = self._read_full_agent_message(timeout)
+
+            if self.include_conversation_metadata:
+                self._read_conversation_metadata()
 
             logger.debug(f"Sent: {message}")
             logger.debug(
@@ -316,6 +328,64 @@ class OpenShiftChatClient:
 
         return result
 
+    def _read_conversation_metadata(self) -> None:
+        """Read and parse the conversation metadata of the TICKET_STATUS line from stdout after agent response.
+
+        Uses select() with a timeout to avoid blocking if no TICKET_STATUS
+        line is emitted (e.g. for **tokens** messages or other non-standard responses).
+        """
+        if not self.process or not self.process.stdout:
+            return
+        if self.process.poll() is not None:
+            logger.debug("Process terminated while reading conversation metadata")
+            return
+        try:
+            ready, _, _ = select.select([self.process.stdout], [], [], 5.0)
+            if not ready:
+                return
+            line = self.process.stdout.readline()
+            if not line:
+                return
+            s = line.strip()
+            if s.startswith("TICKET_STATUS:"):
+                self.last_conversation_metadata = self._parse_conversation_metadata(s)
+        except Exception as e:
+            logger.debug(f"Read error capturing conversation metadata: {e}")
+
+    def _parse_conversation_metadata(self, line: str) -> Optional[Dict[str, str]]:
+        """
+        Parse conversation metadata output from ticket-responses-request-mgr.py.
+
+        Looks for lines in format:
+        TICKET_STATUS:{number}:{state}:owner={owner}:group={group}
+
+        Args:
+            line: Output line to parse for conversation metadata information
+
+        Returns:
+            Dictionary with state, owner, and group if parsed successfully,
+            None if parsing fails.
+        """
+        if not line.startswith("TICKET_STATUS:"):
+            return None
+        try:
+            parts = line.split(":")
+            if len(parts) < 3:
+                return None
+            result: Dict[str, str] = {
+                "state": parts[2],
+            }
+            for part in parts[3:]:
+                if part.startswith("owner="):
+                    result["owner"] = part[6:]
+                elif part.startswith("group="):
+                    result["group"] = part[6:]
+            logger.debug(f"Successfully parsed conversation metadata: {result}")
+            return result
+        except (ValueError, IndexError) as e:
+            logger.warning(f"Failed to parse conversation metadata '{line}': {e}")
+            return None
+
     def _parse_token_output(self, line: str) -> None:
         """
         Parse token summary output from chat-lg-state.py.
@@ -367,6 +437,16 @@ class OpenShiftChatClient:
             Dictionary with input, output, total, and calls counts
         """
         return self.app_tokens.copy()
+
+    def get_last_conversation_metadata(self) -> Optional[Dict[str, str]]:
+        """
+        Get the conversation metadata read from the last agent response.
+
+        Returns:
+            Dictionary with state, owner, and group,
+            or None if no conversation metadata was read.
+        """
+        return self.last_conversation_metadata
 
     def close_session(self) -> None:
         """

--- a/evaluations/helpers/run_conversation_flow.py
+++ b/evaluations/helpers/run_conversation_flow.py
@@ -23,6 +23,7 @@ class ConversationFlowTester:
         skip_initial_message: bool = False,
         message_timeout: int = 60,
         ticket_title: Optional[str] = None,
+        include_conversation_metadata: bool = False,
     ) -> None:
         """
         Initialize the ConversationFlowTester.
@@ -37,6 +38,7 @@ class ConversationFlowTester:
             message_timeout: Timeout in seconds for individual message send/response operations (default: 60)
             ticket_title: Passed to ticket-responses-request-mgr.py as ``--ticket-title`` when set
                 (Zammad subject). Should match the evaluation flow (laptop vs unrelated).
+            include_conversation_metadata: If True, pass --include-conversation_metadata to emit TICKET_STATUS lines after each agent response.
         """
         self.test_script = test_script
         self.reset_conversation = reset_conversation
@@ -44,6 +46,7 @@ class ConversationFlowTester:
         self.skip_initial_message = skip_initial_message
         self.message_timeout = message_timeout
         self.ticket_title = ticket_title
+        self.include_conversation_metadata = include_conversation_metadata
         self.conversation_history: list[Any] = []
         self.total_app_tokens = {"input": 0, "output": 0, "total": 0, "calls": 0}
 
@@ -52,7 +55,7 @@ class ConversationFlowTester:
         questions: list[str],
         authoritative_user_id: str,
         initial_message: Optional[str] = None,
-    ) -> List[Dict[str, str]]:
+    ) -> List[Dict[str, Any]]:
         """
         Run a conversation flow with the given questions.
 
@@ -80,6 +83,7 @@ class ConversationFlowTester:
             skip_initial_message=self.skip_initial_message,
             message_timeout=self.message_timeout,
             ticket_title=self.ticket_title,
+            include_conversation_metadata=self.include_conversation_metadata,
         )
 
         try:
@@ -102,7 +106,16 @@ class ConversationFlowTester:
                 # Add user message
                 conversation.append({"role": "user", "content": question})
                 # Add assistant response
-                conversation.append({"role": "assistant", "content": response})
+                assistant_turn: Dict[str, Any] = {
+                    "role": "assistant",
+                    "content": response,
+                }
+                actual_conversation_metadata = client.get_last_conversation_metadata()
+                if actual_conversation_metadata:
+                    assistant_turn["actual_conversation_metadata"] = (
+                        actual_conversation_metadata
+                    )
+                conversation.append(assistant_turn)
 
                 # Keep the old format for conversation_history if needed
                 self.conversation_history.append({"role": "user", "content": question})
@@ -233,6 +246,15 @@ class ConversationFlowTester:
                 results = self.run_flow(
                     questions, authoritative_user_id, initial_message=initial_message
                 )
+
+                # Carry over expected_conversation_metadata from input to result user turns
+                input_user_turns = [t for t in turns if t.get("role") == "user"]
+                result_user_turns = [t for t in results if t.get("role") == "user"]
+                for input_turn, result_turn in zip(input_user_turns, result_user_turns):
+                    if "expected_conversation_metadata" in input_turn:
+                        result_turn["expected_conversation_metadata"] = input_turn[
+                            "expected_conversation_metadata"
+                        ]
 
                 # Format results in the new conversation format with metadata
                 formatted_results = {

--- a/evaluations/results/ticket_laptop_refresh/conversation_results/known_good_flow.json
+++ b/evaluations/results/ticket_laptop_refresh/conversation_results/known_good_flow.json
@@ -6,35 +6,75 @@
   "conversation": [
     {
       "role": "user",
-      "content": "A new ticket was created by a user with the following content\nI would like to refresh my laptop"
+      "content": "A new ticket was created by a user with the following content\nI would like to refresh my laptop",
+      "expected_conversation_metadata": {
+        "state": "open",
+        "owner": "agent.laptop-specialist",
+        "group": "Users"
+      }
     },
     {
       "role": "assistant",
-      "content": "Based on the laptop refresh policy, your laptop is over 3 years old and eligible for a replacement.\nHere is a summary of your laptop details:\n- Name: Alice Johnson\n- Employee ID: 1001\n- Location: EMEA\n- Laptop Model: Latitude 7420\n- Laptop Serial Number: DL7420001\n- Laptop Purchase Date: 2020-01-15\nYou are eligible to request a new laptop. Would you like to proceed to the next step, which is reviewing the available laptop options?"
+      "content": "Based on the laptop refresh policy, your laptop is over 3 years old and eligible for a replacement.\nHere is a summary of your laptop details:\n- Name: Alice Johnson\n- Employee ID: 1001\n- Location: EMEA\n- Laptop Model: Latitude 7420\n- Laptop Serial Number: DL7420001\n- Laptop Purchase Date: 2020-01-15\nYou are eligible to request a new laptop. Would you like to proceed to the next step, which is reviewing the available laptop options?",
+      "actual_conversation_metadata": {
+        "state": "open",
+        "owner": "agent.laptop-specialist",
+        "group": "Users"
+      }
     },
     {
       "role": "user",
-      "content": "yes"
+      "content": "yes",
+      "expected_conversation_metadata": {
+        "state": "open",
+        "owner": "agent.laptop-specialist",
+        "group": "Users"
+      }
     },
     {
       "role": "assistant",
-      "content": "Here are the available laptop options for your location (EMEA):\n1. Model: MacBook Air M2 - ServiceNow Code: apple_mac_book_air_m_2\n- Manufacturer: Apple\n- Target User: General Office\n- Cost: €1,299\n- Operating System: macOS\n- Display Size: 13.6 inches\n- Display Resolution: 2560 x 1664\n- Graphics Card: Apple M2 GPU\n- Minimum Storage: 256 GB SSD\n- Weight: 2.7 lbs\n- Ports: 2 x Thunderbolt/USB 4, MagSafe\n- Minimum Processor: Apple M2\n- Minimum Memory: 8 GB\n- Dimensions: 11.97 x 8.46 x 0.44 inches\n2. Model: MacBook Pro 16 M3 Max - ServiceNow Code: apple_mac_book_pro_16_m_3_max\n- Manufacturer: Apple\n- Target User: Developers\n- Cost: €3,299\n- Operating System: macOS\n- Display Size: 16.2 inches\n- Display Resolution: 3456 x 2234\n- Graphics Card: Apple M3 Max GPU\n- Minimum Storage: 1 TB SSD\n- Weight: 4.8 lbs\n- Ports: 3 x Thunderbolt 4, HDMI, SDXC, MagSafe\n- Minimum Processor: Apple M3 Max\n- Minimum Memory: 36 GB\n- Dimensions: 14.01 x 9.77 x 0.66 inches\n3. Model: ThinkPad T14s Gen 5 AMD - ServiceNow Code: lenovo_think_pad_t_14_s_gen_5_amd\n- Manufacturer: Lenovo\n- Target User: General Office\n- Cost: €1,380\n- Operating System: Windows 11 Pro\n- Display Size: 14 inches\n- Display Resolution: 1920 x 1200\n- Graphics Card: Integrated AMD Radeon\n- Minimum Storage: 512 GB SSD\n- Weight: 2.8 lbs\n- Ports: 2 x USB-C, 2 x USB-A, HDMI, Audio Jack\n- Minimum Processor: AMD Ryzen 7 PRO 7840U\n- Minimum Memory: 16 GB\n- Dimensions: 12.4 x 8.7 x 0.6 inches\n4. Model: ThinkPad P16 Gen 2 - ServiceNow Code: lenovo_think_pad_p_16_gen_2\n- Manufacturer: Lenovo\n- Target User: Engineers\n- Cost: €2,650\n- Operating System: Red Hat Linux\n- Display Size: 16 inches\n- Display Resolution: 2560 x 1600\n- Graphics Card: NVIDIA RTX A2000\n- Minimum Storage: 1 TB SSD\n- Weight: 6.5 lbs\n- Ports: 2 x USB-C, 2 x USB-A, HDMI, Ethernet, Audio Jack\n- Minimum Processor: Intel Core i7-13700HX\n- Minimum Memory: 32 GB\n- Dimensions: 14.3 x 10.5 x 1.2 inches\nPlease select one of the above options. Remember to consider your job role and requirements when making your selection."
+      "content": "Here are the available laptop options for your location (EMEA):\n1. Model: MacBook Air M2 - ServiceNow Code: apple_mac_book_air_m_2\n- Manufacturer: Apple\n- Target User: General Office\n- Cost: €1,299\n- Operating System: macOS\n- Display Size: 13.6 inches\n- Display Resolution: 2560 x 1664\n- Graphics Card: Apple M2 GPU\n- Minimum Storage: 256 GB SSD\n- Weight: 2.7 lbs\n- Ports: 2 x Thunderbolt/USB 4, MagSafe\n- Minimum Processor: Apple M2\n- Minimum Memory: 8 GB\n- Dimensions: 11.97 x 8.46 x 0.44 inches\n2. Model: MacBook Pro 16 M3 Max - ServiceNow Code: apple_mac_book_pro_16_m_3_max\n- Manufacturer: Apple\n- Target User: Developers\n- Cost: €3,299\n- Operating System: macOS\n- Display Size: 16.2 inches\n- Display Resolution: 3456 x 2234\n- Graphics Card: Apple M3 Max GPU\n- Minimum Storage: 1 TB SSD\n- Weight: 4.8 lbs\n- Ports: 3 x Thunderbolt 4, HDMI, SDXC, MagSafe\n- Minimum Processor: Apple M3 Max\n- Minimum Memory: 36 GB\n- Dimensions: 14.01 x 9.77 x 0.66 inches\n3. Model: ThinkPad T14s Gen 5 AMD - ServiceNow Code: lenovo_think_pad_t_14_s_gen_5_amd\n- Manufacturer: Lenovo\n- Target User: General Office\n- Cost: €1,380\n- Operating System: Windows 11 Pro\n- Display Size: 14 inches\n- Display Resolution: 1920 x 1200\n- Graphics Card: Integrated AMD Radeon\n- Minimum Storage: 512 GB SSD\n- Weight: 2.8 lbs\n- Ports: 2 x USB-C, 2 x USB-A, HDMI, Audio Jack\n- Minimum Processor: AMD Ryzen 7 PRO 7840U\n- Minimum Memory: 16 GB\n- Dimensions: 12.4 x 8.7 x 0.6 inches\n4. Model: ThinkPad P16 Gen 2 - ServiceNow Code: lenovo_think_pad_p_16_gen_2\n- Manufacturer: Lenovo\n- Target User: Engineers\n- Cost: €2,650\n- Operating System: Red Hat Linux\n- Display Size: 16 inches\n- Display Resolution: 2560 x 1600\n- Graphics Card: NVIDIA RTX A2000\n- Minimum Storage: 1 TB SSD\n- Weight: 6.5 lbs\n- Ports: 2 x USB-C, 2 x USB-A, HDMI, Ethernet, Audio Jack\n- Minimum Processor: Intel Core i7-13700HX\n- Minimum Memory: 32 GB\n- Dimensions: 14.3 x 10.5 x 1.2 inches\nPlease select one of the above options. Remember to consider your job role and requirements when making your selection.",
+      "actual_conversation_metadata": {
+        "state": "open",
+        "owner": "agent.laptop-specialist",
+        "group": "Users"
+      }
     },
     {
       "role": "user",
-      "content": "I would like option 3"
+      "content": "I would like option 3",
+      "expected_conversation_metadata": {
+        "state": "open",
+        "owner": "agent.laptop-specialist",
+        "group": "Users"
+      }
     },
     {
       "role": "assistant",
-      "content": "You have selected the ThinkPad T14s Gen 5 AMD. Would you like the ticket to be sent for approval by your manager"
+      "content": "You have selected the ThinkPad T14s Gen 5 AMD. Would you like the ticket to be sent for approval by your manager",
+      "actual_conversation_metadata": {
+        "state": "open",
+        "owner": "agent.laptop-specialist",
+        "group": "Users"
+      }
     },
     {
       "role": "user",
-      "content": "proceed"
+      "content": "proceed",
+      "expected_conversation_metadata": {
+        "state": "open",
+        "owner": "manager1",
+        "group": "Users"
+      }
     },
     {
       "role": "assistant",
-      "content": "I have assigned the ticket to your manager for approval, you can watch the ticket for future updates as it progresses through the approval process"
+      "content": "I have assigned the ticket to your manager for approval, you can watch the ticket for future updates as it progresses through the approval process",
+      "actual_conversation_metadata": {
+        "state": "open",
+        "owner": "manager1",
+        "group": "Users"
+      }
     }
   ]
 }

--- a/evaluations/run_conversations.py
+++ b/evaluations/run_conversations.py
@@ -70,6 +70,9 @@ if __name__ == "__main__":
         flow_initial_message = getattr(flow_module, "DEFAULT_INITIAL_MESSAGE", None)
         flow_skip_initial = getattr(flow_module, "DEFAULT_SKIP_INITIAL_MESSAGE", False)
         flow_ticket_title = getattr(flow_module, "DEFAULT_TICKET_TITLE", None)
+        flow_include_conversation_metadata = getattr(
+            flow_module, "DEFAULT_INCLUDE_CONVERSATION_METADATA", False
+        )
     else:
         # Default mode: existing behavior
         conversations_dir = "conversations_config/conversations"
@@ -79,6 +82,7 @@ if __name__ == "__main__":
         flow_initial_message = None
         flow_skip_initial = False
         flow_ticket_title = None
+        flow_include_conversation_metadata = False
 
     tester = ConversationFlowTester(
         test_script=test_script,
@@ -87,5 +91,6 @@ if __name__ == "__main__":
         skip_initial_message=flow_skip_initial,
         message_timeout=args.message_timeout,
         ticket_title=flow_ticket_title,
+        include_conversation_metadata=flow_include_conversation_metadata,
     )
     tester.run_flows(conversations_dir, output_dir)

--- a/guides/EVALUATIONS_GUIDE.md
+++ b/guides/EVALUATIONS_GUIDE.md
@@ -672,7 +672,7 @@ make test-long-resp-integration-request-mgr
 
 The target for the longer integration was used throughout the development of the quickstart to identify if any regressions had been introduced by changes, and to iteratively improve the agent prompts.
 
-The target for the short integration run was used in CI to validate the basic operation of the self service agent for every PR.
+The target for the longer integration run was used in CI to validate the basic operation of the self service agent for every PR.
 
 ## 3. Creating Predefined Conversations
 

--- a/guides/EVALUATIONS_GUIDE.md
+++ b/guides/EVALUATIONS_GUIDE.md
@@ -672,7 +672,7 @@ make test-long-resp-integration-request-mgr
 
 The target for the longer integration was used throughout the development of the quickstart to identify if any regressions had been introduced by changes, and to iteratively improve the agent prompts.
 
-The target for the longer integration run was used in CI to validate the basic operation of the self service agent for every PR.
+The target for the short integration run was used in CI to validate the basic operation of the self service agent for every PR.
 
 ## 3. Creating Predefined Conversations
 

--- a/test/ticket-responses-request-mgr.py
+++ b/test/ticket-responses-request-mgr.py
@@ -57,15 +57,6 @@ DEFAULT_TICKET_TITLE = "Laptop refresh help request"
 # RM polling: limit 1 / latest session slice used by snapshot + agent_reply poll.
 _RM_CONVERSATIONS_KW = {"limit": 1, "offset": 0, "include_messages": True}
 
-_ZAMMAD_STATE_MAP = {
-    "new": "new",
-    "open": "being processed by agent",
-    "pending reminder": "escalated",
-    "pending close": "escalated",
-    "closed": "closed",
-    "merged": "closed",
-}
-
 
 def _customer_password_effective(cli_password: str | None) -> str:
     """HTTP Basic password for customer ``POST /ticket_articles`` (bootstrap default when unset/blank)."""
@@ -123,10 +114,10 @@ def _zammad_create_ticket(
     return data["id"], str(data["number"])
 
 
-def _zammad_get_ticket_status(
+def _zammad_get_conversation_metadata(
     base_url: str, token: str, ticket_id: int, state_map: dict[int, str]
 ) -> tuple[str, str, str]:
-    """Return (state, owner, group) for the ticket."""
+    """Return the metadata of (state, owner, group) for the ticket."""
     url = f"{_api_v1(base_url)}/tickets/{ticket_id}?expand=true"
     try:
         response = httpx.get(
@@ -136,7 +127,7 @@ def _zammad_get_ticket_status(
         data = response.json()
         state_id = data.get("state_id")
         state_name = state_map.get(state_id, str(state_id))
-        state = _ZAMMAD_STATE_MAP.get(state_name.lower(), state_name)
+        state = state_name
         owner = data.get("owner", {})
         if isinstance(owner, dict):
             owner_name = owner.get("fullname") or owner.get("login") or "unassigned"
@@ -346,11 +337,11 @@ async def _rm_tokens_cli_style(cli: CLIChatClient, *, rm_session_id: str) -> Non
 
 
 # ---------------------------------------------------------------------------
-# Chat loop with ticket status
+# Chat loop with ticket conversation metadata
 # ---------------------------------------------------------------------------
 
 
-async def _chat_loop_with_status(
+async def _chat_loop_with_conversation_metadata(
     rm_client: CLIChatClient,
     send_to_agent: Callable[[str], Awaitable[str]],
     *,
@@ -360,7 +351,7 @@ async def _chat_loop_with_status(
     zammad_base_url: str,
     zammad_token: str,
     state_map: dict[int, str],
-    show_ticket_status: bool,
+    include_conversation_metadata: bool,
     test_mode: bool,
 ) -> None:
     """
@@ -371,9 +362,14 @@ async def _chat_loop_with_status(
     It is printed to stdout so callers can strip it before saving conversations.
     """
 
-    def emit_status() -> None:
-        if show_ticket_status and ticket_id and zammad_base_url and zammad_token:
-            state, owner, group = _zammad_get_ticket_status(
+    def emit_conversation_metadata() -> None:
+        if (
+            include_conversation_metadata
+            and ticket_id
+            and zammad_base_url
+            and zammad_token
+        ):
+            state, owner, group = _zammad_get_conversation_metadata(
                 zammad_base_url, zammad_token, ticket_id, state_map
             )
             print(f"TICKET_STATUS:{ticket_number}:{state}:owner={owner}:group={group}")
@@ -414,7 +410,7 @@ async def _chat_loop_with_status(
                 agent_response = await send_to_agent(message)
                 print(f"agent: {agent_response}")
                 print(AGENT_MESSAGE_TERMINATOR)
-                emit_status()
+                emit_conversation_metadata()
         except (EOFError, KeyboardInterrupt):
             pass
     else:
@@ -431,7 +427,7 @@ async def _chat_loop_with_status(
                         continue
                     agent_response = await send_to_agent(message)
                     print(f"agent: {agent_response}")
-                    emit_status()
+                    emit_conversation_metadata()
             except KeyboardInterrupt:
                 break
 
@@ -461,12 +457,12 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         help=f"Title for the created Zammad ticket (default: '{DEFAULT_TICKET_TITLE}')",
     )
     parser.add_argument(
-        "--delete-ticket-on-close",
+        "--delete-ticket-on-exit",
         action="store_true",
         help="Delete the Zammad ticket when the session ends",
     )
     parser.add_argument(
-        "--show-ticket-status",
+        "--include-conversation_metadata",
         action="store_true",
         help="Emit a TICKET_STATUS line after each agent response",
     )
@@ -616,7 +612,7 @@ async def main() -> None:
     print("Using LangGraph state machine for conversation management")
 
     try:
-        await _chat_loop_with_status(
+        await _chat_loop_with_conversation_metadata(
             rm,
             send_to_agent,
             initial_message=initial_message,
@@ -625,12 +621,12 @@ async def main() -> None:
             zammad_base_url=zammad_base_url,
             zammad_token=zammad_token,
             state_map=state_map,
-            show_ticket_status=args.show_ticket_status,
+            include_conversation_metadata=args.include_conversation_metadata,
             test_mode=not sys.stdin.isatty(),
         )
     finally:
         if (
-            args.delete_ticket_on_close
+            args.delete_ticket_on_exit
             and ticket_id
             and zammad_base_url
             and zammad_token


### PR DESCRIPTION
Reference: https://redhat.atlassian.net/browse/APPENG-4761

Adds ticket status validation to the evaluation framework for predefined conversation flows (ticket_laptop_refresh, ticket_unrelated) while supporintg known_good_flow and known_bad_conversations.

This is done by:
- capturing the actual ticket state (state, owner, group) after each agent response and compares it against expected values defined in predefined conversation files.
- Adding a new deterministic `ConversationMetadataEval` metric
   
### Changes:
Phase 1 — Capture ticket status from agent
Phase 2 — Stores expected/actual metadata in Turn.additional_metadata — no content pollution
Phase 3 - Custom deterministic `ConversationMetadataEval` metric (no LLM)
Phase 4 - Only active on ticket flows — default flow unaffected.

### Note:
Generated and exported conversations will be handled on a separate PR (see [Jira issue](https://redhat.atlassian.net/browse/APPENG-4995)) so currently they are skipping the ticket status evaluation and are running as before this fix.

### additional fixes:
 - EVALUATIONS_GUIDE.md — doc typo fix
 - ticket-responses-request-mgr.py — renamed --`delete-ticket-on-close` flag to --`delete-ticket-on-exit` for clarity purpose.