### PR TITLE
fix: improve intent classification and reduce laptop options hallucination

### DIFF
--- a/agent-service/config/lg-prompts/ticket-general-lg-prompt-small.yaml
+++ b/agent-service/config/lg-prompts/ticket-general-lg-prompt-small.yaml
@@ -107,9 +107,9 @@ states:
       Analyze the user's message and determine their intent. The user said: "{user_input}"
 
       Classify their intent as one of the following:
-      1. ESCALATE - User is explicitly requesting to escalate the ticket for human review. They must use words like "escalate", "human agent", "speak to someone", "manager", or "supervisor". Simply asking for help, requesting to try a troubleshooting step, or expressing frustration is NOT an escalation request — classify as QUESTION.
-      2. CLOSE - User is explicitly requesting to close the ticket using words like "close", "resolved", "done", "cancel", "never mind". Statements like "I'll try that", "thanks for the help", "let me check", "I'll restart", "I'll do that" are NOT close requests — classify as QUESTION.
-      3. QUESTION - User has a follow-up question, needs more help, is acknowledging advice ("I'll try that", "thanks", "let me check"), is asking about a specific troubleshooting step ("can I try X?", "should I do Y?", "can I just re-enroll?"), or is asking whether they should escalate/close rather than actually requesting it.
+      1. ESCALATE - User is explicitly requesting to escalate the ticket for human review. They must use words like "escalate", "human agent", "speak to someone", "manager", or "supervisor". Simply asking for help, requesting to try a troubleshooting step, expressing frustration, or asking for contact information ("reach out directly", "get the phone number", "contact details") is NOT an escalation request — classify as QUESTION.
+      2. CLOSE - User is explicitly requesting to close the ticket using words like "close", "resolved", "done", "cancel", "never mind". Statements like "I'll try that", "thanks for the help", "let me check", "I'll restart", "I'll do that", "I've got all the information I need" are NOT close requests — classify as QUESTION.
+      3. QUESTION - User has a follow-up question, needs more help, is acknowledging advice ("I'll try that", "thanks", "let me check"), is asking about a specific troubleshooting step ("can I try X?", "should I do Y?", "can I just re-enroll?"), is asking for contact information or details, or is asking whether they should escalate/close rather than actually requesting it.
 
       Respond with only the classification: ESCALATE, CLOSE, or QUESTION
     intent_actions:

--- a/agent-service/config/lg-prompts/ticket-laptop-refresh-lg-prompt-small.yaml
+++ b/agent-service/config/lg-prompts/ticket-laptop-refresh-lg-prompt-small.yaml
@@ -311,7 +311,7 @@ states:
   # State 5: Select Laptop
   select_laptop:
     type: "llm_processor"
-    temperature: 0.2
+    temperature: 0.1
     allowed_tools: []
     failure_transition: "waiting_proceed_confirmation"
     prompt: |


### PR DESCRIPTION
Reference: https://redhat.atlassian.net/browse/APPENG-4976

Including the following fixes:

1. Refined the intent classifier for the `ticket_unrelated` flow to prevent false escalations and false closes when the user asked for contact/information. 

   E.g., user said "can I get the contact information for the IT Helpdesk so I can reach out to
  them directly?" and the agent escalated instead of answering the question.

   This failure was reproduced on the July 18 nightly 70b run (speeding-up-ticket-resolution run #29640713560)

2. Lowered the `select_laptop` state temperature from 0.2 to 0.1 to reduce LLM hallucination when presenting laptop options. Lowering temperature to 0.1 makes the model more deterministic and faithful to the `knowledge_search` results. 

   This failure was reproduced for me on local E2E test 70b run with a generated conversation for user ahmed.hassan@company.com (EMEA).