### PR TITLE
feat: add eval capabilities for ticket status of generated conversations

### DIFF
--- a/evaluations/flows/ticket_laptop_refresh/metrics.py
+++ b/evaluations/flows/ticket_laptop_refresh/metrics.py
@@ -11,7 +11,10 @@ from typing import Any, List, Optional
 from deepeval.metrics import ConversationalGEval
 from deepeval.models import DeepEvalBaseLLM
 from deepeval.test_case import ConversationalTestCase, TurnParams
-from helpers.conversation_metadata_eval import ConversationMetadataEval
+from helpers.conversation_metadata_deterministic_eval import (
+    ConversationMetadataDeterministicEval,
+)
+from helpers.conversation_metadata_llm_eval import ConversationMetadataLLMEval
 from helpers.load_conversation_context import load_default_context
 
 # Context directory for this flow (populated at eval time by copy_flow_context).
@@ -345,9 +348,26 @@ def get_metrics(
                 "IMPORTANT: Do NOT require the agent to confirm the ticket was sent. Do NOT fail this metric because the ticket was never sent. Do NOT consider whether the laptop selection was valid or invalid.",
             ],
         ),
-        ConversationMetadataEval(
-            name="Correct conversation metadata",
+        ConversationMetadataDeterministicEval(
+            name="Correct conversation metadata — deterministic (predefined)",
             threshold=1.0,
+        ),
+        ConversationMetadataLLMEval(
+            name="Correct conversation metadata — LLM (generated)",
+            threshold=1.0,
+            model=custom_model,
+            evaluation_steps=[
+                "Check each assistant turn's actual_conversation_metadata against these state machine rules:",
+                "Ticket starts as: state=open, owner=agent.laptop-specialist, group=Users",
+                "While agent is processing the laptop refresh: state=open, owner=agent.laptop-specialist, group=Users",
+                "After ticket is sent to manager for approval: state=open, owner=manager1 or manager2, group=Users. This is a valid final state — the conversation may end here.",
+                "User asks to close the ticket: state=closed, owner=agent.laptop-specialist, group=Users",
+                "User asks to escalate: state=open, owner=-, group=escalated_laptop_refresh_tickets",
+                "A conversation ending after the ticket was sent to manager for approval, or close, or escalate is complete and valid.",
+                "PASS if ALL metadata transitions are correct and consistent with the rules.",
+                "FAIL if ANY metadata transition violates the rules.",
+                "Report which turn(s) and field(s) did not match.",
+            ],
         ),
     ]
 

--- a/evaluations/flows/ticket_unrelated/metrics.py
+++ b/evaluations/flows/ticket_unrelated/metrics.py
@@ -5,7 +5,10 @@ from typing import Any, List, Optional
 from deepeval.metrics import ConversationalGEval
 from deepeval.models import DeepEvalBaseLLM
 from deepeval.test_case import TurnParams
-from helpers.conversation_metadata_eval import ConversationMetadataEval
+from helpers.conversation_metadata_deterministic_eval import (
+    ConversationMetadataDeterministicEval,
+)
+from helpers.conversation_metadata_llm_eval import ConversationMetadataLLMEval
 
 
 def get_metrics(
@@ -72,9 +75,24 @@ def get_metrics(
                 "PASS if the agent responds normally even if it cannot fully resolve the user's issue.",
             ],
         ),
-        ConversationMetadataEval(
-            name="Correct conversation metadata",
+        ConversationMetadataDeterministicEval(
+            name="Correct conversation metadata — deterministic (predefined)",
             threshold=1.0,
+        ),
+        ConversationMetadataLLMEval(
+            name="Correct conversation metadata — LLM (generated)",
+            threshold=1.0,
+            model=custom_model,
+            evaluation_steps=[
+                "Check each assistant turn's actual_conversation_metadata against these state machine rules:",
+                "Ticket starts as: state=open, owner=agent.general, group=Users",
+                "While agent is handling the request: state=open, owner=agent.general, group=Users",
+                "User asks to close the ticket: state=closed, owner=agent.general, group=Users",
+                "User asks to escalate: state=open, owner=-, group=human_managed_tickets",
+                "PASS if ALL metadata transitions are correct and consistent with the rules.",
+                "FAIL if ANY metadata transition violates the rules.",
+                "Report which turn(s) and field(s) did not match.",
+            ],
         ),
     ]
 

--- a/evaluations/generator.py
+++ b/evaluations/generator.py
@@ -48,7 +48,7 @@ import os
 import random
 from multiprocessing import Pool
 from pathlib import Path
-from typing import Any, List, Optional
+from typing import Any, Dict, List, Optional
 
 from deepeval.dataset import ConversationalGolden
 from deepeval.simulator import ConversationSimulator
@@ -227,6 +227,7 @@ def _run_worker(
     initial_message: Optional[str] = None,
     skip_initial_message: bool = False,
     ticket_title: Optional[str] = None,
+    include_conversation_metadata: bool = False,
 ) -> dict[str, Any]:
     """
     Worker function to generate conversations in parallel.
@@ -321,7 +322,14 @@ def _run_worker(
             worker_logger.debug(
                 f"[Worker {worker_id}] Response preview: '{response[:200]}...'"
             )
-            return Turn(role="assistant", content=response)
+            actual_conversation_metadata = (
+                worker_client.get_last_conversation_metadata()
+            )
+            return Turn(
+                role="assistant",
+                content=response,
+                additional_metadata=actual_conversation_metadata,
+            )
 
         except Exception as e:
             worker_logger.error(
@@ -366,6 +374,7 @@ def _run_worker(
                 initial_message=initial_message,
                 skip_initial_message=skip_initial_message,
                 ticket_title=ticket_title,
+                include_conversation_metadata=include_conversation_metadata,
             )
 
             # Start session
@@ -497,7 +506,10 @@ def _convert_test_case_to_conversation_format(
                     # If parsing fails, keep original content
                     pass
 
-            conversation_turns.append({"role": turn.role, "content": content})
+            turn_data: Dict[str, Any] = {"role": turn.role, "content": content}
+            if turn.role == "assistant" and turn.additional_metadata:
+                turn_data["actual_conversation_metadata"] = turn.additional_metadata
+            conversation_turns.append(turn_data)
 
     return {
         "metadata": {
@@ -552,6 +564,7 @@ if __name__ == "__main__":
     initial_message: Optional[str] = None
     skip_initial_message: bool = False
     ticket_title: Optional[str] = None
+    include_conversation_metadata: bool = False
 
     if args.flow:
         import sys as _sys
@@ -574,6 +587,9 @@ if __name__ == "__main__":
             flow_module, "DEFAULT_SKIP_INITIAL_MESSAGE", False
         )
         ticket_title = getattr(flow_module, "DEFAULT_TICKET_TITLE", None)
+        include_conversation_metadata = getattr(
+            flow_module, "DEFAULT_INCLUDE_CONVERSATION_METADATA", False
+        )
         flow_max_turns = getattr(flow_module, "DEFAULT_MAX_TURNS", None)
         if flow_max_turns is not None:
             args.max_turns = flow_max_turns
@@ -642,6 +658,7 @@ if __name__ == "__main__":
                 initial_message,
                 skip_initial_message,
                 ticket_title,
+                include_conversation_metadata,
             )
             for i in range(args.concurrency)
         ]

--- a/evaluations/helpers/conversation_metadata_deterministic_eval.py
+++ b/evaluations/helpers/conversation_metadata_deterministic_eval.py
@@ -8,10 +8,10 @@ User turns hold expected metadata, assistant turns hold actual metadata.
 The metric compares all fields in each pair and reports mismatches.
 
 Usage:
-    from helpers.conversation_metadata_eval import ConversationMetadataEval
+    from helpers.conversation_metadata_deterministic_eval import ConversationMetadataDeterministicEval
 
-    metric = ConversationMetadataEval(
-        name="Correct conversation metadata",
+    metric = ConversationMetadataDeterministicEval(
+        name="Correct conversation metadata — deterministic (predefined)",
         threshold=1.0,
     )
 """
@@ -22,9 +22,10 @@ from deepeval.metrics import BaseConversationalMetric
 from deepeval.test_case import ConversationalTestCase
 
 
-class ConversationMetadataEval(BaseConversationalMetric):
+class ConversationMetadataDeterministicEval(BaseConversationalMetric):
     """
-    Deterministic metric that compares expected vs actual metadata per turn pair.
+    Deterministic metric that validates predefined conversation by comparing
+    expected vs actual metadata per turn pair.
 
     For each user turn with additional_metadata (expected), finds the immediately
     following assistant turn's additional_metadata (actual) and compares all fields.
@@ -35,7 +36,7 @@ class ConversationMetadataEval(BaseConversationalMetric):
 
     def __init__(
         self,
-        name: str = "Correct conversation metadata",
+        name: str = "Correct conversation metadata — deterministic (predefined)",
         threshold: float = 1.0,
         include_reason: bool = True,
         async_mode: bool = True,

--- a/evaluations/helpers/conversation_metadata_llm_eval.py
+++ b/evaluations/helpers/conversation_metadata_llm_eval.py
@@ -1,0 +1,156 @@
+"""
+A custom LLM-based conversational metric for validating conversation metadata transitions.
+
+This metric uses an LLM to judge whether actual_conversation_metadata on assistant
+turns follows valid estimated metadata values based on flow-specific state machine rules.
+
+It is designed for generated conversations that have actual metadata but no
+expected metadata. Skips when expected metadata exists (since deterministic metric handles it).
+
+Usage:
+    from helpers.conversation_metadata_llm_eval import ConversationMetadataLLMEval
+
+    metric = ConversationMetadataLLMEval(
+        name="Correct conversation metadata — LLM (generated)",
+        threshold=1.0,
+        model=custom_model,
+        evaluation_steps=[...],  # flow-specific state machine rules
+    )
+"""
+
+import json
+import logging
+from typing import Any, List, Optional
+
+from deepeval.metrics import BaseConversationalMetric
+from deepeval.models import DeepEvalBaseLLM
+from deepeval.test_case import ConversationalTestCase, Turn
+
+logger = logging.getLogger(__name__)
+
+
+class ConversationMetadataLLMEval(BaseConversationalMetric):
+    """
+    LLM-based metric that validates generated conversation metadata transitions.
+
+    For each assistant turn with actual_conversation_metadata, uses an LLM to
+    judge whether the state transitions follow the flow's state machine rules.
+
+    Scores 1.0 if all transitions are valid, 0.0 if any transition violates the rules.
+    Skips (scores 1.0) if expected metadata exists, no actual metadata, or no model configured.
+    """
+
+    def __init__(
+        self,
+        name: str = "Correct conversation metadata — LLM (generated)",
+        threshold: float = 1.0,
+        include_reason: bool = True,
+        async_mode: bool = True,
+        model: Optional[DeepEvalBaseLLM] = None,
+        evaluation_steps: Optional[List[str]] = None,
+        **kwargs: Any,
+    ) -> None:
+        if evaluation_steps is not None and len(evaluation_steps) == 0:
+            raise ValueError("'evaluation_steps' must not be an empty list.")
+
+        self.threshold = threshold
+        self.name = name
+        self.include_reason = include_reason
+        self.async_mode = async_mode
+        self.model = model
+        self.evaluation_steps = evaluation_steps
+
+    def measure(
+        self, test_case: ConversationalTestCase, *args: Any, **kwargs: Any
+    ) -> float:
+        turns = test_case.turns
+
+        has_expected_metadata = any(
+            turn.role == "user" and turn.additional_metadata is not None
+            for turn in turns
+        )
+        has_actual_metadata = any(
+            turn.role == "assistant" and turn.additional_metadata is not None
+            for turn in turns
+        )
+
+        # Skip — deterministic metric handles predefined conversations
+        if has_expected_metadata:
+            self.score = 1.0
+            self.success = True
+            self.reason = "Skipped — expected metadata present (deterministic metric handles this)"
+            return self.score
+
+        # Skip — no actual metadata or no model/evaluation_steps configured
+        if (
+            not has_actual_metadata
+            or self.model is None
+            or self.evaluation_steps is None
+        ):
+            self.score = 1.0
+            self.success = True
+            self.reason = (
+                "No conversation metadata to evaluate"
+                if not has_actual_metadata
+                else f"Actual metadata present but no {'model' if self.model is None else 'evaluation_steps'} configured"
+            )
+            return self.score
+
+        # Build conversation text with metadata tags on assistant turns
+        conversation_lines: List[str] = []
+        for turn in turns:
+            metadata_str = ""
+            if turn.role == "assistant" and turn.additional_metadata:
+                meta = turn.additional_metadata
+                metadata_str = (
+                    f" [actual_conversation_metadata: "
+                    f"state={meta.get('state')}, "
+                    f"owner={meta.get('owner')}, "
+                    f"group={meta.get('group')}]"
+                )
+            conversation_lines.append(f"{turn.role}: {turn.content}{metadata_str}")
+
+        steps = "\n".join(self.evaluation_steps)
+        prompt = (
+            f"{steps}\n\n"
+            f"Conversation:\n" + "\n".join(conversation_lines) + "\n\n"
+            'Respond with ONLY a JSON object: {"score": <integer 0-10>, '
+            '"reason": "<brief explanation>"}'
+        )
+
+        try:
+            response = self.model.generate(prompt)
+            cleaned = response.strip()
+            if cleaned.startswith("```"):
+                cleaned = cleaned.split("\n", 1)[1].rsplit("```", 1)[0].strip()
+            result = json.loads(cleaned)
+            self.score = float(result.get("score", 0)) / 10
+            self.reason = f"LLM evaluation: {result.get('reason', 'no reason')}"
+            logger.info(
+                f"LLM metadata evaluation: score={self.score}, reason={self.reason}"
+            )
+        except Exception as e:
+            logger.warning(f"LLM metadata evaluation failed: {e}")
+            self.score = 0.0
+            self.reason = f"LLM evaluation failed: {e}"
+
+        self.success = self.score >= self.threshold
+        return self.score
+
+    async def a_measure(
+        self, test_case: ConversationalTestCase, *args: Any, **kwargs: Any
+    ) -> float:
+        return self.measure(test_case)
+
+    def is_successful(self) -> bool:
+        if self.error is not None:
+            self.success = False
+        elif self.score is None:
+            self.success = False
+        else:
+            self.success = self.score >= self.threshold
+        return self.success
+
+    @property
+    def __name__(self) -> str:
+        return self.name


### PR DESCRIPTION
Reference: https://redhat.atlassian.net/browse/APPENG-4995

Add LLM-based evaluation for generated conversations metadata like the Zammad ticket state.

This is done by:
- Captures actual_conversation_metadata from Zammad after each agent response during generation.
- stores it in result files.
- Evaluates transitions against flow-specific state machine rules using a new `ConversationMetadataLLMEval` metric.
- The two metrics complement each other: deterministic runs on predefined, LLM runs on generated, each skips the other's domain.
- Default flow is unaffected — no metadata metrics, no metadata capture and therefore both metrics are ignored for the default flow.
