### PR TITLE
fix: increase metadata capture timeout to avoid missing conversation metadata

### DIFF
--- a/evaluations/helpers/openshift_chat_client.py
+++ b/evaluations/helpers/openshift_chat_client.py
@@ -340,7 +340,7 @@ class OpenShiftChatClient:
             logger.debug("Process terminated while reading conversation metadata")
             return
         try:
-            ready, _, _ = select.select([self.process.stdout], [], [], 5.0)
+            ready, _, _ = select.select([self.process.stdout], [], [], 60.0)
             if not ready:
                 return
             line = self.process.stdout.readline()


### PR DESCRIPTION
**Problem:**
The `_zammad_get_conversation_metadata()` call sometimes takes longer than 5 seconds to fetch ticket state from Zammad.

This happens because Zammad uses a single worker for handling requests sequentially and may be busy processing other requests (dispatcher article writes, webhook triggers) at the same time.

When that happens, the `TICKET_STATUS` line arrives after the 5-second select() timeout, causing the evaluator to record no actual metadata for that turn — resulting in `"assistant turn has no actual metadata"` metric errors.

**Fix:**
Increase the select() timeout from 5 to 60 seconds, giving enough time for the `TICKET_STATUS` line to arrive even under Zammad load.

**Why CI tests don't hit this:**
CI runs on Kind where all pods are on the same machine — there are no network delays between pods and no other workloads on the cluster.