### PR TITLE
revert: - added PR action for test-short-ticket-laptop-refresh (#373)

### DIFF
--- a/.github/workflows/pr-e2e-tests.yml
+++ b/.github/workflows/pr-e2e-tests.yml
@@ -95,15 +95,6 @@ jobs:
           LLM_URL: ${{ vars.LLM_URL_EVAL }}
           LLM_API_TOKEN: ${{ secrets.LLM_API_TOKEN_EVAL }}
 
-      - name: Run ticket laptop refresh flow evaluation
-        if: always()
-        shell: bash
-        run: |
-          make test-short-ticket-laptop-refresh
-        env:
-          LLM_URL: ${{ vars.LLM_URL_EVAL }}
-          LLM_API_TOKEN: ${{ secrets.LLM_API_TOKEN_EVAL }}
-
       - name: Inspect Cluster - Self-Service Agent
         if: failure()
         uses: ./.github/actions/inspect


### PR DESCRIPTION
This reverts commit c78faff43f4a336e6e1395cf5f4f7762bddfa173.

I missed that it does not handle deploying correctly, just tries to run the ticketing flow with the regular deployment