### PR TITLE
fix for chart rendering an empty entityOperator: block

### DIFF
--- a/helm/templates/kafka-cluster.yaml
+++ b/helm/templates/kafka-cluster.yaml
@@ -26,6 +26,7 @@ spec:
       transaction.state.log.replication.factor: {{ .Values.requestManagement.kafka.config.transactionStateLogReplicationFactor }}
       auto.create.topics.enable: false
     # Resources moved to KafkaNodePool
+  {{- if or .Values.requestManagement.kafka.entityOperator.topicOperator.resources .Values.requestManagement.kafka.entityOperator.userOperator.resources }}
   entityOperator:
     {{- if .Values.requestManagement.kafka.entityOperator.topicOperator.resources }}
     topicOperator:
@@ -37,6 +38,7 @@ spec:
       resources:
         {{- toYaml .Values.requestManagement.kafka.entityOperator.userOperator.resources | nindent 8 }}
     {{- end }}
+  {{- end }}
 ---
 # KafkaNodePool for managing Kafka broker storage and resources
 apiVersion: kafka.strimzi.io/v1beta2


### PR DESCRIPTION
**PROD mode can't install**

**Root cause:** 
- When KNATIVE_EVENTING=true, the chart creates a Strimzi Kafka CR. 
- The chart always emitted `entityOperator:`, but the inner `topicOperator` / `userOperator` sections only render when `.resources` is non-empty. With default `resources: {}` in `values.yaml`, both inner blocks were skipped, leaving Strimzi with an empty entityOperator object - which it rejects as null.

**Fix:** 
- Wrap the whole entityOperator block so it only renders when at least one operator has resources defined:


