### PR TITLE
fix: add allow-unsafe-pr-checkout for pull_request_target workflows

### DIFF
--- a/.github/workflows/pr-e2e-tests-ticket-flow.yml
+++ b/.github/workflows/pr-e2e-tests-ticket-flow.yml
@@ -38,6 +38,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          allow-unsafe-pr-checkout: true
 
       - name: Prepare Runner
         uses: ./.github/actions/prepare-runner

--- a/.github/workflows/pr-e2e-tests.yml
+++ b/.github/workflows/pr-e2e-tests.yml
@@ -38,6 +38,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          allow-unsafe-pr-checkout: true
 
       - name: Prepare Runner
         uses: ./.github/actions/prepare-runner

--- a/.github/workflows/pr-evaluation-check.yml
+++ b/.github/workflows/pr-evaluation-check.yml
@@ -35,6 +35,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          allow-unsafe-pr-checkout: true
 
       - name: Set up Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
Duplicate of [PR 431](https://github.com/rh-ai-quickstart/it-self-service-agent/pull/431) to allow for ci checks to run