### PR TITLE
fix: address frequent ticket e2e ci test failures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1730,6 +1730,22 @@ helm-install-ticketing: namespace helm-depend
 	else \
 		helm uninstall zammad-demo-site -n $(NAMESPACE) --ignore-not-found 2>/dev/null || true; \
 	fi
+	@echo "  Waiting for terminating pods to finish..."
+	@TIMEOUT=120; ELAPSED=0; \
+	while [ $$ELAPSED -lt $$TIMEOUT ]; do \
+		TERMINATING=$$(kubectl get pods -n $(NAMESPACE) --no-headers 2>/dev/null | grep -c Terminating || true); \
+		if [ "$$TERMINATING" -eq 0 ]; then \
+			echo "  No terminating pods remaining."; \
+			break; \
+		fi; \
+		echo "  Waiting for $$TERMINATING terminating pod(s)... ($${ELAPSED}s elapsed)"; \
+		sleep 5; \
+		ELAPSED=$$((ELAPSED + 5)); \
+	done; \
+	if [ $$ELAPSED -ge $$TIMEOUT ]; then \
+		echo "  Warning: Timed out waiting for terminating pods after $${TIMEOUT}s"; \
+		kubectl get pods -n $(NAMESPACE); \
+	fi
 	@$(MAKE) print-urls
 	@echo "Step 3/3: Printing checklist..."
 	@$(MAKE) _helm-install-ticketing-print-checklist NAMESPACE=$(NAMESPACE)

--- a/agent-service/config/lg-prompts/ticket-laptop-refresh-lg-prompt-big.yaml
+++ b/agent-service/config/lg-prompts/ticket-laptop-refresh-lg-prompt-big.yaml
@@ -69,7 +69,7 @@ states:
 
         6) CRITICAL SELF-CHECK: Before formatting the list, confirm you have raw knowledge base tool output from step 5. If you skipped the tool call in step 5 or cannot identify its output, go back and call the knowledge base tool now — do NOT proceed using your own knowledge. CRITICAL: Do not let the employee's current laptop model influence which options you present. The list must come exclusively from the knowledge base query result. Return a numbered sequential list of EVERY available laptop from the laptop-refresh knowledge base from the prior step. CRITICAL You MUST present ALL 15 specification fields for EACH laptop that you retrieved in step 5. CRITICAL The required fields are: Manufacturer, Model, ServiceNow Code, Target User, Cost, Operating System, Display Size, Display Resolution, Graphics Card, Minimum Storage, Weight, Ports, Minimum Processor, Minimum Memory, and Dimensions. CRITICAL Present EVERY field for EVERY laptop - do NOT present just the model name and ServiceNow code. CRITICAL Do NOT summarize or abbreviate the specifications. CRITICAL Copy the complete specifications EXACTLY as retrieved from the knowledge base in step 5 — every value must match the knowledge base verbatim. CRITICAL For each laptop include the category it belongs to and ALL the detailed specifications. CRITICAL Ask them to select ONLY ONE of the specific laptops. CRITICAL If the answer is not found in the provided context, state that the information is unavailable. CRITICAL Do not use any outside knowledge. CRITICAL Do not invent information. CRITICAL: If the conversation history already contains the laptop information block from step 4 (Employee Name, Laptop Model, Serial Number, etc.) and the eligibility summary, DO NOT include any of that in this response. Begin your response directly with "Here are the available laptop options for your location" — nothing before it. Do NOT restate laptop info, purchase date, age, eligibility, or any content already shown in a prior assistant message.
 
-        7) CRITICAL MANDATORY CONFIRMATION STEP: After the user selects a laptop, you MUST ask them if they would like to send the existing ticket to their manager for approval. CRITICAL DO NOT send the ticket yet. Your response must acknowledge their selection and explicitly ask for confirmation (e.g., "You've selected [laptop name]. Would you like to send this ticket to your manager for approval?"). CRITICAL This confirmation question MUST be asked in a SEPARATE agent response after laptop selection. CRITICAL Even if the user says "please send it" or "yes proceed" when selecting the laptop, you MUST STILL ask for confirmation in your response and wait for their next message. CRITICAL Wait for the user's next message confirming they want to proceed before moving to step 8.
+        7) CRITICAL MANDATORY CONFIRMATION STEP: After the user selects a laptop, you MUST respond with ONLY a confirmation question acknowledging their selection. Your response MUST NOT include any tool calls — no send_to_manager_review, no escalate_for_human_review, no close. Example: "You've selected [laptop name]. Would you like to send this ticket to your manager for approval?" CRITICAL: If your response contains a call to send_to_manager_review, you have violated this step. The confirmation question and the tool call MUST be in different turns. End your response after asking the question and wait for the user's reply.
 
         8) CRITICAL MANAGER APPROVAL STEP: Only after the user explicitly confirms in step 7, call the send_to_manager_review tool, then reply with ONLY this exact text and nothing else: Your ticket has been sent to your manager for approval. You will receive updates as your request is reviewed. ticket_complete. CRITICAL: Do NOT include laptop information, eligibility details, or any other text in this response.
 
@@ -147,19 +147,19 @@ states:
 
       **Assistant:** [calls escalate_for_human_review tool] Your ticket has been escalated for human review. ticket_escalated
 
-      ## CRITICAL: Always Ask for Confirmation Before Sending to Manager
+      ## CRITICAL: Always Ask for Confirmation Before Sending to Manager — NO TOOL CALLS IN STEP 7
 
-      Even if the user asks to send the ticket to their manager when selecting the laptop, you MUST still ask for confirmation as a separate step:
+      When the user selects a laptop, your response MUST contain ONLY text — zero tool calls. Ask for confirmation and stop.
 
       **User:** I'd like to select the Lenovo ThinkPad T14 Gen 5 Intel, can you please send it to my manager for approval?
 
-      **Assistant (CORRECT - still asks for confirmation):** You've selected the Lenovo ThinkPad T14 Gen 5 Intel. Would you like to send this ticket to your manager for approval?
+      **Assistant (CORRECT - text only, no tool call):** You've selected the Lenovo ThinkPad T14 Gen 5 Intel. Would you like to send this ticket to your manager for approval?
 
       **User:** Yes, please.
 
-      **Assistant:** Your ticket has been sent to your manager for approval. You will receive updates as your request is reviewed.
+      **Assistant (CORRECT - NOW call send_to_manager_review):** [calls send_to_manager_review tool] Your ticket has been sent to your manager for approval. You will receive updates as your request is reviewed. ticket_complete
 
-      **Assistant (INCORRECT - sends immediately):** ❌ DO NOT DO THIS - Your ticket has been sent to your manager for approval...
+      **Assistant (INCORRECT - calls tool in same turn as confirmation question):** ❌ DO NOT DO THIS — calling send_to_manager_review while asking the confirmation question
 
       ## CRITICAL: Preventing Duplicate Manager Routing
 


### PR DESCRIPTION
  
    - add wait for terminating pods. Earlier versions of oc had a bug
      which caused oc exec to sometimes pick a terminating pod
    - tweak to avoid assigning ticket to manager before confirmation as this
      was occuring frequently in my testing for other PRs
