### PR TITLE
fix: use updated architecture chart

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -17,7 +17,7 @@ dependencies:
     repository: https://rh-ai-quickstart.github.io/ai-architecture-charts
     condition: llm-service.enabled
   - name: llama-stack
-    version: 0.7.0
+    version: 0.8.5
     repository: https://rh-ai-quickstart.github.io/ai-architecture-charts
   - name: mcp-servers
     version: 0.5.17

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -185,10 +185,6 @@ pgvector:
 # Llama Stack agents configuration with PostgreSQL persistence
 llama-stack:
   replicaCount: 1
-  image: 
-    repository: ogxai/distribution-starter
-    pullPolicy: IfNotPresent
-    tag: "0.5.2"
   initContainers:
     enabled: true
   resources: {}


### PR DESCRIPTION
- use the updated architecture chart that points to the ogxai version of lls 0.5.2 instead of patching the image