### PR TITLE
ci: add Helm/Kafka diagnostics to nightly prod runs

### DIFF
--- a/.github/workflows/nightly-e2e-prod-dev.yml
+++ b/.github/workflows/nightly-e2e-prod-dev.yml
@@ -154,6 +154,7 @@ jobs:
 
       - name: Log post-install Kafka cluster diagnostics
         if: always()
+        continue-on-error: true
         shell: bash
         run: ./scripts/ci/log-helm-kafka-diagnostics.sh post-install
         env:

--- a/.github/workflows/nightly-e2e-prod-dev.yml
+++ b/.github/workflows/nightly-e2e-prod-dev.yml
@@ -107,6 +107,12 @@ jobs:
           PROD_TOKEN: ${{ secrets.PROD_TOKEN }}
           PROD_SERVER: ${{ secrets.PROD_SERVER }}
 
+      - name: Log Helm and cluster tool versions
+        shell: bash
+        run: ./scripts/ci/log-helm-kafka-diagnostics.sh tools
+        env:
+          NAMESPACE: self-service-agent-ci-project-1
+
       - name: Make sure there are no pods running in the namespace
         continue-on-error: true
         shell: bash
@@ -125,6 +131,13 @@ jobs:
           echo "Commit SHA: ${COMMIT_SHA}"
           echo "Version with commit: ${VERSION_WITH_COMMIT}"
 
+      - name: Log pre-install Kafka manifest diagnostics
+        shell: bash
+        run: ./scripts/ci/log-helm-kafka-diagnostics.sh pre-install
+        env:
+          NAMESPACE: self-service-agent-ci-project-1
+          VERSION: ${{ steps.version.outputs.version }}
+
       - name: Install the quickstart
         shell: bash
         run: |
@@ -138,6 +151,13 @@ jobs:
           SERVICENOW_INSTANCE_URL: ${{ secrets.SERVICENOW_INSTANCE_URL }}
           SERVICENOW_API_KEY: ${{ secrets.SERVICENOW_API_KEY }}
           SERVICENOW_LAPTOP_REFRESH_ID: ${{ secrets.SERVICENOW_LAPTOP_REFRESH_ID }}
+
+      - name: Log post-install Kafka cluster diagnostics
+        if: always()
+        shell: bash
+        run: ./scripts/ci/log-helm-kafka-diagnostics.sh post-install
+        env:
+          NAMESPACE: self-service-agent-ci-project-1
 
       - name: Install evaluations dependencies
         shell: bash

--- a/.github/workflows/nightly-e2e-prod-main.yml
+++ b/.github/workflows/nightly-e2e-prod-main.yml
@@ -159,6 +159,7 @@ jobs:
 
       - name: Log post-install Kafka cluster diagnostics
         if: always()
+        continue-on-error: true
         shell: bash
         run: ./scripts/ci/log-helm-kafka-diagnostics.sh post-install
         env:

--- a/.github/workflows/nightly-e2e-prod-main.yml
+++ b/.github/workflows/nightly-e2e-prod-main.yml
@@ -113,17 +113,42 @@ jobs:
           PROD_TOKEN: ${{ secrets.PROD_TOKEN }}
           PROD_SERVER: ${{ secrets.PROD_SERVER }}
 
+      - name: Log Helm and cluster tool versions
+        shell: bash
+        run: ./scripts/ci/log-helm-kafka-diagnostics.sh tools
+        env:
+          NAMESPACE: self-service-agent-ci-project-1
+
       - name: Make sure there are no pods running in the namespace
         continue-on-error: true
         shell: bash
         run: |
           make helm-uninstall NAMESPACE=self-service-agent-ci-project-1
 
+      - name: Extract version from Makefile
+        id: version
+        run: |
+          BASE_VERSION=$(make version)
+          COMMIT_SHA=$(git rev-parse HEAD)
+          VERSION_WITH_COMMIT="${BASE_VERSION}-${COMMIT_SHA}"
+          echo "version=${VERSION_WITH_COMMIT}" >> $GITHUB_OUTPUT
+          echo "Base version: ${BASE_VERSION}"
+          echo "Commit SHA: ${COMMIT_SHA}"
+          echo "Version with commit: ${VERSION_WITH_COMMIT}"
+
+      - name: Log pre-install Kafka manifest diagnostics
+        shell: bash
+        run: ./scripts/ci/log-helm-kafka-diagnostics.sh pre-install
+        env:
+          NAMESPACE: self-service-agent-ci-project-1
+          VERSION: ${{ steps.version.outputs.version }}
+
       - name: Install the quickstart
         shell: bash
         run: |
           make helm-install-prod NAMESPACE=self-service-agent-ci-project-1 OTEL_EXPORTER_OTLP_ENDPOINT="http://otel-collector-collector.observability-hub.svc.cluster.local:4318"
         env:
+          VERSION: ${{ steps.version.outputs.version }}
           LLM_URL: ${{ vars.LLM_URL_EVAL_70B }}
           LLM_API_TOKEN: ${{ secrets.LLM_API_TOKEN_EVAL_70B }}
           LLM_ID: ${{ vars.LLM_ID_INFERENCE }}
@@ -131,6 +156,13 @@ jobs:
           SERVICENOW_INSTANCE_URL: ${{ secrets.SERVICENOW_INSTANCE_URL }}
           SERVICENOW_API_KEY: ${{ secrets.SERVICENOW_API_KEY }}
           SERVICENOW_LAPTOP_REFRESH_ID: ${{ secrets.SERVICENOW_LAPTOP_REFRESH_ID }}
+
+      - name: Log post-install Kafka cluster diagnostics
+        if: always()
+        shell: bash
+        run: ./scripts/ci/log-helm-kafka-diagnostics.sh post-install
+        env:
+          NAMESPACE: self-service-agent-ci-project-1
 
       - name: Install evaluations dependencies
         shell: bash

--- a/scripts/ci/log-helm-kafka-diagnostics.sh
+++ b/scripts/ci/log-helm-kafka-diagnostics.sh
@@ -69,19 +69,30 @@ log_pre_install() {
   section "entityOperator values in chart defaults"
   grep -A 6 'entityOperator:' helm/values.yaml 2>/dev/null | head -8 || true
   if [ -f helm/values-production.yaml ]; then
-    echo "(values-production.yaml has no entityOperator overrides)"
-    grep 'entityOperator' helm/values-production.yaml 2>/dev/null || true
+    local found
+    found=$(grep 'entityOperator' helm/values-production.yaml 2>/dev/null || true)
+    if [ -z "$found" ]; then
+      echo "(values-production.yaml has no entityOperator overrides)"
+    else
+      echo "(values-production.yaml entityOperator overrides found:)"
+      echo "$found"
+    fi
   fi
 
   helm_prod_template_args
   make helm-depend >/dev/null 2>&1 || true
 
+  KAFKA_CLUSTER_YAML="$(helm template "${HELM_TEMPLATE_ARGS[@]}" --show-only templates/kafka-cluster.yaml 2>/dev/null || true)"
+  KAFKA_YAML="$(echo "$KAFKA_CLUSTER_YAML" | awk '/^kind: Kafka$/,/^---$/')"
+
   section "Rendered Kafka CR (helm template)"
-  helm template "${HELM_TEMPLATE_ARGS[@]}" --show-only templates/kafka-cluster.yaml 2>/dev/null | \
-    awk '/^kind: Kafka$/,/^---$/' || warn "Could not render kafka-cluster.yaml"
+  if [ -n "$KAFKA_YAML" ]; then
+    echo "$KAFKA_YAML"
+  else
+    warn "Could not render kafka-cluster.yaml"
+  fi
 
   section "entityOperator serialization check (rendered manifest)"
-  KAFKA_YAML="$(helm template "${HELM_TEMPLATE_ARGS[@]}" --show-only templates/kafka-cluster.yaml 2>/dev/null | awk '/^kind: Kafka$/,/^---$/')"
   if [ -z "$KAFKA_YAML" ]; then
     warn "No Kafka manifest rendered (eventing disabled or template missing?)"
   elif echo "$KAFKA_YAML" | grep -q 'entityOperator: null'; then
@@ -90,13 +101,13 @@ log_pre_install() {
     warn "Rendered Kafka CR contains bare 'entityOperator:' with no child keys"
   elif echo "$KAFKA_YAML" | grep -q '^  entityOperator:'; then
     echo "entityOperator key is present in rendered manifest"
-    echo "$KAFKA_YAML" | awk '/^  entityOperator:/,/^  [a-zA-Z]/ {print}'
+    echo "$KAFKA_YAML" | awk '/^  entityOperator:/{flag=1; print; next} flag && /^  [a-zA-Z]/{exit} flag{print}'
   else
     echo "entityOperator key is omitted from rendered manifest (expected when no operator resources are set)"
   fi
 
   section "Full helm template kafka-cluster.yaml (for log capture)"
-  helm template "${HELM_TEMPLATE_ARGS[@]}" --show-only templates/kafka-cluster.yaml 2>/dev/null || true
+  echo "$KAFKA_CLUSTER_YAML"
 }
 
 log_post_install() {
@@ -113,7 +124,8 @@ log_post_install() {
     echo -n "jsonpath .spec.entityOperator="
     kubectl get kafka "$KAFKA_NAME" -n "$NAMESPACE" -o jsonpath='{.spec.entityOperator}' 2>/dev/null || true
     echo ""
-    kubectl get kafka "$KAFKA_NAME" -n "$NAMESPACE" -o yaml 2>/dev/null | awk '/^  entityOperator:/,/^  [a-z]/ {print}' | head -20
+    kubectl get kafka "$KAFKA_NAME" -n "$NAMESPACE" -o yaml 2>/dev/null | \
+      awk '/^  entityOperator:/{flag=1; print; next} flag && /^  [a-zA-Z]/{exit} flag{print}' | head -20
   else
     warn "Kafka CR ${KAFKA_NAME} not found in ${NAMESPACE}"
   fi

--- a/scripts/ci/log-helm-kafka-diagnostics.sh
+++ b/scripts/ci/log-helm-kafka-diagnostics.sh
@@ -9,6 +9,10 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+cd "${REPO_ROOT}"
+
 NAMESPACE="${NAMESPACE:-self-service-agent-ci-project-1}"
 KAFKA_NAME="${KAFKA_NAME:-self-service-agent-kafka}"
 CHART_NAME="${CHART_NAME:-self-service-agent}"

--- a/scripts/ci/log-helm-kafka-diagnostics.sh
+++ b/scripts/ci/log-helm-kafka-diagnostics.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# Logs Helm/Kafka diagnostics for nightly prod CI runs.
+# Helps debug Kafka entityOperator rendering and Strimzi acceptance issues.
+#
+# Usage:
+#   ./scripts/ci/log-helm-kafka-diagnostics.sh tools
+#   ./scripts/ci/log-helm-kafka-diagnostics.sh pre-install
+#   ./scripts/ci/log-helm-kafka-diagnostics.sh post-install
+
+set -euo pipefail
+
+NAMESPACE="${NAMESPACE:-self-service-agent-ci-project-1}"
+KAFKA_NAME="${KAFKA_NAME:-self-service-agent-kafka}"
+CHART_NAME="${CHART_NAME:-self-service-agent}"
+PHASE="${1:-all}"
+
+section() {
+  echo ""
+  echo "========== $1 =========="
+}
+
+warn() {
+  echo "WARNING: $*"
+}
+
+helm_prod_template_args() {
+  VERSION="${VERSION:-$(make -s version 2>/dev/null || echo latest)}"
+  echo "Using VERSION=${VERSION} for helm template"
+  HELM_TEMPLATE_ARGS=(
+    "$CHART_NAME" helm
+    -n "$NAMESPACE"
+    -f helm/values-production.yaml
+    --set "requestManagement.knative.eventing.enabled=true"
+    --set "image.tag=${VERSION}"
+  )
+}
+
+log_tools() {
+  section "Git commit"
+  git rev-parse HEAD 2>/dev/null || true
+  git log -1 --oneline 2>/dev/null || true
+
+  section "Helm client"
+  command -v helm || true
+  helm version
+
+  section "Kubernetes / OpenShift clients"
+  command -v kubectl || true
+  kubectl version --client=true 2>/dev/null || true
+  command -v oc || true
+  oc version --client=true 2>/dev/null || true
+
+  section "Cluster access"
+  oc whoami 2>/dev/null || kubectl config current-context 2>/dev/null || true
+  kubectl cluster-info 2>/dev/null | head -5 || true
+  kubectl get ns "$NAMESPACE" -o wide 2>/dev/null || echo "Namespace ${NAMESPACE} not found yet"
+
+  section "AMQ Streams / Strimzi operator (cluster-wide)"
+  kubectl get csv -n openshift-operators 2>/dev/null | grep -Ei 'amq-streams|strimzi' || \
+    kubectl get csv -A 2>/dev/null | grep -Ei 'amq-streams|strimzi' || echo "(operator CSV not found)"
+  kubectl get deploy -n openshift-operators 2>/dev/null | grep -Ei 'amq-streams|strimzi' || true
+}
+
+log_pre_install() {
+  section "entityOperator values in chart defaults"
+  grep -A 6 'entityOperator:' helm/values.yaml 2>/dev/null | head -8 || true
+  if [ -f helm/values-production.yaml ]; then
+    echo "(values-production.yaml has no entityOperator overrides)"
+    grep 'entityOperator' helm/values-production.yaml 2>/dev/null || true
+  fi
+
+  helm_prod_template_args
+  make helm-depend >/dev/null 2>&1 || true
+
+  section "Rendered Kafka CR (helm template)"
+  helm template "${HELM_TEMPLATE_ARGS[@]}" --show-only templates/kafka-cluster.yaml 2>/dev/null | \
+    awk '/^kind: Kafka$/,/^---$/' || warn "Could not render kafka-cluster.yaml"
+
+  section "entityOperator serialization check (rendered manifest)"
+  KAFKA_YAML="$(helm template "${HELM_TEMPLATE_ARGS[@]}" --show-only templates/kafka-cluster.yaml 2>/dev/null | awk '/^kind: Kafka$/,/^---$/')"
+  if [ -z "$KAFKA_YAML" ]; then
+    warn "No Kafka manifest rendered (eventing disabled or template missing?)"
+  elif echo "$KAFKA_YAML" | grep -q 'entityOperator: null'; then
+    warn "Rendered Kafka CR contains 'entityOperator: null' (often rejected by Strimzi / AMQ Streams)"
+  elif echo "$KAFKA_YAML" | awk '/^  entityOperator:$/{getline; if ($0 ~ /^---$/ || $0 ~ /^  [a-z]/ || $0 ~ /^kind:/) {print "empty"} else {print "populated"}}' | grep -q '^empty$'; then
+    warn "Rendered Kafka CR contains bare 'entityOperator:' with no child keys"
+  elif echo "$KAFKA_YAML" | grep -q '^  entityOperator:'; then
+    echo "entityOperator key is present in rendered manifest"
+    echo "$KAFKA_YAML" | awk '/^  entityOperator:/,/^  [a-zA-Z]/ {print}'
+  else
+    echo "entityOperator key is omitted from rendered manifest (expected when no operator resources are set)"
+  fi
+
+  section "Full helm template kafka-cluster.yaml (for log capture)"
+  helm template "${HELM_TEMPLATE_ARGS[@]}" --show-only templates/kafka-cluster.yaml 2>/dev/null || true
+}
+
+log_post_install() {
+  section "Helm release metadata"
+  helm list -n "$NAMESPACE" 2>/dev/null || true
+  helm get metadata "$CHART_NAME" -n "$NAMESPACE" 2>/dev/null || echo "(Helm release ${CHART_NAME} not found in ${NAMESPACE})"
+  helm history "$CHART_NAME" -n "$NAMESPACE" --max 3 2>/dev/null || true
+
+  section "Kafka / KafkaNodePool resources"
+  kubectl get kafka,kafkanodepool -n "$NAMESPACE" -o wide 2>/dev/null || true
+
+  section "Kafka CR spec.entityOperator (live object)"
+  if kubectl get kafka "$KAFKA_NAME" -n "$NAMESPACE" >/dev/null 2>&1; then
+    echo -n "jsonpath .spec.entityOperator="
+    kubectl get kafka "$KAFKA_NAME" -n "$NAMESPACE" -o jsonpath='{.spec.entityOperator}' 2>/dev/null || true
+    echo ""
+    kubectl get kafka "$KAFKA_NAME" -n "$NAMESPACE" -o yaml 2>/dev/null | awk '/^  entityOperator:/,/^  [a-z]/ {print}' | head -20
+  else
+    warn "Kafka CR ${KAFKA_NAME} not found in ${NAMESPACE}"
+  fi
+
+  section "Kafka CR status conditions"
+  kubectl get kafka "$KAFKA_NAME" -n "$NAMESPACE" -o jsonpath='{range .status.conditions[*]}{.type}={.status} reason={.reason} message={.message}{"\n"}{end}' 2>/dev/null || true
+
+  section "Kafka CR status (first 50 lines)"
+  kubectl get kafka "$KAFKA_NAME" -n "$NAMESPACE" -o yaml 2>/dev/null | awk '/^status:/,0' | head -50 || true
+
+  section "KafkaNodePool status"
+  kubectl get kafkanodepool -n "$NAMESPACE" -o yaml 2>/dev/null | awk '/^status:/,/^---$/' | head -40 || true
+
+  section "Recent Kafka events"
+  kubectl get events -n "$NAMESPACE" --field-selector "involvedObject.kind=Kafka" --sort-by='.lastTimestamp' 2>/dev/null | tail -20 || true
+
+  section "Recent namespace events (last 30)"
+  kubectl get events -n "$NAMESPACE" --sort-by='.lastTimestamp' 2>/dev/null | tail -30 || true
+
+  section "Pods not Running/Succeeded (if install failed partially)"
+  kubectl get pods -n "$NAMESPACE" --field-selector=status.phase!=Running,status.phase!=Succeeded 2>/dev/null || true
+}
+
+case "$PHASE" in
+  tools) log_tools ;;
+  pre-install) log_pre_install ;;
+  post-install) log_post_install ;;
+  all) log_tools; log_pre_install; log_post_install ;;
+  *)
+    echo "Usage: $0 [tools|pre-install|post-install|all]" >&2
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
## Summary
- Adds `scripts/ci/log-helm-kafka-diagnostics.sh` and wires it into both nightly prod workflows (`nightly-e2e-prod-dev.yml` and `nightly-e2e-prod-main.yml`).
- Logs **Helm client version**, git commit, kubectl/oc versions, AMQ Streams operator version, and cluster/namespace context before install.
- Logs **pre-install** `helm template` output for `kafka-cluster.yaml`, including warnings when `entityOperator` renders as empty/null.
- Logs **post-install** Helm release metadata, live Kafka CR `spec.entityOperator`, status conditions, KafkaNodePool status, and recent namespace/Kafka events (runs even if install fails).
- Aligns main nightly workflow with dev by extracting `VERSION` before install for consistent template rendering.

## Motivation
We are debugging Kafka install failures caused by an empty `entityOperator:` block in the rendered chart (Helm 3 vs Helm 4 serialization differences). Nightly CI currently does not log Helm version or Kafka CR details, making it hard to compare CI behavior with local repros.