### PR TITLE
fix: optimize startup time

### DIFF
--- a/helm/zammad/templates/bootstrap-job.yaml
+++ b/helm/zammad/templates/bootstrap-job.yaml
@@ -59,6 +59,8 @@ spec:
               value: {{ .Release.Name | quote }}
             - name: ZAMMAD_INIT_JOB_WAIT_TIMEOUT_SEC
               value: {{ .Values.bootstrap.waitForZammadInitJobTimeoutSec | default 3600 | quote }}
+            - name: ZAMMAD_POST_USER_CREATE_SETTLE_SEC
+              value: {{ .Values.bootstrap.postUserCreateSettleSec | default 0 | quote }}
             {{- if .Values.bootstrap.createToken }}
             - name: ZAMMAD_CREATE_TOKEN
               value: "true"


### PR DESCRIPTION
It may be that the settle time is no longer needed. Setting to 0 for now. Review of the logs reports that there were no 502s or retries.

Shaves 72s off the startup time