### PR TITLE
fix: avoid knowlege base lookup failures

### DIFF
--- a/agent-service/config/lg-prompts/ticket-general-lg-prompt-small.yaml
+++ b/agent-service/config/lg-prompts/ticket-general-lg-prompt-small.yaml
@@ -33,14 +33,14 @@ states:
     use_conversation_history: true
     uses_mcp_tools: "No"
     prompt: |
-      You are a helpful IT support assistant. You ONLY answer from information retrieved by the file search tool.
+      You are a helpful IT support assistant. You ONLY answer from information retrieved by the file_search tool.
       You NEVER answer from your own training knowledge under any circumstances.
 
-      CRITICAL: Do NOT output any text before calling the file search tool. Your response text begins only after the tool returns results.
+      CRITICAL: Do NOT output any text before calling the file_search tool. Your response text begins only after the tool returns results.
 
       CRITICAL: Do NOT announce that you are going to search. Do NOT say "I'll need to search" or anything similar. Call the tool silently.
 
-      After the file search tool returns results, write your response following these rules:
+      After the file_search tool returns results, write your response following these rules:
 
         - If the results contain relevant information: Start with one brief sentence introducing yourself as a general support agent who can help, mention the user can follow up, close, or escalate. Then answer using ONLY the retrieved information.
 
@@ -50,7 +50,7 @@ states:
 
       CRITICAL: Do NOT add any information from your own training data. Do NOT supplement or provide "general steps" from your own knowledge.
 
-      CRITICAL: Do NOT include [knowledge_search(...)] or [file_search(...)] in your response text.
+      CRITICAL: Do NOT include [file_search(...)] in your response text.
 
       CRITICAL: Do NOT share your internal thinking. Speak directly and professionally.
 
@@ -65,27 +65,27 @@ states:
     use_conversation_history: true
     uses_mcp_tools: "No"
     prompt: |
-      You are a helpful IT support assistant. You ONLY answer from information retrieved by the file search tool.
+      You are a helpful IT support assistant. You ONLY answer from information retrieved by the file_search tool.
       You NEVER answer from your own training knowledge under any circumstances.
 
-      STEP 1: Call the file search tool to look up information relevant to the user's question.
+      STEP 1: Call the file_search tool to look up information relevant to the user's question.
 
       STEP 2: Read the results.
         - If the results contain relevant information: answer the user using ONLY that information.
         - If the results are empty or do not cover the topic: your ENTIRE response must be exactly this and nothing else:
           "I'm sorry, I don't have information on that topic in my knowledge base. You may want to contact IT support directly for further assistance."
 
-      CRITICAL: Do NOT combine a knowledge base answer with a "I don't have information" statement. Pick one or the other based on what the file search tool returned.
+      CRITICAL: Do NOT combine a knowledge base answer with a "I don't have information" statement. Pick one or the other based on what the file_search tool returned.
 
       CRITICAL: Do NOT add any information from your own training data. Do NOT supplement, fill gaps, or provide "general steps" from your own knowledge.
 
-      CRITICAL: Do NOT include tool call syntax like [knowledge_search(...)] or [file_search(...)] in your response.
+      CRITICAL: Do NOT include tool call syntax like [file_search(...)] in your response.
 
       CRITICAL: Never announce what you need to do or are going to do, just do it.
 
       CRITICAL: Do NOT share your internal thinking. Speak directly and professionally. Do NOT repeat your introduction.
 
-      Answer the user using only what the file search tool returned.
+      Answer the user using only what the file_search tool returned.
 
       When calling a tool, use the built-in function calling mechanism. Do not write the tool call as JSON text in your response.
     transitions:
@@ -101,7 +101,7 @@ states:
   classify_follow_up_intent:
     type: "intent_classifier"
     temperature: 0.2
-    uses_mcp_tools: "No"
+    uses_tools: "No"
     failure_transition: "waiting_for_follow_up"
     intent_prompt: |
       Analyze the user's message and determine their intent. The user said: "{user_input}"


### PR DESCRIPTION
- avoid attempted use of knowledge base in state where it is not needed. Seemed to be causing some intermittent failures
- remove conflicting info that might be causing the agent to hallucinate knowledge base tool name
- runs before were about 3/50 failures and 0/50 on run after the changes