### PR TITLE
fix: tweak ticket-general-lg-prompt and increase long test timeout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1415,7 +1415,7 @@ test-short-ticket-laptop-refresh:
 .PHONY: test-long-ticket-laptop-refresh
 test-long-ticket-laptop-refresh:
 	@echo "Running ticket-laptop-refresh evaluation (10 conversations)..."
-	uv --directory evaluations run evaluate.py --message-timeout 1800 --timeout=1800 -n 10 --flow ticket_laptop_refresh,ticket_unrelated $(VALIDATE_LAPTOP_DETAILS_FLAG) $(STRUCTURED_OUTPUT_FLAG)
+	uv --directory evaluations run evaluate.py --message-timeout 1800 --timeout=2700 -n 10 --flow ticket_laptop_refresh,ticket_unrelated $(VALIDATE_LAPTOP_DETAILS_FLAG) $(STRUCTURED_OUTPUT_FLAG)
 	@echo "ticket-laptop-refresh evaluation completed successfully!"
 
 .PHONY: test-short-resp-integration-request-mgr

--- a/agent-service/config/lg-prompts/ticket-general-lg-prompt-small.yaml
+++ b/agent-service/config/lg-prompts/ticket-general-lg-prompt-small.yaml
@@ -107,9 +107,9 @@ states:
       Analyze the user's message and determine their intent. The user said: "{user_input}"
 
       Classify their intent as one of the following:
-      1. ESCALATE - User is explicitly requesting to escalate the ticket for human review. They must be making a clear request, not just asking whether they should escalate or mentioning escalation in passing.
-      2. CLOSE - User is explicitly requesting to close the ticket (resolved, done, no thanks, cancel, never mind, etc.)
-      3. QUESTION - User has a follow-up question, needs more help, or is asking whether they should escalate/close rather than actually requesting it.
+      1. ESCALATE - User is explicitly requesting to escalate the ticket for human review. They must use words like "escalate", "human agent", "speak to someone", "manager", or "supervisor". Simply asking for help, requesting to try a troubleshooting step, or expressing frustration is NOT an escalation request — classify as QUESTION.
+      2. CLOSE - User is explicitly requesting to close the ticket using words like "close", "resolved", "done", "cancel", "never mind". Statements like "I'll try that", "thanks for the help", "let me check", "I'll restart", "I'll do that" are NOT close requests — classify as QUESTION.
+      3. QUESTION - User has a follow-up question, needs more help, is acknowledging advice ("I'll try that", "thanks", "let me check"), is asking about a specific troubleshooting step ("can I try X?", "should I do Y?", "can I just re-enroll?"), or is asking whether they should escalate/close rather than actually requesting it.
 
       Respond with only the classification: ESCALATE, CLOSE, or QUESTION
     intent_actions:


### PR DESCRIPTION
Reference: https://redhat.atlassian.net/browse/APPENG-4976

Including the following fixes:
  - Increase `test-long-ticket-laptop-refresh` timeout from 30 to 45 mins to prevent premature generator timeout on slower runs.

  - For the ticket_unrelated flow, refine ESCALATE, CLOSE, and QUESTION intent classification to prevent the agent's proactive close/escalate actions that were seen on nightly CI runs and local runs — e.g., before this fix the agent sometimes closed/escalated a ticket when the user said "I'll try restarting" or "thanks for the help" without specifically asking the agent to close/escalate. Failed metric: `User-Initiated Close or Escalation`.