### PR TITLE
fix: increase Zammad Puma workers and Extend default evaluation timeout

### DIFF
--- a/evaluations/evaluate.py
+++ b/evaluations/evaluate.py
@@ -46,7 +46,7 @@ logger = logging.getLogger(__name__)
 
 
 def run_script(
-    script_name: str, args: Optional[List[str]] = None, timeout: int = 600
+    script_name: str, args: Optional[List[str]] = None, timeout: int = 2700
 ) -> bool:
     """
     Run a Python script with optional arguments and timeout, showing real-time output.
@@ -510,8 +510,8 @@ def _parse_arguments() -> argparse.Namespace:
     parser.add_argument(
         "--timeout",
         type=int,
-        default=600,
-        help="Timeout in seconds for each script execution (default: 600)",
+        default=2700,
+        help="Timeout in seconds for each script execution (default: 2700s / 45 min).",
     )
     parser.add_argument(
         "--max-turns",
@@ -548,7 +548,7 @@ def _parse_arguments() -> argparse.Namespace:
         "--message-timeout",
         type=int,
         default=60,
-        help="Timeout in seconds for individual message send/response operations in generator.py (default: 60). "
+        help="Timeout in seconds for individual message send/response operations (default: 60). "
         "Increase for slower agents or high concurrency scenarios.",
     )
     parser.add_argument(
@@ -609,7 +609,7 @@ def _parse_arguments() -> argparse.Namespace:
 
 
 def run_check_known_bad_conversations(
-    timeout: int = 600,
+    timeout: int = 2700,
     validate_full_laptop_details: bool = True,
     use_structured_output: bool = False,
     flow: Optional[str] = None,
@@ -932,7 +932,7 @@ def run_check_known_bad_conversations(
 
 def run_evaluation_pipeline(
     num_conversations: int = 20,
-    timeout: int = 600,
+    timeout: int = 2700,
     max_turns: int = 20,
     test_script: str = "chat-responses-request-mgr.py",
     reset_conversation: bool = False,
@@ -1147,6 +1147,14 @@ def main() -> int:
         if args.flow and args.all_flows:
             logger.error("--flow and --all-flows are mutually exclusive")
             return 1
+
+        if args.message_timeout >= args.timeout:
+            logger.warning(
+                "⚠️  --message-timeout (%ss) >= --timeout (%ss); "
+                "the subprocess may be killed before a single message completes.",
+                args.message_timeout,
+                args.timeout,
+            )
 
         # Parse comma-separated flow names
         flow_names = (

--- a/helm/zammad/values.yaml
+++ b/helm/zammad/values.yaml
@@ -2,7 +2,10 @@
 # Zammad subchart values go under the "zammad" key.
 # Override via helm/values-ticketing.yaml (when deployed as a subchart of the main chart).
 
-zammad: {}
+zammad:
+  zammadConfig:
+    railsserver:
+      webConcurrency: 2
 
 # OpenShift Route for external access to Zammad Web UI
 externalRoute:


### PR DESCRIPTION
Reference: https://redhat.atlassian.net/browse/APPENG-5631

A replacement of PR #427 (original author @djljvv).

Content:
      - Increase Zammad Puma workers from 1 to 2 to handle concurrent requests during ticket flows
      - Add validation warning when message-timeout >= subprocess timeout
      - Raise default script timeout from 600s to 2700s

Tested successfully with **make test-long-ticket-laptop-refresh** against dev02