### PR TITLE
chore: update to latest architecture chart for llamastack

### DIFF
--- a/agent-service/pyproject.toml
+++ b/agent-service/pyproject.toml
@@ -13,8 +13,8 @@ dependencies = [
     "cloudevents>=1.10.0",
     "httpx>=0.25.0",
     "structlog>=23.2.0",
-    # LlamaStack integration (matches server version 0.5.0)
-    "llama-stack-client==0.5.0",
+    # LlamaStack integration (matches server version 0.6.1)
+    "llama-stack-client==0.6.1",
     "requests>=2.31.0",
     "self-service-agent-shared-models",
     "protobuf>=6.33.5",

--- a/agent-service/requirements.txt
+++ b/agent-service/requirements.txt
@@ -977,9 +977,9 @@ langsmith==0.6.6 \
     --hash=sha256:64ba70e7b795cff3c498fe6f2586314da1cc855471a5e5b6a357950324af3874 \
     --hash=sha256:fe655e73b198cd00d0ecd00a26046eaf1f78cd0b2f0d94d1e5591f3143c5f592
     # via langchain-core
-llama-stack-client==0.5.0 \
-    --hash=sha256:5e7272c7fb58cd169985191c42af78dc6c4d212b7050949b063788bfb9e7ed36 \
-    --hash=sha256:e005ae9d975cda30b3b86261057f228d700107e263e12b796b920cd1fb9ba968
+llama-stack-client==0.6.1 \
+    --hash=sha256:13dabd74c29d5159cdcfca5a9e6f99c99f08aa688fa8403d6c5f6042b61519d2 \
+    --hash=sha256:47aa4f47b591ffbd35b7be946552c4198006daaf57505898372d7bc7c1df510f
     # via self-service-agent-service
 mako==1.3.10 \
     --hash=sha256:99579a6f39583fa7e5630a28c3c1f440e4e97a414b80372649c0ce338da2ea28 \

--- a/agent-service/uv.lock
+++ b/agent-service/uv.lock
@@ -1634,7 +1634,7 @@ wheels = [
 
 [[package]]
 name = "llama-stack-client"
-version = "0.5.0"
+version = "0.6.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -1653,9 +1653,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/af/a1/1bd9ed2b6982fb1edf0215be1a4569eb65c9354b86bfdcb5b1414b489162/llama_stack_client-0.5.0.tar.gz", hash = "sha256:e005ae9d975cda30b3b86261057f228d700107e263e12b796b920cd1fb9ba968", size = 368629, upload-time = "2026-02-05T17:23:06.688Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/01/47b32f2fb003b7f3fc24a401cd7b091892025f626dd07661647f64e3df68/llama_stack_client-0.6.1.tar.gz", hash = "sha256:13dabd74c29d5159cdcfca5a9e6f99c99f08aa688fa8403d6c5f6042b61519d2", size = 368690, upload-time = "2026-03-30T13:11:39.597Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2d/93/63b434955cdb80d54c69bdb51ecd1a12595451ce238667fdaa125fb7d1ec/llama_stack_client-0.5.0-py3-none-any.whl", hash = "sha256:5e7272c7fb58cd169985191c42af78dc6c4d212b7050949b063788bfb9e7ed36", size = 391950, upload-time = "2026-02-05T17:23:04.238Z" },
+    { url = "https://files.pythonhosted.org/packages/57/bd/da2f43993b9b753f0465548b17efbbee492a6980fdd5e14fadf8566cdb1f/llama_stack_client-0.6.1-py3-none-any.whl", hash = "sha256:47aa4f47b591ffbd35b7be946552c4198006daaf57505898372d7bc7c1df510f", size = 391998, upload-time = "2026-03-30T13:11:38.067Z" },
 ]
 
 [[package]]
@@ -3289,7 +3289,7 @@ requires-dist = [
     { name = "langfuse", specifier = ">=3.0.0" },
     { name = "langgraph", specifier = "==1.0.7" },
     { name = "langgraph-checkpoint-postgres", specifier = ">=2.0.0" },
-    { name = "llama-stack-client", specifier = "==0.5.0" },
+    { name = "llama-stack-client", specifier = "==0.6.1" },
     { name = "mlflow", specifier = ">=2.14.0" },
     { name = "openai", specifier = ">=1.0.0" },
     { name = "opentelemetry-exporter-otlp-proto-http", specifier = ">=1.37.0" },

--- a/helm/Chart.lock
+++ b/helm/Chart.lock
@@ -7,12 +7,12 @@ dependencies:
   version: 0.5.6
 - name: llama-stack
   repository: https://rh-ai-quickstart.github.io/ai-architecture-charts
-  version: 0.8.5
+  version: 0.8.9
 - name: mcp-servers
   repository: https://rh-ai-quickstart.github.io/ai-architecture-charts
   version: 0.5.17
 - name: ticketingZammad
   repository: file://./zammad
   version: 0.1.0
-digest: sha256:0d76fee0a49fb2f60016e464051ab04b8c52b0baa2661828d49f6374d21d9971
-generated: "2026-06-09T09:32:36.545631665-04:00"
+digest: sha256:aaded133869ee9f5deaa1709eb2f7246c2adf6694da0b737a0cf0462ace0d78f
+generated: "2026-08-20T23:11:36.684114426+03:00"

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -17,7 +17,7 @@ dependencies:
     repository: https://rh-ai-quickstart.github.io/ai-architecture-charts
     condition: llm-service.enabled
   - name: llama-stack
-    version: 0.8.5
+    version: 0.8.9
     repository: https://rh-ai-quickstart.github.io/ai-architecture-charts
   - name: mcp-servers
     version: 0.5.17

--- a/request-manager/requirements.txt
+++ b/request-manager/requirements.txt
@@ -962,9 +962,9 @@ langsmith==0.6.6 \
     --hash=sha256:64ba70e7b795cff3c498fe6f2586314da1cc855471a5e5b6a357950324af3874 \
     --hash=sha256:fe655e73b198cd00d0ecd00a26046eaf1f78cd0b2f0d94d1e5591f3143c5f592
     # via langchain-core
-llama-stack-client==0.5.0 \
-    --hash=sha256:5e7272c7fb58cd169985191c42af78dc6c4d212b7050949b063788bfb9e7ed36 \
-    --hash=sha256:e005ae9d975cda30b3b86261057f228d700107e263e12b796b920cd1fb9ba968
+llama-stack-client==0.6.1 \
+    --hash=sha256:13dabd74c29d5159cdcfca5a9e6f99c99f08aa688fa8403d6c5f6042b61519d2 \
+    --hash=sha256:47aa4f47b591ffbd35b7be946552c4198006daaf57505898372d7bc7c1df510f
     # via self-service-agent-service
 mako==1.3.10 \
     --hash=sha256:99579a6f39583fa7e5630a28c3c1f440e4e97a414b80372649c0ce338da2ea28 \

--- a/request-manager/uv.lock
+++ b/request-manager/uv.lock
@@ -1606,7 +1606,7 @@ wheels = [
 
 [[package]]
 name = "llama-stack-client"
-version = "0.5.0"
+version = "0.6.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -1625,9 +1625,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/af/a1/1bd9ed2b6982fb1edf0215be1a4569eb65c9354b86bfdcb5b1414b489162/llama_stack_client-0.5.0.tar.gz", hash = "sha256:e005ae9d975cda30b3b86261057f228d700107e263e12b796b920cd1fb9ba968", size = 368629, upload-time = "2026-02-05T17:23:06.688Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/01/47b32f2fb003b7f3fc24a401cd7b091892025f626dd07661647f64e3df68/llama_stack_client-0.6.1.tar.gz", hash = "sha256:13dabd74c29d5159cdcfca5a9e6f99c99f08aa688fa8403d6c5f6042b61519d2", size = 368690, upload-time = "2026-03-30T13:11:39.597Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2d/93/63b434955cdb80d54c69bdb51ecd1a12595451ce238667fdaa125fb7d1ec/llama_stack_client-0.5.0-py3-none-any.whl", hash = "sha256:5e7272c7fb58cd169985191c42af78dc6c4d212b7050949b063788bfb9e7ed36", size = 391950, upload-time = "2026-02-05T17:23:04.238Z" },
+    { url = "https://files.pythonhosted.org/packages/57/bd/da2f43993b9b753f0465548b17efbbee492a6980fdd5e14fadf8566cdb1f/llama_stack_client-0.6.1-py3-none-any.whl", hash = "sha256:47aa4f47b591ffbd35b7be946552c4198006daaf57505898372d7bc7c1df510f", size = 391998, upload-time = "2026-03-30T13:11:38.067Z" },
 ]
 
 [[package]]
@@ -3336,7 +3336,7 @@ requires-dist = [
     { name = "langfuse", specifier = ">=3.0.0" },
     { name = "langgraph", specifier = "==1.0.7" },
     { name = "langgraph-checkpoint-postgres", specifier = ">=2.0.0" },
-    { name = "llama-stack-client", specifier = "==0.5.0" },
+    { name = "llama-stack-client", specifier = "==0.6.1" },
     { name = "mlflow", specifier = ">=2.14.0" },
     { name = "openai", specifier = ">=1.0.0" },
     { name = "opentelemetry-exporter-otlp-proto-http", specifier = ">=1.37.0" },


### PR DESCRIPTION
Reference: https://redhat.atlassian.net/browse/APPENG-5794

Upgrade **llama-stack Helm chart** 0.8.5 -> 0.8.9 (image 0.5.2 -> 0.6.1) and **llama-stack-client** 0.5.0 -> 0.6.1 to match.