### PR TITLE
Disable zammadui attachments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1707,7 +1707,7 @@ helm-install-ticketing: namespace helm-depend
 		true)
 	@rm -f $(ZAMMAD_TICKETING_OVERLAY)
 	@echo "Waiting for Zammad deployments to be ready..."
-	@for dep in zammad-nginx zammad-railsserver zammad-websocket zammad-scheduler mcp-zammad-mcp; do \
+	@for dep in zammad-edge zammad-nginx zammad-railsserver zammad-websocket zammad-scheduler mcp-zammad-mcp; do \
 		echo "  Waiting for $$dep..."; \
 		kubectl rollout status deploy/$$dep -n $(NAMESPACE) --timeout=10m; \
 	done

--- a/helm/values-ticketing.yaml
+++ b/helm/values-ticketing.yaml
@@ -37,6 +37,10 @@ ticketingZammad:
   externalRoute:
     enabled: true
 
+  # Nginx edge proxy: hide attachment UI (CSS) and block upload API (403). Stock Zammad image unchanged.
+  edgeProxy:
+    disableAttachments: true
+
   # Upstream Zammad subchart values
   zammad:
     # Keep service names as zammad-* regardless of Helm release name
@@ -74,6 +78,10 @@ ticketingZammad:
           - 10.0.0.0/8
           - 172.16.0.0/12
           - 192.168.0.0/16
+        # Edge proxy + OpenShift Route: inner nginx must tell Rails the client used HTTPS (CSRF/session cookies).
+        extraHeaders:
+          - 'X-Forwarded-Proto https'
+          - 'X-Forwarded-Ssl on'
       railsserver:
         trustedProxies: "['127.0.0.1', '::1', '10.0.0.0/8', '172.16.0.0/12', '192.168.0.0/16']"
 

--- a/helm/zammad/templates/_helpers.tpl
+++ b/helm/zammad/templates/_helpers.tpl
@@ -1,0 +1,39 @@
+{{- define "ticketingZammad.zammadNginxService" -}}
+{{- printf "%s-nginx" (default .Release.Name .Values.zammad.fullnameOverride) -}}
+{{- end -}}
+
+{{- define "ticketingZammad.zammadWebsocketService" -}}
+{{- printf "%s-websocket" (default .Release.Name .Values.zammad.fullnameOverride) -}}
+{{- end -}}
+
+{{- define "ticketingZammad.zammadRailsserverService" -}}
+{{- printf "%s-railsserver" (default .Release.Name .Values.zammad.fullnameOverride) -}}
+{{- end -}}
+
+{{- define "ticketingZammad.edgeProxyService" -}}
+{{- printf "%s-edge" (default .Release.Name .Values.zammad.fullnameOverride) -}}
+{{- end -}}
+
+{{- define "ticketingZammad.disableAttachmentsCss" -}}
+.article-attachment,.attachmentPlaceholder,.attachmentPlaceholder-inputHolder,.attachmentPlaceholder-label,.attachmentUpload,.dropArea{display:none!important;pointer-events:none!important}
+{{- end -}}
+
+{{- define "ticketingZammad.edgeProxyHtmlLocation" -}}
+        location {{ .location }} {
+            proxy_http_version 1.1;
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $forwarded_proto;
+            proxy_set_header X-Forwarded-Ssl on;
+            proxy_set_header X-Forwarded-Host $http_host;
+            proxy_set_header Accept-Encoding "";
+            proxy_read_timeout 300s;
+            proxy_pass http://{{ .zammadNginx }}:8080;
+
+            gunzip on;
+            sub_filter_once on;
+            sub_filter_types text/html;
+            sub_filter '</head>' '{{ .headInject }}';
+        }
+{{- end -}}

--- a/helm/zammad/templates/edge-proxy-configmap.yaml
+++ b/helm/zammad/templates/edge-proxy-configmap.yaml
@@ -1,0 +1,108 @@
+{{- if and .Values.externalRoute.enabled .Values.edgeProxy.disableAttachments }}
+{{- $zammadNginx := include "ticketingZammad.zammadNginxService" . -}}
+{{- $zammadWebsocket := include "ticketingZammad.zammadWebsocketService" . -}}
+{{- $zammadRailsserver := include "ticketingZammad.zammadRailsserverService" . -}}
+{{- $edgeSvc := include "ticketingZammad.edgeProxyService" . -}}
+{{- $disableAttachmentsHead := printf "<style id=\"ssa-disable-attachments\">%s</style></head>" (include "ticketingZammad.disableAttachmentsCss" . | trim) -}}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ $edgeSvc }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: zammad-edge
+data:
+  default.conf: |
+    map $http_x_forwarded_proto $forwarded_proto {
+        default $http_x_forwarded_proto;
+        ''      $scheme;
+    }
+
+    server {
+        listen 8080;
+        server_name _;
+
+        client_max_body_size 50M;
+
+        location ~ ^/api/v1/upload_caches {
+            return 403;
+        }
+
+        location /ws {
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "Upgrade";
+            proxy_set_header Host $http_host;
+            proxy_set_header CLIENT_IP $remote_addr;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $forwarded_proto;
+            proxy_set_header X-Forwarded-Ssl on;
+            proxy_set_header X-Forwarded-Host $http_host;
+            proxy_buffering off;
+            proxy_read_timeout 86400;
+            proxy_pass http://{{ $zammadWebsocket }}:6042;
+        }
+
+        location /cable {
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "Upgrade";
+            proxy_set_header Host $http_host;
+            proxy_set_header CLIENT_IP $remote_addr;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $forwarded_proto;
+            proxy_set_header X-Forwarded-Ssl on;
+            proxy_set_header X-Forwarded-Host $http_host;
+            proxy_buffering off;
+            proxy_read_timeout 86400;
+            proxy_pass http://{{ $zammadRailsserver }}:3000;
+        }
+
+        location /api/ {
+            proxy_http_version 1.1;
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $forwarded_proto;
+            proxy_set_header X-Forwarded-Ssl on;
+            proxy_set_header X-Forwarded-Host $http_host;
+            proxy_buffering off;
+            proxy_read_timeout 3600s;
+            proxy_pass http://{{ $zammadRailsserver }}:3000;
+        }
+
+        location /graphql {
+            proxy_http_version 1.1;
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $forwarded_proto;
+            proxy_set_header X-Forwarded-Ssl on;
+            proxy_set_header X-Forwarded-Host $http_host;
+            proxy_buffering off;
+            proxy_read_timeout 3600s;
+            proxy_pass http://{{ $zammadRailsserver }}:3000;
+        }
+
+    {{ include "ticketingZammad.edgeProxyHtmlLocation" (dict "location" "= /" "zammadNginx" $zammadNginx "headInject" $disableAttachmentsHead) }}
+    {{ include "ticketingZammad.edgeProxyHtmlLocation" (dict "location" "^~ /desktop" "zammadNginx" $zammadNginx "headInject" $disableAttachmentsHead) }}
+    {{ include "ticketingZammad.edgeProxyHtmlLocation" (dict "location" "^~ /app" "zammadNginx" $zammadNginx "headInject" $disableAttachmentsHead) }}
+
+        location / {
+            proxy_http_version 1.1;
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $forwarded_proto;
+            proxy_set_header X-Forwarded-Ssl on;
+            proxy_set_header X-Forwarded-Host $http_host;
+            proxy_read_timeout 86400;
+            proxy_pass http://{{ $zammadNginx }}:8080;
+        }
+    }
+{{- end }}

--- a/helm/zammad/templates/edge-proxy.yaml
+++ b/helm/zammad/templates/edge-proxy.yaml
@@ -1,0 +1,81 @@
+{{- if and .Values.externalRoute.enabled .Values.edgeProxy.disableAttachments }}
+{{- $edgeSvc := include "ticketingZammad.edgeProxyService" . -}}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $edgeSvc }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: zammad-edge
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: zammad-edge
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/component: zammad-edge
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/edge-proxy-configmap.yaml") . | sha256sum }}
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: nginx
+          image: {{ .Values.edgeProxy.image | quote }}
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+          ports:
+            - name: http
+              containerPort: 8080
+          volumeMounts:
+            - name: config
+              mountPath: /etc/nginx/conf.d/default.conf
+              subPath: default.conf
+              readOnly: true
+          readinessProbe:
+            tcpSocket:
+              port: http
+            periodSeconds: 10
+          livenessProbe:
+            tcpSocket:
+              port: http
+            periodSeconds: 20
+      volumes:
+        - name: config
+          configMap:
+            name: {{ $edgeSvc }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $edgeSvc }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: zammad-edge
+spec:
+  selector:
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: zammad-edge
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http
+{{- end }}

--- a/helm/zammad/templates/external-route.yaml
+++ b/helm/zammad/templates/external-route.yaml
@@ -11,13 +11,14 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: zammad
   annotations:
-    haproxy.router.openshift.io/timeout: "300s"
+    # WebSocket/ActionCable (/ws, /cable) and long-poll need longer-lived connections.
+    haproxy.router.openshift.io/timeout: "3600s"
 spec:
   # Keep the main Zammad route at / so a path-prefixed Route (demo site, e.g. /demo-portal) can share this host.
   path: /
   to:
     kind: Service
-    name: {{ default .Release.Name .Values.zammad.fullnameOverride }}-nginx
+    name: {{ if .Values.edgeProxy.disableAttachments }}{{ include "ticketingZammad.edgeProxyService" . }}{{ else }}{{ include "ticketingZammad.zammadNginxService" . }}{{ end }}
     weight: 100
   port:
     targetPort: http

--- a/helm/zammad/templates/network-policy.yaml
+++ b/helm/zammad/templates/network-policy.yaml
@@ -1,11 +1,42 @@
 {{- if .Values.externalRoute.enabled }}
+{{- $edgeEnabled := .Values.edgeProxy.disableAttachments }}
 ---
-# Allow ingress from OpenShift router to Zammad nginx (for ssa-zammad Route)
-# Zammad pods use app.kubernetes.io/instance=zammad, not self-service-agent
+# Allow ingress from OpenShift router to Zammad edge proxy or nginx (ssa-zammad Route).
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: {{ .Release.Name }}-allow-zammad-ingress
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: zammad
+spec:
+  podSelector:
+    matchLabels:
+      {{- if $edgeEnabled }}
+      app.kubernetes.io/component: zammad-edge
+      {{- else }}
+      app.kubernetes.io/name: zammad
+      app.kubernetes.io/component: zammad-nginx
+      {{- end }}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          network.openshift.io/policy-group: ingress
+    ports:
+    - protocol: TCP
+      port: 8080
+{{- if $edgeEnabled }}
+---
+# Edge proxy → zammad-nginx (HTML, assets, API pass-through).
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ .Release.Name }}-allow-zammad-edge-to-nginx
   namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
@@ -20,10 +51,63 @@ spec:
   - Ingress
   ingress:
   - from:
-    - namespaceSelector:
+    - podSelector:
         matchLabels:
-          network.openshift.io/policy-group: ingress
+          app.kubernetes.io/component: zammad-edge
     ports:
     - protocol: TCP
       port: 8080
+---
+# Edge proxy → zammad-websocket (direct /ws WebSocket, avoids double-hop).
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ .Release.Name }}-allow-zammad-edge-to-websocket
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: zammad
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: zammad
+      app.kubernetes.io/component: zammad-websocket
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector:
+        matchLabels:
+          app.kubernetes.io/component: zammad-edge
+    ports:
+    - protocol: TCP
+      port: 6042
+---
+# Edge proxy → zammad-railsserver (direct /cable ActionCable, avoids double-hop).
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ .Release.Name }}-allow-zammad-edge-to-railsserver
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: zammad
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: zammad
+      app.kubernetes.io/component: zammad-railsserver
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector:
+        matchLabels:
+          app.kubernetes.io/component: zammad-edge
+    ports:
+    - protocol: TCP
+      port: 3000
+{{- end }}
 {{- end }}

--- a/helm/zammad/values.yaml
+++ b/helm/zammad/values.yaml
@@ -8,6 +8,14 @@ zammad: {}
 externalRoute:
   enabled: false
 
+# Optional nginx edge proxy in front of stock zammad-nginx (no Zammad image/chart changes).
+# When disableAttachments is true and externalRoute is enabled, the Route targets the edge proxy:
+#   - 403 on /api/v1/upload_caches (upload API)
+#   - CSS injection to hide attachment controls in the web UI
+edgeProxy:
+  disableAttachments: false
+  image: nginxinc/nginx-unprivileged:1.27-alpine
+
 bootstrap:
   # imageTag ↔ Makefile BASE_VERSION / scripts/bump-release.sh. Ticketing overrides via helm-install-ticketing overlay.
   imageRegistry: quay.io/rh-ai-quickstart

--- a/zammad-bootstrap/bootstrap.py
+++ b/zammad-bootstrap/bootstrap.py
@@ -1074,6 +1074,31 @@ def ensure_agent_overviews() -> None:
     )
 
 
+def ensure_websocket_backend() -> None:
+    """Legacy UI must use /ws on the public host (not websocketPort :6042)."""
+    for setting in api("GET", "settings"):
+        if setting.get("name") != "websocket_backend":
+            continue
+        # Zammad stores the active value in state_current.value; fall back to state.
+        state_current = setting.get("state_current")
+        if isinstance(state_current, dict):
+            current = state_current.get("value", setting.get("state"))
+        else:
+            current = state_current or setting.get("state")
+        if current == "websocket":
+            print("  websocket_backend already websocket")
+            return
+        api("PUT", f"settings/{setting['id']}", json={"state_current": {"value": "websocket"}})
+        print(f"  websocket_backend set to websocket (was {current!r})")
+        return
+    print("  WARNING: websocket_backend setting not found", file=sys.stderr)
+
+
+def ensure_ssa_zammad_ui() -> None:
+    print("\n[6b/7] SSA Zammad UI (websocket backend)...")
+    ensure_websocket_backend()
+
+
 def ensure_integration_webhook_and_trigger():
     """Create or update Zammad Webhook + Trigger for integration-dispatcher POST /zammad/webhook."""
     endpoint = os.environ.get("ZAMMAD_INTEGRATION_WEBHOOK_URL", "").strip()
@@ -1296,6 +1321,7 @@ def main():
         )
 
     ensure_integration_webhook_and_trigger()
+    ensure_ssa_zammad_ui()
 
     print("\n[7/7] Ensuring admin overviews for AI agent statistics...")
     ensure_agent_overviews()

--- a/zammad-bootstrap/bootstrap.py
+++ b/zammad-bootstrap/bootstrap.py
@@ -1088,7 +1088,11 @@ def ensure_websocket_backend() -> None:
         if current == "websocket":
             print("  websocket_backend already websocket")
             return
-        api("PUT", f"settings/{setting['id']}", json={"state_current": {"value": "websocket"}})
+        api(
+            "PUT",
+            f"settings/{setting['id']}",
+            json={"state_current": {"value": "websocket"}},
+        )
         print(f"  websocket_backend set to websocket (was {current!r})")
         return
     print("  WARNING: websocket_backend setting not found", file=sys.stderr)


### PR DESCRIPTION
- Users no longer see attachment controls in Zammad (new ticket + reply)
- File uploads are blocked even if someone tries via the API
- Stock Zammad image and upstream Helm chart are unchanged

**How it works (two layers)**
1. Block uploads (server-side)
- Small nginx edge proxy (zammad-edge) sits in front of stock Zammad
- OpenShift Route (ssa-zammad) points to zammad-edge, not zammad-nginx directly
- Edge proxy returns 403 on POST /api/v1/upload_caches/* (Zammad’s upload API)
- Uploads fail even if the UI were visible

2. Hide attachment UI (client-side)
- Edge proxy injects inline CSS into Zammad HTML pages (/, /desktop, /app) using nginx sub_filter
- CSS hides Zammad’s attachment elements (.article-attachment, .attachmentPlaceholder, file inputs, etc.)
- Applies to new ticket and reply forms (same widget in both)