### PR TITLE
Eval/gpt oss 120b evaluation

### DIFF
--- a/evaluations/helpers/custom_llm.py
+++ b/evaluations/helpers/custom_llm.py
@@ -125,6 +125,27 @@ class CustomLLM(DeepEvalBaseLLM):
             if schema is not None and content:
                 try:
                     data = json.loads(content)
+                    # GPT-OSS-120b sometimes wraps output in {"final": "{...}"} or
+                    # emits malformed keys like {"final{": 0, "reason": "..."}.
+                    # Unwrap/remap any key starting with "final".
+                    if isinstance(data, dict) and "score" not in data:
+                        final_key = next(
+                            (k for k in data if k.startswith("final")), None
+                        )
+                        if final_key is not None:
+                            inner = data[final_key]
+                            if isinstance(inner, (int, float)):
+                                data = {
+                                    "score": inner,
+                                    "reason": data.get("reason", ""),
+                                }
+                            elif isinstance(inner, str):
+                                try:
+                                    data = json.loads(inner)
+                                except json.JSONDecodeError:
+                                    pass
+                            elif isinstance(inner, dict):
+                                data = inner
                     return schema(**data)
                 except (json.JSONDecodeError, Exception) as e:
                     logger.error(f"Failed to parse response as {schema.__name__}: {e}")
@@ -213,6 +234,27 @@ class CustomLLM(DeepEvalBaseLLM):
             if schema is not None and content:
                 try:
                     data = json.loads(content)
+                    # GPT-OSS-120b sometimes wraps output in {"final": "{...}"} or
+                    # emits malformed keys like {"final{": 0, "reason": "..."}.
+                    # Unwrap/remap any key starting with "final".
+                    if isinstance(data, dict) and "score" not in data:
+                        final_key = next(
+                            (k for k in data if k.startswith("final")), None
+                        )
+                        if final_key is not None:
+                            inner = data[final_key]
+                            if isinstance(inner, (int, float)):
+                                data = {
+                                    "score": inner,
+                                    "reason": data.get("reason", ""),
+                                }
+                            elif isinstance(inner, str):
+                                try:
+                                    data = json.loads(inner)
+                                except json.JSONDecodeError:
+                                    pass
+                            elif isinstance(inner, dict):
+                                data = inner
                     return schema(**data)
                 except (json.JSONDecodeError, Exception) as e:
                     logger.error(f"Failed to parse response as {schema.__name__}: {e}")


### PR DESCRIPTION
**Problem**

  When using GPT-OSS-120b as the evaluation judge via DeepEval, the model occasionally wraps its `ReasonScore` output in non-standard formats instead of the expected flat {"score": ..., "reason": ...}:

  - Wrapped string: {"final": "{\"score\": 8, \"reason\": \"...\"}"}
  - Malformed key: {"final{": 0, "reason": "..."}

  Both caused `ReasonScore` pydantic validation errors, crashing the evaluation mid-run and marking conversations as unevaluated.

  **Fix**

  Added a small rescue block in `evaluations/helpers/custom_llm.py` (both generate and a_generate) that activates only when score is missing from the parsed JSON and a key starting with "final" is present. It unwraps the value into the expected structure before passing it to pydantic.

  The fix is backward compatible — models that return correct JSON `({"score": ..., "reason": ...})` hit the "score" not in data guard as False and are completely unaffected.

