### PR TITLE
fix: fixup demo site redirect

### DIFF
--- a/helm/zammad-demo-site/templates/_demo-site.tpl
+++ b/helm/zammad-demo-site/templates/_demo-site.tpl
@@ -510,7 +510,7 @@
     var HUB_CHANNEL = 'zammad-demo-hub';
     var SESSION_KEY = 'zammad-demo-last-user';
     var SHELL_URL = (function() {
-      var p = window.location.pathname.replace(/[^/]*$/, '');
+      var p = window.location.pathname.replace(/\/?$/, '/');
       return p + 'zammad-shell.html';
     })();
 


### PR DESCRIPTION
- when acessing demo site from route shown in openshift login to users would fail with 404 as there is no / at end of URL in route
- URL printed by makefile already had / so we'd not noticed
- update redirect to work with both