### PR TITLE
fix: remove laptop agent from main landing page

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1529,10 +1529,18 @@ namespace:
 .PHONY: helm-depend
 helm-depend:
 	@needs_update=; \
+	for pair in $$(awk '/^- name:/{n=$$3} /^  version:/{if(n){v=$$2; gsub(/"/,"",v); print n"-"v".tgz"; n=""}}' helm/zammad/Chart.lock 2>/dev/null); do \
+		if [ ! -f "helm/zammad/charts/$$pair" ]; then \
+			echo "Updating Zammad sub-chart dependencies"; \
+			(cd helm/zammad && helm dependency update); \
+			needs_update=1; \
+			break; \
+		fi; \
+	done; \
+	if grep -q 'file://' helm/Chart.lock 2>/dev/null; then needs_update=1; fi; \
 	for pair in $$(awk '/^- name:/{n=$$3} /^  version:/{if(n){v=$$2; gsub(/"/,"",v); print n"-"v".tgz"; n=""}}' helm/Chart.lock 2>/dev/null); do \
 		if [ ! -f "helm/charts/$$pair" ]; then needs_update=1; break; fi; \
 	done; \
-	if grep -q 'file://' helm/Chart.lock 2>/dev/null; then needs_update=1; fi; \
 	if [ -z "$$needs_update" ] && [ -n "$$(awk '/^- name:/{n=$$3} /^  version:/{if(n){print; n=""}}' helm/Chart.lock 2>/dev/null)" ]; then \
 		echo "Helm dependencies present (Chart.lock), skipping update"; \
 	else \

--- a/helm/zammad-demo-site/values.yaml
+++ b/helm/zammad-demo-site/values.yaml
@@ -103,17 +103,5 @@ demoSite:
             bg: "#fed7aa"
             shortName: Escalated 2
             roleShort: Laptop refresh
-    - id: cat-specialist
-      navLabel: Laptop specialist
-      sectionTitle: Laptop specialist
-      rows:
-        - role: Agent
-          email: agent.laptop-specialist@example.com
-          password: "ChangeMe123!"
-          persona:
-            icon: "💻"
-            bg: "#ccfbf1"
-            shortName: Specialist
-            roleShort: Laptop agent
 
 image: nginxinc/nginx-unprivileged:alpine


### PR DESCRIPTION
- removed laptop agent login from main landing page as we have overviews that show laptop agent activity and it was felt having the agent on the page would be more confusing than helpfull.
- Also fixed promblem with zammad charts that caused install failures after cloning an empty repository.