### PR TITLE
add known-bad evals for missing close/escalate confirmation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1383,6 +1383,12 @@ check-known-bad-conversations: sync-evaluations
 	uv --directory evaluations run evaluate.py --check
 	@echo "Evaluation check completed successfully!"
 
+.PHONY: check-known-bad-ticket-laptop-refresh
+check-known-bad-ticket-laptop-refresh: sync-evaluations
+	@echo "Running evaluation check on known bad ticket laptop refresh and ticket_unrelated flows..."
+	uv --directory evaluations run evaluate.py --check --flow ticket_laptop_refresh,ticket_unrelated
+	@echo "Evaluation check completed successfully!"
+
 .PHONY: test-short-ticket-laptop-refresh
 test-short-ticket-laptop-refresh:
 	@echo "Running short responses integration test for ticket-laptop-refresh flow..."

--- a/evaluations/.gitignore
+++ b/evaluations/.gitignore
@@ -9,5 +9,6 @@ results/**/conversation_results/*
 !results/ticket_laptop_refresh/conversation_results/known_good_flow.json
 
 results/**/deep_eval_results/
+results/**/known_bad_results/
 
 results/token_usage/*

--- a/evaluations/flows/ticket_laptop_refresh/known_bad_conversations/missing-last-message-close.json
+++ b/evaluations/flows/ticket_laptop_refresh/known_bad_conversations/missing-last-message-close.json
@@ -1,0 +1,53 @@
+{
+  "metadata": {
+    "authoritative_user_id": "david.chen@company.com",
+    "description": "Known bad conversation - User requests ticket close but agent confirmation message is missing"
+  },
+  "conversation": [
+    {
+      "role": "user",
+      "content": "I would like to refresh my laptop",
+      "expected_conversation_metadata": {
+        "state": "open",
+        "owner": "agent.laptop-specialist",
+        "group": "Users"
+      }
+    },
+    {
+      "role": "assistant",
+      "content": "According to the knowledge base, the refresh interval is 3 years.\nYour laptop, a ZenBook Pro 15, was purchased on 2020-07-22 and is currently 5 years and 9 months old (69 total months). The company's laptop refresh policy states that standard laptops will be refreshed every 3 years (36 months) from the date of issuance. Since your laptop is 5 years and 9 months old (69 months), which is greater than or equal to 3 years (36 months), you are eligible for a laptop refresh.\nHere is your laptop information:\nEmployee Name: David Chen\nEmployee Location: APAC\nLaptop Model: ZenBook Pro 15\nLaptop Serial Number: AS15008\nLaptop Purchase Date: 2020-07-22\nLaptop Age: 5 years and 9 months\nLaptop Warranty Expiry Date: 2023-07-22\nLaptop Warranty: Expired\nWould you like to proceed with reviewing the available laptop options for your location?",
+      "actual_conversation_metadata": {
+        "state": "open",
+        "owner": "agent.laptop-specialist",
+        "group": "Users"
+      }
+    },
+    {
+      "role": "user",
+      "content": "yes, show me the laptop options",
+      "expected_conversation_metadata": {
+        "state": "open",
+        "owner": "agent.laptop-specialist",
+        "group": "Users"
+      }
+    },
+    {
+      "role": "assistant",
+      "content": "Here are the available laptop options for your location (APAC):\n1. Model: MacBook Air M2\n2. Model: MacBook Pro 14 M3\n3. Model: ThinkPad T14 Gen 5 AMD\n4. Model: ThinkPad P1 Gen 6\nPlease select one of the above options.",
+      "actual_conversation_metadata": {
+        "state": "open",
+        "owner": "agent.laptop-specialist",
+        "group": "Users"
+      }
+    },
+    {
+      "role": "user",
+      "content": "please close this ticket, I've changed my mind",
+      "expected_conversation_metadata": {
+        "state": "closed",
+        "owner": "agent.laptop-specialist",
+        "group": "Users"
+      }
+    }
+  ]
+}

--- a/evaluations/flows/ticket_laptop_refresh/known_bad_conversations/missing-last-message-escalate.json
+++ b/evaluations/flows/ticket_laptop_refresh/known_bad_conversations/missing-last-message-escalate.json
@@ -1,0 +1,53 @@
+{
+  "metadata": {
+    "authoritative_user_id": "david.chen@company.com",
+    "description": "Known bad conversation - User requests ticket escalation but agent confirmation message is missing"
+  },
+  "conversation": [
+    {
+      "role": "user",
+      "content": "I would like to refresh my laptop",
+      "expected_conversation_metadata": {
+        "state": "open",
+        "owner": "agent.laptop-specialist",
+        "group": "Users"
+      }
+    },
+    {
+      "role": "assistant",
+      "content": "According to the knowledge base, the refresh interval is 3 years.\nYour laptop, a ZenBook Pro 15, was purchased on 2020-07-22 and is currently 5 years and 9 months old (69 total months). The company's laptop refresh policy states that standard laptops will be refreshed every 3 years (36 months) from the date of issuance. Since your laptop is 5 years and 9 months old (69 months), which is greater than or equal to 3 years (36 months), you are eligible for a laptop refresh.\nHere is your laptop information:\nEmployee Name: David Chen\nEmployee Location: APAC\nLaptop Model: ZenBook Pro 15\nLaptop Serial Number: AS15008\nLaptop Purchase Date: 2020-07-22\nLaptop Age: 5 years and 9 months\nLaptop Warranty Expiry Date: 2023-07-22\nLaptop Warranty: Expired\nWould you like to proceed with reviewing the available laptop options for your location?",
+      "actual_conversation_metadata": {
+        "state": "open",
+        "owner": "agent.laptop-specialist",
+        "group": "Users"
+      }
+    },
+    {
+      "role": "user",
+      "content": "yes, show me the laptop options",
+      "expected_conversation_metadata": {
+        "state": "open",
+        "owner": "agent.laptop-specialist",
+        "group": "Users"
+      }
+    },
+    {
+      "role": "assistant",
+      "content": "Here are the available laptop options for your location (APAC):\n1. Model: MacBook Air M2\n2. Model: MacBook Pro 14 M3\n3. Model: ThinkPad T14 Gen 5 AMD\n4. Model: ThinkPad P1 Gen 6\nPlease select one of the above options.",
+      "actual_conversation_metadata": {
+        "state": "open",
+        "owner": "agent.laptop-specialist",
+        "group": "Users"
+      }
+    },
+    {
+      "role": "user",
+      "content": "please escalate this ticket, I want a human to handle it",
+      "expected_conversation_metadata": {
+        "state": "open",
+        "owner": "-",
+        "group": "escalated_laptop_refresh_tickets"
+      }
+    }
+  ]
+}

--- a/evaluations/flows/ticket_laptop_refresh/metrics.py
+++ b/evaluations/flows/ticket_laptop_refresh/metrics.py
@@ -11,8 +11,8 @@ from typing import Any, List, Optional
 from deepeval.metrics import ConversationalGEval
 from deepeval.models import DeepEvalBaseLLM
 from deepeval.test_case import ConversationalTestCase, TurnParams
-from helpers.close_escalation_confirmation_deterministic_eval import (
-    CloseOrEscalationConfirmationDeterministicEval,
+from helpers.user_turn_assistant_reply_deterministic_eval import (
+    UserTurnAssistantReplyDeterministicEval,
 )
 from helpers.conversation_metadata_deterministic_eval import (
     ConversationMetadataDeterministicEval,
@@ -352,7 +352,7 @@ def get_metrics(
                 "IMPORTANT: Do NOT require the agent to confirm the ticket was sent. Do NOT fail this metric because the ticket was never sent. Do NOT consider whether the laptop selection was valid or invalid.",
             ],
         ),
-        CloseOrEscalationConfirmationDeterministicEval(
+        UserTurnAssistantReplyDeterministicEval(
             threshold=1.0,
         ),
         ConversationMetadataDeterministicEval(

--- a/evaluations/flows/ticket_laptop_refresh/metrics.py
+++ b/evaluations/flows/ticket_laptop_refresh/metrics.py
@@ -11,6 +11,9 @@ from typing import Any, List, Optional
 from deepeval.metrics import ConversationalGEval
 from deepeval.models import DeepEvalBaseLLM
 from deepeval.test_case import ConversationalTestCase, TurnParams
+from helpers.close_escalation_confirmation_deterministic_eval import (
+    CloseOrEscalationConfirmationDeterministicEval,
+)
 from helpers.conversation_metadata_deterministic_eval import (
     ConversationMetadataDeterministicEval,
 )
@@ -198,6 +201,7 @@ def get_metrics(
                 "  3. Ticket closed — the agent states the ticket was closed",
                 "PASS this metric if and ONLY if the agent explicitly confirms one of these three actions.",
                 "FAIL this metric if the conversation ends with anything other than one of these three actions — including but not limited to: creating a ticket, asking a question, giving a vague statement, or simply stopping.",
+                "FAIL this metric if the user requests ticket close or escalation and the conversation ends without an assistant confirmation message following that request — even if the ticket state may have changed in the background.",
                 "CRITICAL: The confirmation must be a statement that the action was performed, not a question asking whether to perform it.",
             ],
         ),
@@ -347,6 +351,9 @@ def get_metrics(
                 "FAIL this metric ONLY if: the ticket is explicitly sent to the manager WITHOUT the agent having asked for confirmation first, or before the user responds.",
                 "IMPORTANT: Do NOT require the agent to confirm the ticket was sent. Do NOT fail this metric because the ticket was never sent. Do NOT consider whether the laptop selection was valid or invalid.",
             ],
+        ),
+        CloseOrEscalationConfirmationDeterministicEval(
+            threshold=1.0,
         ),
         ConversationMetadataDeterministicEval(
             name="Correct conversation metadata — deterministic (predefined)",

--- a/evaluations/flows/ticket_laptop_refresh/metrics.py
+++ b/evaluations/flows/ticket_laptop_refresh/metrics.py
@@ -11,14 +11,14 @@ from typing import Any, List, Optional
 from deepeval.metrics import ConversationalGEval
 from deepeval.models import DeepEvalBaseLLM
 from deepeval.test_case import ConversationalTestCase, TurnParams
-from helpers.user_turn_assistant_reply_deterministic_eval import (
-    UserTurnAssistantReplyDeterministicEval,
-)
 from helpers.conversation_metadata_deterministic_eval import (
     ConversationMetadataDeterministicEval,
 )
 from helpers.conversation_metadata_llm_eval import ConversationMetadataLLMEval
 from helpers.load_conversation_context import load_default_context
+from helpers.user_turn_assistant_reply_deterministic_eval import (
+    UserTurnAssistantReplyDeterministicEval,
+)
 
 # Context directory for this flow (populated at eval time by copy_flow_context).
 # Path is relative to the evaluations/ working directory.

--- a/evaluations/flows/ticket_unrelated/known_bad_conversations/missing-last-message-close.json
+++ b/evaluations/flows/ticket_unrelated/known_bad_conversations/missing-last-message-close.json
@@ -1,0 +1,35 @@
+{
+  "metadata": {
+    "authoritative_user_id": "maria.garcia@company.com",
+    "description": "Known bad conversation - User requests ticket close but agent confirmation message is missing"
+  },
+  "conversation": [
+    {
+      "role": "user",
+      "content": "How do I set up two-factor authentication on my work account?",
+      "expected_conversation_metadata": {
+        "state": "open",
+        "owner": "agent.general",
+        "group": "Users"
+      }
+    },
+    {
+      "role": "assistant",
+      "content": "Hello! I'm a general support agent and I'll do my best to help based on my general knowledge. Feel free to ask follow-up questions at any time. If your issue is resolved you can ask to close the ticket, or escalate if you need further human assistance.\n\nTo set up two-factor authentication, go to your account security settings and look for a 'Two-Factor Authentication' or 'MFA' option. You'll typically be asked to download an authenticator app such as Microsoft Authenticator or Google Authenticator, then scan a QR code to link it to your account.",
+      "actual_conversation_metadata": {
+        "state": "open",
+        "owner": "agent.general",
+        "group": "Users"
+      }
+    },
+    {
+      "role": "user",
+      "content": "That worked, please close the ticket",
+      "expected_conversation_metadata": {
+        "state": "closed",
+        "owner": "agent.general",
+        "group": "Users"
+      }
+    }
+  ]
+}

--- a/evaluations/flows/ticket_unrelated/known_bad_conversations/missing-last-message-escalate.json
+++ b/evaluations/flows/ticket_unrelated/known_bad_conversations/missing-last-message-escalate.json
@@ -1,0 +1,35 @@
+{
+  "metadata": {
+    "authoritative_user_id": "carlos.rodriguez@company.com",
+    "description": "Known bad conversation - User requests ticket escalation but agent confirmation message is missing"
+  },
+  "conversation": [
+    {
+      "role": "user",
+      "content": "My VPN keeps disconnecting every few minutes",
+      "expected_conversation_metadata": {
+        "state": "open",
+        "owner": "agent.general",
+        "group": "Users"
+      }
+    },
+    {
+      "role": "assistant",
+      "content": "Hello! I'm a general support agent and I'll do my best to help based on my general knowledge. Feel free to ask follow-up questions at any time. If your issue is resolved you can ask to close the ticket, or escalate if you need further human assistance.\n\nFrequent VPN disconnections are often caused by an unstable internet connection, an outdated VPN client, or a misconfigured idle timeout setting. Try restarting your VPN client and checking for updates.",
+      "actual_conversation_metadata": {
+        "state": "open",
+        "owner": "agent.general",
+        "group": "Users"
+      }
+    },
+    {
+      "role": "user",
+      "content": "Please escalate this to a network specialist",
+      "expected_conversation_metadata": {
+        "state": "open",
+        "owner": "-",
+        "group": "human_managed_tickets"
+      }
+    }
+  ]
+}

--- a/evaluations/flows/ticket_unrelated/metrics.py
+++ b/evaluations/flows/ticket_unrelated/metrics.py
@@ -5,13 +5,13 @@ from typing import Any, List, Optional
 from deepeval.metrics import ConversationalGEval
 from deepeval.models import DeepEvalBaseLLM
 from deepeval.test_case import TurnParams
-from helpers.user_turn_assistant_reply_deterministic_eval import (
-    UserTurnAssistantReplyDeterministicEval,
-)
 from helpers.conversation_metadata_deterministic_eval import (
     ConversationMetadataDeterministicEval,
 )
 from helpers.conversation_metadata_llm_eval import ConversationMetadataLLMEval
+from helpers.user_turn_assistant_reply_deterministic_eval import (
+    UserTurnAssistantReplyDeterministicEval,
+)
 
 
 def get_metrics(

--- a/evaluations/flows/ticket_unrelated/metrics.py
+++ b/evaluations/flows/ticket_unrelated/metrics.py
@@ -5,8 +5,8 @@ from typing import Any, List, Optional
 from deepeval.metrics import ConversationalGEval
 from deepeval.models import DeepEvalBaseLLM
 from deepeval.test_case import TurnParams
-from helpers.close_escalation_confirmation_deterministic_eval import (
-    CloseOrEscalationConfirmationDeterministicEval,
+from helpers.user_turn_assistant_reply_deterministic_eval import (
+    UserTurnAssistantReplyDeterministicEval,
 )
 from helpers.conversation_metadata_deterministic_eval import (
     ConversationMetadataDeterministicEval,
@@ -79,7 +79,7 @@ def get_metrics(
                 "PASS if the agent responds normally even if it cannot fully resolve the user's issue.",
             ],
         ),
-        CloseOrEscalationConfirmationDeterministicEval(
+        UserTurnAssistantReplyDeterministicEval(
             threshold=1.0,
         ),
         ConversationMetadataDeterministicEval(

--- a/evaluations/flows/ticket_unrelated/metrics.py
+++ b/evaluations/flows/ticket_unrelated/metrics.py
@@ -5,6 +5,9 @@ from typing import Any, List, Optional
 from deepeval.metrics import ConversationalGEval
 from deepeval.models import DeepEvalBaseLLM
 from deepeval.test_case import TurnParams
+from helpers.close_escalation_confirmation_deterministic_eval import (
+    CloseOrEscalationConfirmationDeterministicEval,
+)
 from helpers.conversation_metadata_deterministic_eval import (
     ConversationMetadataDeterministicEval,
 )
@@ -45,6 +48,7 @@ def get_metrics(
                 "  - The ticket has been closed (e.g. 'Your ticket has been closed')",
                 "  - The ticket has been escalated for human review (e.g. 'Your ticket has been escalated for human review')",
                 "FAIL if the conversation ends without either of these confirmations.",
+                "FAIL if the user requests ticket close or escalation and the conversation ends without an assistant confirmation message following that request — even if the ticket state may have changed in the background.",
             ],
         ),
         ConversationalGEval(
@@ -74,6 +78,9 @@ def get_metrics(
                 "  - Tool call failures or stack traces visible in the response",
                 "PASS if the agent responds normally even if it cannot fully resolve the user's issue.",
             ],
+        ),
+        CloseOrEscalationConfirmationDeterministicEval(
+            threshold=1.0,
         ),
         ConversationMetadataDeterministicEval(
             name="Correct conversation metadata — deterministic (predefined)",

--- a/evaluations/helpers/close_escalation_confirmation_deterministic_eval.py
+++ b/evaluations/helpers/close_escalation_confirmation_deterministic_eval.py
@@ -1,0 +1,211 @@
+"""
+Deterministic metric that validates assistant confirmation after close/escalation requests.
+
+When a user explicitly asks to close or escalate a ticket, the assistant must respond
+with a confirmation message. This catches the production bug where the ticket state
+changes but the user never sees the agent's closing/escalation message.
+"""
+
+import re
+from typing import Any, Optional
+
+from deepeval.metrics import BaseConversationalMetric
+from deepeval.test_case import ConversationalTestCase
+
+_CLOSE_REQUEST_PHRASES = (
+    "close the ticket",
+    "close this ticket",
+    "close my ticket",
+    "close ticket",
+    "closing the ticket",
+    "closing this ticket",
+    "please close",
+    "close it",
+    "close this",
+    "ticket be closed",
+    "ask to close",
+)
+
+# Catches morphological variants not listed above (e.g. "could you close the ticket").
+_CLOSE_TICKET_PATTERN = re.compile(
+    r"\bclos(?:e|es|ing|ed)\b(?:\s+\w+){0,4}\s+(?:the\s+)?ticket\b"
+    r"|\bclos(?:e|es|ing)\b\s+it\b"
+    r"|\bticket\b(?:\s+\w+){0,4}\s+be\s+closed\b",
+    re.IGNORECASE,
+)
+
+_ESCALATE_REQUEST_PHRASES = (
+    "escalate",
+    "escalating",
+    "escalation",
+    "escalating to",
+    "escalate to",
+    "escalate this",
+    "human to handle",
+    "network specialist",
+    "human review",
+    "human assistance",
+    "human agent",
+    "speak to a human",
+    "talk to a human",
+    "to a human",
+    "to a specialist",
+)
+
+# Catches morphological variants (e.g. "need escalating to", "I'd like escalating this to a human").
+_ESCALATE_TICKET_PATTERN = re.compile(
+    r"\bescalat(?:e|es|ing|ion)\b(?:\s+\w+){0,4}\s+(?:to\s+)?(?:a\s+)?(?:human|specialist|agent)\b"
+    r"|\b(?:need|want|like|rather)\b(?:\s+\w+){0,4}\s+escalat(?:e|es|ing|ion)\b",
+    re.IGNORECASE,
+)
+
+# Exclude negated formulations (e.g. "Please don't escalate this to a network specialist").
+_CLOSE_NEGATION_PATTERN = re.compile(
+    r"(?:don'?t|do not|shouldn'?t|should not|won'?t|will not|never|without)\s+(?:\w+\s+){0,10}"
+    r"(?:clos(?:e|es|ing)\b(?:\s+\w+){0,4}\s+(?:the\s+)?ticket\b|ticket\b(?:\s+\w+){0,4}\s+be\s+closed\b)"
+    r"|\bnot\s+(?:\w+\s+){0,4}clos(?:e|es|ing)\b(?:\s+\w+){0,4}\s+(?:the\s+)?ticket\b",
+    re.IGNORECASE,
+)
+_ESCALATE_NEGATION_PATTERN = re.compile(
+    r"(?:don'?t|do not|shouldn'?t|should not|won'?t|will not|never|without)\s+(?:\w+\s+){0,10}"
+    r"(?:escalat(?:e|es|ing|ion)\b|network specialist\b|human to handle\b|human assistance\b|"
+    r"human agent\b|human review\b|speak to a human\b|talk to a human\b|to a specialist\b|to a human\b)"
+    r"|\bnot\s+(?:\w+\s+){0,4}(?:escalat(?:e|es|ing|ion)\b|network specialist\b)",
+    re.IGNORECASE,
+)
+
+# Exclude self-directed questions (e.g. "should I escalate?"), not agent-directed requests
+# such as "Can you close the ticket?".
+_CLOSE_QUESTION_PATTERN = re.compile(
+    r"(?:should|could|would|can|may|might)\s+(?:I|we)\s+(?:\w+\s+){0,10}"
+    r"(?:clos(?:e|es|ing)\b|ticket\b(?:\s+\w+){0,4}\s+be\s+closed\b)"
+    r"|(?:should|could|would|can)\s+(?:the|this|my)\s+ticket\b(?:\s+\w+){0,4}\s+be\s+closed\b",
+    re.IGNORECASE,
+)
+_ESCALATE_QUESTION_PATTERN = re.compile(
+    r"(?:should|could|would|can|may|might)\s+(?:I|we)\s+(?:\w+\s+){0,10}"
+    r"(?:escalat(?:e|es|ing|ion)\b|network specialist\b|human\b|specialist\b|agent\b)"
+    r"|(?:should|could|would|can)\s+(?:the|this|my)\s+ticket\b(?:\s+\w+){0,4}\s+be\s+escalated\b",
+    re.IGNORECASE,
+)
+
+_CLOSE_CONFIRMATION_PHRASES = (
+    "closed",
+    "ticket_closed",
+)
+
+_ESCALATE_CONFIRMATION_PHRASES = (
+    "escalated",
+    "ticket_escalated",
+)
+
+
+def _is_excluded_request(content: str, action: str) -> bool:
+    """Return True for negated or self-directed question formulations."""
+    if action == "close":
+        return bool(
+            _CLOSE_NEGATION_PATTERN.search(content)
+            or _CLOSE_QUESTION_PATTERN.search(content)
+        )
+    return bool(
+        _ESCALATE_NEGATION_PATTERN.search(content)
+        or _ESCALATE_QUESTION_PATTERN.search(content)
+    )
+
+
+def _user_requests_close_or_escalate(content: str) -> Optional[str]:
+    lower = content.lower()
+    if any(phrase in lower for phrase in _CLOSE_REQUEST_PHRASES) or _CLOSE_TICKET_PATTERN.search(
+        content
+    ):
+        if not _is_excluded_request(content, "close"):
+            return "close"
+    if any(phrase in lower for phrase in _ESCALATE_REQUEST_PHRASES) or _ESCALATE_TICKET_PATTERN.search(
+        content
+    ):
+        if not _is_excluded_request(content, "escalate"):
+            return "escalate"
+    return None
+
+
+def _assistant_confirms_action(content: str, action: str) -> bool:
+    lower = content.lower()
+    phrases = (
+        _CLOSE_CONFIRMATION_PHRASES
+        if action == "close"
+        else _ESCALATE_CONFIRMATION_PHRASES
+    )
+    return any(phrase in lower for phrase in phrases)
+
+
+class CloseOrEscalationConfirmationDeterministicEval(BaseConversationalMetric):
+    """
+    Deterministic metric: after a user requests ticket close or escalation,
+    the assistant must reply with an explicit confirmation message.
+    """
+
+    def __init__(
+        self,
+        name: str = "Close or Escalation Confirmation — deterministic",
+        threshold: float = 1.0,
+        include_reason: bool = True,
+        async_mode: bool = True,
+        **kwargs: Any,
+    ) -> None:
+        self.threshold = threshold
+        self.name = name
+        self.include_reason = include_reason
+        self.async_mode = async_mode
+
+    def measure(
+        self, test_case: ConversationalTestCase, *args: Any, **kwargs: Any
+    ) -> float:
+        turns = test_case.turns
+        failures: list[str] = []
+
+        for i, turn in enumerate(turns):
+            if turn.role != "user":
+                continue
+
+            action = _user_requests_close_or_escalate(turn.content)
+            if action is None:
+                continue
+
+            next_turn = turns[i + 1] if i + 1 < len(turns) else None
+            if not next_turn or next_turn.role != "assistant":
+                failures.append(
+                    f"User requested ticket {action} but no assistant confirmation message followed"
+                )
+                continue
+
+            if not _assistant_confirms_action(next_turn.content, action):
+                failures.append(
+                    f"Assistant reply after {action} request did not confirm the action"
+                )
+
+        self.score = 0.0 if failures else 1.0
+        self.reason = (
+            "; ".join(failures)
+            if failures
+            else "All close/escalation requests received assistant confirmation"
+        )
+        self.success = self.score >= self.threshold
+        return self.score
+
+    async def a_measure(
+        self, test_case: ConversationalTestCase, *args: Any, **kwargs: Any
+    ) -> float:
+        return self.measure(test_case)
+
+    def is_successful(self) -> bool:
+        if self.error is not None:
+            self.success = False
+        elif self.score is None:
+            self.success = False
+        else:
+            self.success = self.score >= self.threshold
+        return self.success
+
+    @property
+    def __name__(self) -> str:
+        return self.name

--- a/evaluations/helpers/close_escalation_confirmation_deterministic_eval.py
+++ b/evaluations/helpers/close_escalation_confirmation_deterministic_eval.py
@@ -1,9 +1,9 @@
 """
-Deterministic metric that validates an assistant reply follows close/escalation requests.
+Deterministic metric that validates every user turn receives an assistant reply.
 
-When a user message appears to request ticket close or escalation, the assistant must
-respond with a follow-up message. This catches the production bug where the ticket
-state changes but the user never sees any agent reply.
+This catches the production bug where ticket state changes but the user never sees
+any agent reply — including close/escalate requests phrased in ways phrase matching
+may miss (e.g. "Mark this as resolved").
 """
 
 import re
@@ -120,11 +120,10 @@ def _user_requests_close_or_escalate(content: str) -> Optional[str]:
 
 class CloseOrEscalationConfirmationDeterministicEval(BaseConversationalMetric):
     """
-    Deterministic metric: after a user message that appears to request ticket close
-    or escalation, the assistant must reply with any follow-up message.
+    Deterministic metric: every user turn must be followed by an assistant reply.
 
-    Request detection is best-effort (phrases, regex, negation/question exclusions).
-    This metric only checks that an assistant turn exists — not the wording of the reply.
+    Close/escalate phrase matching is best-effort and used only to label failures
+    (close / escalate / other). It does not gate whether the check runs.
     """
 
     def __init__(
@@ -150,21 +149,20 @@ class CloseOrEscalationConfirmationDeterministicEval(BaseConversationalMetric):
             if turn.role != "user":
                 continue
 
-            action = _user_requests_close_or_escalate(turn.content)
-            if action is None:
+            next_turn = turns[i + 1] if i + 1 < len(turns) else None
+            if next_turn and next_turn.role == "assistant":
                 continue
 
-            next_turn = turns[i + 1] if i + 1 < len(turns) else None
-            if not next_turn or next_turn.role != "assistant":
-                failures.append(
-                    f"User requested ticket {action} but no assistant message followed"
-                )
+            request_type = _user_requests_close_or_escalate(turn.content) or "other"
+            failures.append(
+                f"User message ({request_type} request) had no assistant reply following"
+            )
 
         self.score = 0.0 if failures else 1.0
         self.reason = (
             "; ".join(failures)
             if failures
-            else "All detected close/escalation requests received an assistant reply"
+            else "All user turns received an assistant reply"
         )
         self.success = self.score >= self.threshold
         return self.score

--- a/evaluations/helpers/close_escalation_confirmation_deterministic_eval.py
+++ b/evaluations/helpers/close_escalation_confirmation_deterministic_eval.py
@@ -1,9 +1,9 @@
 """
-Deterministic metric that validates assistant confirmation after close/escalation requests.
+Deterministic metric that validates an assistant reply follows close/escalation requests.
 
-When a user explicitly asks to close or escalate a ticket, the assistant must respond
-with a confirmation message. This catches the production bug where the ticket state
-changes but the user never sees the agent's closing/escalation message.
+When a user message appears to request ticket close or escalation, the assistant must
+respond with a follow-up message. This catches the production bug where the ticket
+state changes but the user never sees any agent reply.
 """
 
 import re
@@ -89,16 +89,6 @@ _ESCALATE_QUESTION_PATTERN = re.compile(
     re.IGNORECASE,
 )
 
-_CLOSE_CONFIRMATION_PHRASES = (
-    "closed",
-    "ticket_closed",
-)
-
-_ESCALATE_CONFIRMATION_PHRASES = (
-    "escalated",
-    "ticket_escalated",
-)
-
 
 def _is_excluded_request(content: str, action: str) -> bool:
     """Return True for negated or self-directed question formulations."""
@@ -115,33 +105,26 @@ def _is_excluded_request(content: str, action: str) -> bool:
 
 def _user_requests_close_or_escalate(content: str) -> Optional[str]:
     lower = content.lower()
-    if any(phrase in lower for phrase in _CLOSE_REQUEST_PHRASES) or _CLOSE_TICKET_PATTERN.search(
-        content
-    ):
+    if any(
+        phrase in lower for phrase in _CLOSE_REQUEST_PHRASES
+    ) or _CLOSE_TICKET_PATTERN.search(content):
         if not _is_excluded_request(content, "close"):
             return "close"
-    if any(phrase in lower for phrase in _ESCALATE_REQUEST_PHRASES) or _ESCALATE_TICKET_PATTERN.search(
-        content
-    ):
+    if any(
+        phrase in lower for phrase in _ESCALATE_REQUEST_PHRASES
+    ) or _ESCALATE_TICKET_PATTERN.search(content):
         if not _is_excluded_request(content, "escalate"):
             return "escalate"
     return None
 
 
-def _assistant_confirms_action(content: str, action: str) -> bool:
-    lower = content.lower()
-    phrases = (
-        _CLOSE_CONFIRMATION_PHRASES
-        if action == "close"
-        else _ESCALATE_CONFIRMATION_PHRASES
-    )
-    return any(phrase in lower for phrase in phrases)
-
-
 class CloseOrEscalationConfirmationDeterministicEval(BaseConversationalMetric):
     """
-    Deterministic metric: after a user requests ticket close or escalation,
-    the assistant must reply with an explicit confirmation message.
+    Deterministic metric: after a user message that appears to request ticket close
+    or escalation, the assistant must reply with any follow-up message.
+
+    Request detection is best-effort (phrases, regex, negation/question exclusions).
+    This metric only checks that an assistant turn exists — not the wording of the reply.
     """
 
     def __init__(
@@ -174,20 +157,14 @@ class CloseOrEscalationConfirmationDeterministicEval(BaseConversationalMetric):
             next_turn = turns[i + 1] if i + 1 < len(turns) else None
             if not next_turn or next_turn.role != "assistant":
                 failures.append(
-                    f"User requested ticket {action} but no assistant confirmation message followed"
-                )
-                continue
-
-            if not _assistant_confirms_action(next_turn.content, action):
-                failures.append(
-                    f"Assistant reply after {action} request did not confirm the action"
+                    f"User requested ticket {action} but no assistant message followed"
                 )
 
         self.score = 0.0 if failures else 1.0
         self.reason = (
             "; ".join(failures)
             if failures
-            else "All close/escalation requests received assistant confirmation"
+            else "All detected close/escalation requests received an assistant reply"
         )
         self.success = self.score >= self.threshold
         return self.score

--- a/evaluations/helpers/user_turn_assistant_reply_deterministic_eval.py
+++ b/evaluations/helpers/user_turn_assistant_reply_deterministic_eval.py
@@ -2,128 +2,18 @@
 Deterministic metric that validates every user turn receives an assistant reply.
 
 This catches the production bug where ticket state changes but the user never sees
-any agent reply — including close/escalate requests phrased in ways phrase matching
-may miss (e.g. "Mark this as resolved").
+any agent reply after their message.
 """
 
-import re
-from typing import Any, Optional
+from typing import Any
 
 from deepeval.metrics import BaseConversationalMetric
 from deepeval.test_case import ConversationalTestCase
-
-_CLOSE_REQUEST_PHRASES = (
-    "close the ticket",
-    "close this ticket",
-    "close my ticket",
-    "close ticket",
-    "closing the ticket",
-    "closing this ticket",
-    "please close",
-    "close it",
-    "close this",
-    "ticket be closed",
-    "ask to close",
-)
-
-# Catches morphological variants not listed above (e.g. "could you close the ticket").
-_CLOSE_TICKET_PATTERN = re.compile(
-    r"\bclos(?:e|es|ing|ed)\b(?:\s+\w+){0,4}\s+(?:the\s+)?ticket\b"
-    r"|\bclos(?:e|es|ing)\b\s+it\b"
-    r"|\bticket\b(?:\s+\w+){0,4}\s+be\s+closed\b",
-    re.IGNORECASE,
-)
-
-_ESCALATE_REQUEST_PHRASES = (
-    "escalate",
-    "escalating",
-    "escalation",
-    "escalating to",
-    "escalate to",
-    "escalate this",
-    "human to handle",
-    "network specialist",
-    "human review",
-    "human assistance",
-    "human agent",
-    "speak to a human",
-    "talk to a human",
-    "to a human",
-    "to a specialist",
-)
-
-# Catches morphological variants (e.g. "need escalating to", "I'd like escalating this to a human").
-_ESCALATE_TICKET_PATTERN = re.compile(
-    r"\bescalat(?:e|es|ing|ion)\b(?:\s+\w+){0,4}\s+(?:to\s+)?(?:a\s+)?(?:human|specialist|agent)\b"
-    r"|\b(?:need|want|like|rather)\b(?:\s+\w+){0,4}\s+escalat(?:e|es|ing|ion)\b",
-    re.IGNORECASE,
-)
-
-# Exclude negated formulations (e.g. "Please don't escalate this to a network specialist").
-_CLOSE_NEGATION_PATTERN = re.compile(
-    r"(?:don'?t|do not|shouldn'?t|should not|won'?t|will not|never|without)\s+(?:\w+\s+){0,10}"
-    r"(?:clos(?:e|es|ing)\b(?:\s+\w+){0,4}\s+(?:the\s+)?ticket\b|ticket\b(?:\s+\w+){0,4}\s+be\s+closed\b)"
-    r"|\bnot\s+(?:\w+\s+){0,4}clos(?:e|es|ing)\b(?:\s+\w+){0,4}\s+(?:the\s+)?ticket\b",
-    re.IGNORECASE,
-)
-_ESCALATE_NEGATION_PATTERN = re.compile(
-    r"(?:don'?t|do not|shouldn'?t|should not|won'?t|will not|never|without)\s+(?:\w+\s+){0,10}"
-    r"(?:escalat(?:e|es|ing|ion)\b|network specialist\b|human to handle\b|human assistance\b|"
-    r"human agent\b|human review\b|speak to a human\b|talk to a human\b|to a specialist\b|to a human\b)"
-    r"|\bnot\s+(?:\w+\s+){0,4}(?:escalat(?:e|es|ing|ion)\b|network specialist\b)",
-    re.IGNORECASE,
-)
-
-# Exclude self-directed questions (e.g. "should I escalate?"), not agent-directed requests
-# such as "Can you close the ticket?".
-_CLOSE_QUESTION_PATTERN = re.compile(
-    r"(?:should|could|would|can|may|might)\s+(?:I|we)\s+(?:\w+\s+){0,10}"
-    r"(?:clos(?:e|es|ing)\b|ticket\b(?:\s+\w+){0,4}\s+be\s+closed\b)"
-    r"|(?:should|could|would|can)\s+(?:the|this|my)\s+ticket\b(?:\s+\w+){0,4}\s+be\s+closed\b",
-    re.IGNORECASE,
-)
-_ESCALATE_QUESTION_PATTERN = re.compile(
-    r"(?:should|could|would|can|may|might)\s+(?:I|we)\s+(?:\w+\s+){0,10}"
-    r"(?:escalat(?:e|es|ing|ion)\b|network specialist\b|human\b|specialist\b|agent\b)"
-    r"|(?:should|could|would|can)\s+(?:the|this|my)\s+ticket\b(?:\s+\w+){0,4}\s+be\s+escalated\b",
-    re.IGNORECASE,
-)
-
-
-def _is_excluded_request(content: str, action: str) -> bool:
-    """Return True for negated or self-directed question formulations."""
-    if action == "close":
-        return bool(
-            _CLOSE_NEGATION_PATTERN.search(content)
-            or _CLOSE_QUESTION_PATTERN.search(content)
-        )
-    return bool(
-        _ESCALATE_NEGATION_PATTERN.search(content)
-        or _ESCALATE_QUESTION_PATTERN.search(content)
-    )
-
-
-def _user_requests_close_or_escalate(content: str) -> Optional[str]:
-    lower = content.lower()
-    if any(
-        phrase in lower for phrase in _CLOSE_REQUEST_PHRASES
-    ) or _CLOSE_TICKET_PATTERN.search(content):
-        if not _is_excluded_request(content, "close"):
-            return "close"
-    if any(
-        phrase in lower for phrase in _ESCALATE_REQUEST_PHRASES
-    ) or _ESCALATE_TICKET_PATTERN.search(content):
-        if not _is_excluded_request(content, "escalate"):
-            return "escalate"
-    return None
 
 
 class UserTurnAssistantReplyDeterministicEval(BaseConversationalMetric):
     """
     Deterministic metric: every user turn must be followed by an assistant reply.
-
-    Close/escalate phrase matching is best-effort and used only to label failures
-    (close / escalate / general). It does not gate whether the check runs.
     """
 
     def __init__(
@@ -153,10 +43,7 @@ class UserTurnAssistantReplyDeterministicEval(BaseConversationalMetric):
             if next_turn and next_turn.role == "assistant":
                 continue
 
-            request_type = _user_requests_close_or_escalate(turn.content) or "general"
-            failures.append(
-                f"User message ({request_type} request) had no assistant reply following"
-            )
+            failures.append("User message had no assistant reply following")
 
         self.score = 0.0 if failures else 1.0
         self.reason = (

--- a/evaluations/helpers/user_turn_assistant_reply_deterministic_eval.py
+++ b/evaluations/helpers/user_turn_assistant_reply_deterministic_eval.py
@@ -118,17 +118,17 @@ def _user_requests_close_or_escalate(content: str) -> Optional[str]:
     return None
 
 
-class CloseOrEscalationConfirmationDeterministicEval(BaseConversationalMetric):
+class UserTurnAssistantReplyDeterministicEval(BaseConversationalMetric):
     """
     Deterministic metric: every user turn must be followed by an assistant reply.
 
     Close/escalate phrase matching is best-effort and used only to label failures
-    (close / escalate / other). It does not gate whether the check runs.
+    (close / escalate / general). It does not gate whether the check runs.
     """
 
     def __init__(
         self,
-        name: str = "Close or Escalation Confirmation — deterministic",
+        name: str = "User Turn Assistant Reply — deterministic",
         threshold: float = 1.0,
         include_reason: bool = True,
         async_mode: bool = True,
@@ -153,7 +153,7 @@ class CloseOrEscalationConfirmationDeterministicEval(BaseConversationalMetric):
             if next_turn and next_turn.role == "assistant":
                 continue
 
-            request_type = _user_requests_close_or_escalate(turn.content) or "other"
+            request_type = _user_requests_close_or_escalate(turn.content) or "general"
             failures.append(
                 f"User message ({request_type} request) had no assistant reply following"
             )


### PR DESCRIPTION
- Add known-bad conversations for ticket_laptop_refresh and ticket_unrelated where the user requests ticket close or escalation but the final assistant confirmation message is missing - reproducing the production bug where ticket state changes without the user seeing a response.

- Add a deterministic CloseOrEscalationConfirmationEval metric and tighten Process Completion / Ticket Resolution prompts so evals fail when close/escalate requests are not followed by an assistant confirmation.

- Extend make check-known-bad-conversations to run known-bad checks for both ticket flows.