### PR TITLE
fix: increase Zammad Puma workers and auto-detect eval message timeout

### DIFF
--- a/evaluations/evaluate.py
+++ b/evaluations/evaluate.py
@@ -46,7 +46,7 @@ logger = logging.getLogger(__name__)
 
 
 def run_script(
-    script_name: str, args: Optional[List[str]] = None, timeout: int = 600
+    script_name: str, args: Optional[List[str]] = None, timeout: int = 2700
 ) -> bool:
     """
     Run a Python script with optional arguments and timeout, showing real-time output.
@@ -510,8 +510,8 @@ def _parse_arguments() -> argparse.Namespace:
     parser.add_argument(
         "--timeout",
         type=int,
-        default=600,
-        help="Timeout in seconds for each script execution (default: 600)",
+        default=2700,
+        help="Timeout in seconds for each script execution (default: 2700s / 45 min).",
     )
     parser.add_argument(
         "--max-turns",
@@ -547,9 +547,10 @@ def _parse_arguments() -> argparse.Namespace:
     parser.add_argument(
         "--message-timeout",
         type=int,
-        default=60,
-        help="Timeout in seconds for individual message send/response operations in generator.py (default: 60). "
-        "Increase for slower agents or high concurrency scenarios.",
+        default=None,
+        help="Timeout in seconds for individual message send/response operations. "
+        "Default: auto — 60 for chat-responses-request-mgr.py; "
+        "TRIGGER_POLL_TIMEOUT+60 (240s by default) for ticket-responses-request-mgr.py.",
     )
     parser.add_argument(
         "--validate-full-laptop-details",
@@ -609,7 +610,7 @@ def _parse_arguments() -> argparse.Namespace:
 
 
 def run_check_known_bad_conversations(
-    timeout: int = 600,
+    timeout: int = 2700,
     validate_full_laptop_details: bool = True,
     use_structured_output: bool = False,
     flow: Optional[str] = None,
@@ -932,12 +933,12 @@ def run_check_known_bad_conversations(
 
 def run_evaluation_pipeline(
     num_conversations: int = 20,
-    timeout: int = 600,
+    timeout: int = 2700,
     max_turns: int = 20,
     test_script: str = "chat-responses-request-mgr.py",
     reset_conversation: bool = False,
     concurrency: int = 1,
-    message_timeout: int = 60,
+    message_timeout: Optional[int] = None,
     validate_full_laptop_details: bool = True,
     use_structured_output: bool = False,
     conversation_source: str = "generate",
@@ -961,7 +962,9 @@ def run_evaluation_pipeline(
         test_script: Name of the test script to execute
         reset_conversation: Send 'reset' message at the start of each conversation
         concurrency: Number of parallel workers for generator.py (default: 1)
-        message_timeout: Timeout for individual message send/response operations (default: 60)
+        message_timeout: Timeout for individual message send/response operations, forwarded
+            to run_conversations.py/generator.py as-is. None lets those scripts pick a
+            script-aware default (see helpers.calculate_message_timeout).
         validate_full_laptop_details: Enable validation of all 15 laptop specification fields (default: True)
         use_structured_output: Enable structured output with Pydantic schema validation (default: False)
         conversation_source: "generate" to run generator.py, "export" to run export_conversations_from_api.py (default: generate)
@@ -993,9 +996,9 @@ def run_evaluation_pipeline(
         run_conversations_args = [
             "--test-script",
             test_script,
-            "--message-timeout",
-            str(message_timeout),
         ]
+        if message_timeout is not None:
+            run_conversations_args.extend(["--message-timeout", str(message_timeout)])
         if reset_conversation:
             run_conversations_args.append("--reset-conversation")
         if flow:
@@ -1031,9 +1034,9 @@ def run_evaluation_pipeline(
             str(max_turns),
             "--test-script",
             test_script,
-            "--message-timeout",
-            str(message_timeout),
         ]
+        if message_timeout is not None:
+            generator_args.extend(["--message-timeout", str(message_timeout)])
         if concurrency > 1:
             generator_args.extend(["--concurrency", str(concurrency)])
         if reset_conversation:
@@ -1147,6 +1150,14 @@ def main() -> int:
         if args.flow and args.all_flows:
             logger.error("--flow and --all-flows are mutually exclusive")
             return 1
+
+        if args.message_timeout is not None and args.message_timeout >= args.timeout:
+            logger.warning(
+                "⚠️  --message-timeout (%ss) >= --timeout (%ss); "
+                "the subprocess may be killed before a single message completes.",
+                args.message_timeout,
+                args.timeout,
+            )
 
         # Parse comma-separated flow names
         flow_names = (

--- a/evaluations/generator.py
+++ b/evaluations/generator.py
@@ -168,9 +168,10 @@ def _parse_arguments() -> argparse.Namespace:
     parser.add_argument(
         "--message-timeout",
         type=int,
-        default=60,
-        help="Timeout in seconds for individual message send/response operations (default: 60). "
-        "Increase for slower agents or high concurrency scenarios.",
+        default=None,
+        help="Timeout in seconds for individual message send/response operations. "
+        "Default: auto — 60 for chat-responses-request-mgr.py; "
+        "TRIGGER_POLL_TIMEOUT+60 (240s by default) for ticket-responses-request-mgr.py.",
     )
     parser.add_argument(
         "--use-structured-output",
@@ -596,6 +597,16 @@ if __name__ == "__main__":
         flow_scenario = flow_module.get_scenario(args.use_structured_output)
         logger.info(f"Using flow '{args.flow}': saving to {results_dir}")
 
+    from helpers.calculate_message_timeout import calculate_message_timeout
+
+    message_timeout = calculate_message_timeout(test_script, args.message_timeout)
+    if args.message_timeout is None:
+        logger.info(
+            "Auto message-timeout=%ss for test script %s",
+            message_timeout,
+            test_script,
+        )
+
     # Get API configuration from environment variables
     api_key, api_endpoint, model_name = get_api_configuration()
 
@@ -651,7 +662,7 @@ if __name__ == "__main__":
                 args.max_turns,
                 test_script,
                 reset_conversation,
-                args.message_timeout,
+                message_timeout,
                 args.use_structured_output,
                 results_dir,
                 flow_scenario,

--- a/evaluations/helpers/calculate_message_timeout.py
+++ b/evaluations/helpers/calculate_message_timeout.py
@@ -1,0 +1,26 @@
+"""Auto-detect per-message timeout based on test script type."""
+
+import os
+from pathlib import Path
+
+_DEFAULT_CHAT_MESSAGE_TIMEOUT = 60
+_TICKET_SCRIPT = "ticket-responses-request-mgr.py"
+_TICKET_POLL_BUFFER = (
+    60  # extra seconds on top of TRIGGER_POLL_TIMEOUT for slow agent turns
+)
+
+
+def calculate_message_timeout(test_script: str, explicit: int | None) -> int:
+    """Return explicit timeout (seconds) if set, otherwise infer from test_script name.
+
+    Args:
+        test_script: Script name (e.g. "chat-responses-request-mgr.py").
+        explicit: User-provided --message-timeout value, or None for auto-detect.
+
+    Chat scripts default to 60s; ticket scripts default to TRIGGER_POLL_TIMEOUT + 60s.
+    """
+    if explicit is not None:
+        return explicit
+    if Path(test_script).name == _TICKET_SCRIPT:
+        return int(os.environ.get("TRIGGER_POLL_TIMEOUT", "180")) + _TICKET_POLL_BUFFER
+    return _DEFAULT_CHAT_MESSAGE_TIMEOUT

--- a/evaluations/run_conversations.py
+++ b/evaluations/run_conversations.py
@@ -1,8 +1,11 @@
 #!/usr/bin/env python3
 
 import argparse
+import logging
 import sys
 from pathlib import Path
+
+logger = logging.getLogger(__name__)
 
 from helpers.run_conversation_flow import ConversationFlowTester
 
@@ -35,8 +38,10 @@ def _parse_arguments() -> argparse.Namespace:
     parser.add_argument(
         "--message-timeout",
         type=int,
-        default=60,
-        help="Timeout in seconds for individual message send/response operations (default: 60)",
+        default=None,
+        help="Timeout in seconds for individual message send/response operations. "
+        "Default: auto — 60 for chat-responses-request-mgr.py; "
+        "TRIGGER_POLL_TIMEOUT+60 (240s by default) for ticket-responses-request-mgr.py.",
     )
     return parser.parse_args()
 
@@ -84,12 +89,22 @@ if __name__ == "__main__":
         flow_ticket_title = None
         flow_include_conversation_metadata = False
 
+    from helpers.calculate_message_timeout import calculate_message_timeout
+
+    message_timeout = calculate_message_timeout(test_script, args.message_timeout)
+    if args.message_timeout is None:
+        logger.info(
+            "Auto message-timeout=%ss for test script %s",
+            message_timeout,
+            test_script,
+        )
+
     tester = ConversationFlowTester(
         test_script=test_script,
         reset_conversation=reset_conversation,
         initial_message=flow_initial_message,
         skip_initial_message=flow_skip_initial,
-        message_timeout=args.message_timeout,
+        message_timeout=message_timeout,
         ticket_title=flow_ticket_title,
         include_conversation_metadata=flow_include_conversation_metadata,
     )

--- a/evaluations/tests/test_message_timeout.py
+++ b/evaluations/tests/test_message_timeout.py
@@ -1,0 +1,33 @@
+"""Tests for evaluation message-timeout resolution."""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from helpers.calculate_message_timeout import calculate_message_timeout
+
+
+def test_chat_script_default() -> None:
+    assert calculate_message_timeout("chat-responses-request-mgr.py", None) == 60
+
+
+def test_chat_script_with_path() -> None:
+    assert (
+        calculate_message_timeout("/app/test/chat-responses-request-mgr.py", None) == 60
+    )
+
+
+def test_ticket_script_default() -> None:
+    assert calculate_message_timeout("ticket-responses-request-mgr.py", None) == 240
+
+
+def test_ticket_script_custom_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("TRIGGER_POLL_TIMEOUT", "200")
+    assert calculate_message_timeout("ticket-responses-request-mgr.py", None) == 260
+
+
+def test_explicit_overrides_auto() -> None:
+    assert calculate_message_timeout("ticket-responses-request-mgr.py", 60) == 60

--- a/helm/zammad/values.yaml
+++ b/helm/zammad/values.yaml
@@ -2,7 +2,10 @@
 # Zammad subchart values go under the "zammad" key.
 # Override via helm/values-ticketing.yaml (when deployed as a subchart of the main chart).
 
-zammad: {}
+zammad:
+  zammadConfig:
+    railsserver:
+      webConcurrency: 2
 
 # OpenShift Route for external access to Zammad Web UI
 externalRoute:


### PR DESCRIPTION
Reference: https://redhat.atlassian.net/browse/APPENG-5631

A replacement of PR #427 (original author @djljvv).

Content:
  - Increase Zammad Puma workers from 1 to 2 to handle concurrent requests during ticket flows
  - Auto-detect per-message timeout based on test script type (60s for chat, 240s for ticketing)
  - Add validation warning when message-timeout >= subprocess timeout

Changes from original PR
  - Removed webhook group filter change (triggerSkipGroupFilter) -- kept existing group-based filtering
  - Simplified message_timeout module and tests
  - Fixed trailing whitespace in helm/zammad/values.yaml