### PR TITLE
fix: add allow-unsafe-pr-checkout for pull_request_target workflows

### DIFF
--- a/.github/workflows/pr-e2e-tests-ticket-flow.yml
+++ b/.github/workflows/pr-e2e-tests-ticket-flow.yml
@@ -38,6 +38,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          allow-unsafe-pr-checkout: true
 
       - name: Prepare Runner
         uses: ./.github/actions/prepare-runner

--- a/.github/workflows/pr-e2e-tests.yml
+++ b/.github/workflows/pr-e2e-tests.yml
@@ -38,6 +38,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          allow-unsafe-pr-checkout: true
 
       - name: Prepare Runner
         uses: ./.github/actions/prepare-runner

--- a/.github/workflows/pr-evaluation-check.yml
+++ b/.github/workflows/pr-evaluation-check.yml
@@ -35,6 +35,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          allow-unsafe-pr-checkout: true
 
       - name: Set up Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
As of July 20, 2026, actions/checkout backported a security change that blocks checking out fork PR code in pull_request_target workflows by default. This broke our PR CI for external contributors.

Add allow-unsafe-pr-checkout: true to the 3 affected workflows. Security is maintained via "Require approval for all external collaborators" which gates workflow execution before secrets are exposed.

Ref: https://github.blog/changelog/2026-06-18-safer-pull_request_target-defaults-for-github-actions-checkout/